### PR TITLE
Remove template.type check for looking up linked shared parts since this missing from most configs

### DIFF
--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -269,9 +269,7 @@ function listSharedPartsUsedInTemplate(firmId, type, handle) {
     // Find if it is used in the template
     const templateUsed = sharedPartConfig.used_in?.some((template) => {
       const usedTemplateId = template.id[firmId];
-      return usedTemplateId === templateId && template.type === type
-        ? true
-        : false;
+      return usedTemplateId === templateId ? true : false;
     });
 
     if (templateUsed) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Removed template.type check for looking up shared parts since this is missing from current configs so it will throw errors.

And I think it will only be relevant once we support other template types. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
