### PR TITLE
Store firm name

### DIFF
--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -50,10 +50,9 @@ class FirmCredentials {
    * @param {Object} tokens - Object containing `access_token` and `refresh_token`
    */
   storeNewTokenPair(firmId, tokens) {
-    this.data[firmId] = {
-      accessToken: tokens.access_token || "",
-      refreshToken: tokens.refresh_token || "",
-    };
+    this.data[firmId] = this.data[firmId] || {};
+    this.data[firmId].accessToken = tokens.access_token || "";
+    this.data[firmId].refreshToken = tokens.refresh_token || "";
     this.saveCredentials();
   }
 
@@ -67,6 +66,21 @@ class FirmCredentials {
       return null;
     }
     return this.data[firmId];
+  }
+
+  /** Store firm name for a particular firm */
+  storeFirmName(firmId, firmName) {
+    this.data[firmId] = this.data[firmId] || {};
+    this.data[firmId].firmName = firmName;
+    this.saveCredentials();
+  }
+
+  /** Get the firm name if it has been previously stored */
+  getFirmName(firmId) {
+    if (!this.data.hasOwnProperty(firmId) || !this.data[firmId].firmName) {
+      return null;
+    }
+    return this.data[firmId].firmName;
   }
 
   /** Store default firm id for the current directory

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -2,18 +2,8 @@ const axios = require("axios");
 const open = require("open");
 const prompt = require("prompt-sync")({ sigint: true });
 const apiUtils = require("../utils/apiUtils");
-const missingVariables = ["SF_API_CLIENT_ID", "SF_API_SECRET"].filter(
-  (key) => !process.env[key]
-);
-if (missingVariables.length) {
-  console.log(`Error: Missing API credentials: [${missingVariables}]`);
-  console.log(`Credentials should be defined as environmental variables.`);
-  console.log(`Call export ${missingVariables[0]}=...`);
-  console.log(
-    `If you don't have credentials yet, you need to register your app with Silverfin to get them`
-  );
-  process.exit(1);
-}
+
+apiUtils.checkRequiredEnvVariables();
 
 async function authorizeApp(firmId = undefined) {
   try {
@@ -46,6 +36,8 @@ async function authorizeApp(firmId = undefined) {
     if (tokens) {
       console.log("Authentication successful");
     }
+    // Get firm name
+    await apiUtils.getFirmDetails(firmIdPrompt);
   } catch (error) {
     console.log(error);
     process.exit(1);

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -4,6 +4,21 @@ const axios = require("axios");
 
 const BASE_URL = process.env.SF_HOST || "https://live.getsilverfin.com";
 
+function checkRequiredEnvVariables() {
+  const missingVariables = ["SF_API_CLIENT_ID", "SF_API_SECRET"].filter(
+    (key) => !process.env[key]
+  );
+  if (missingVariables.length) {
+    console.log(`Error: Missing API credentials: [${missingVariables}]`);
+    console.log(`Credentials should be defined as environmental variables.`);
+    console.log(`Call export ${missingVariables[0]}=...`);
+    console.log(
+      `If you don't have credentials yet, you need to register your app with Silverfin to get them`
+    );
+    process.exit(1);
+  }
+}
+
 // Get Tokens for the first time
 async function getAccessToken(firmId, authCode) {
   try {
@@ -46,6 +61,11 @@ async function refreshTokens(firmId, accessToken, refreshToken) {
       data
     );
     firmCredentials.storeNewTokenPair(firmId, response.data);
+    // firm name
+    const firmName = firmCredentials.getFirmName(firmId);
+    if (!firmName) {
+      await getFirmDetails(firmId);
+    }
   } catch (error) {
     console.log(
       `Response Status: ${error.response.status} (${error.response.statusText})`
@@ -64,16 +84,15 @@ async function refreshTokens(firmId, accessToken, refreshToken) {
 
 function setAxiosDefaults(firmId) {
   const firmTokens = firmCredentials.getTokenPair(firmId);
-  if (firmTokens) {
-    axios.defaults.baseURL = `${BASE_URL}/api/v4/f/${firmId}`;
-    axios.defaults.headers["User-Agent"] = `silverfin-cli/${pkg.version}`;
-    axios.defaults.headers.common[
-      "Authorization"
-    ] = `Bearer ${firmTokens.accessToken}`;
-  } else {
+  if (!firmTokens) {
     console.log(`Missing authorization for firm id: ${firmId}`);
     process.exit(1);
   }
+  axios.defaults.baseURL = `${BASE_URL}/api/v4/f/${firmId}`;
+  axios.defaults.headers["User-Agent"] = `silverfin-cli/${pkg.version}`;
+  axios.defaults.headers.common[
+    "Authorization"
+  ] = `Bearer ${firmTokens.accessToken}`;
 }
 
 function responseSuccessHandler(response) {
@@ -145,10 +164,26 @@ async function responseErrorHandler(
   throw error;
 }
 
+/**
+ * Retrieve firm details and store the firm name in the credentials file
+ * @param {Number} firmId
+ */
+async function getFirmDetails(firmId) {
+  setAxiosDefaults(firmId);
+  try {
+    const response = await axios.get(`/user/firm`);
+    if (response && response.data) {
+      firmCredentials.storeFirmName(firmId, response.data.name);
+    }
+  } catch (error) {}
+}
+
 module.exports = {
   BASE_URL,
+  checkRequiredEnvVariables,
   getAccessToken,
   setAxiosDefaults,
   responseSuccessHandler,
   responseErrorHandler,
+  getFirmDetails,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.15.5",
+  "version": "1.16.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

When we perform an authorization, we will now start fetching and storing the firm name as well.
We can later use to indicate more clearly with which firm we are interacting by displaying the name instead of (or next to) the id.
Specially useful for the Extension panel where we now show a list of firm ids, we can start displaying the firm name as well which is much more meaningful.

config should look like now:

```json
{
  "1234": {
    "accessToken": "...",
    "refreshToken": "...",
    "firmName": "My demo firm name"
  },
}
```

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
