### PR TITLE
add User-Agent header to requests

### DIFF
--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const open = require("open");
 const prompt = require("prompt-sync")({ sigint: true });
+const pkg = require("../../package.json");
 const { firmCredentials } = require("./firmCredentials");
 
 const baseURL = process.env.SF_HOST || "https://live.getsilverfin.com";
@@ -117,6 +118,7 @@ function setAxiosDefaults(firmId) {
   if (firmTokens) {
     axios.defaults.baseURL = `${baseURL}/api/v4/f/${firmId}`;
     axios.defaults.headers.common[
+      "User-Agent" = `Silverfin CLI/${pkg.version}`,
       "Authorization"
     ] = `Bearer ${firmTokens.accessToken}`;
   } else {

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -117,8 +117,8 @@ function setAxiosDefaults(firmId) {
   const firmTokens = firmCredentials.getTokenPair(firmId);
   if (firmTokens) {
     axios.defaults.baseURL = `${baseURL}/api/v4/f/${firmId}`;
+    axios.defaults.headers["User-Agent"] = `silverfin-cli/${pkg.version}`;
     axios.defaults.headers.common[
-      "User-Agent" = `Silverfin CLI/${pkg.version}`,
       "Authorization"
     ] = `Bearer ${firmTokens.accessToken}`;
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Added User-Agent header requests to engineering for easier tracking which requests originate from the CLI. 

We should now be sending these headers on a request:
e.g. POST /api/v4/f/13827/reconciliations/67081995 HTTP/1.1

```
Accept: application/json, text/plain, */*
Authorization: Bearer <access_token>
Content-Type: application/json
User-Agent: silverfin-cli/1.14.2
Content-Length: 808
Host: live.getsilverfin.com
Connection: close
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
