### PR TITLE
fix typo in reconciliations endpoint + add template data instead of response to argument of save function

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,11 @@ async function fetchReconciliationByHandle(firmId, handle) {
 
 async function fetchReconciliationById(firmId, id) {
   const template = await SF.readReconciliationTextById(firmId, id);
-  if (!template) {
+
+  if (!template || !template.data) {
     throw `Reconciliation with id ${id} wasn't found`;
   }
-  ReconciliationText.save(firmId, template);
+  ReconciliationText.save(firmId, template.data);
 }
 
 // Import all reconciliations

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -106,7 +106,7 @@ async function readReconciliationTexts(firmId, page = 1, refreshToken = true) {
 async function readReconciliationTextById(firmId, id, refreshToken = true) {
   apiUtils.setAxiosDefaults(firmId);
   try {
-    const response = await axios.get(`reconciliation/${id}`);
+    const response = await axios.get(`reconciliations/${id}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

When trying to import from ID, the command was giving an error that the handle was missing, even though it was defined on the recon to be imported.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
