### PR TITLE
shared part main part is the same name as the shared part instead of 'main'

### DIFF
--- a/lib/sharedPart.js
+++ b/lib/sharedPart.js
@@ -146,8 +146,8 @@ class SharedPart {
     }
   }
 
-  static #readMainLiquid(name, templateConfig) {
-    const mainPartPath = `./${this.TEMPLATE_FOLDER}/${name}/${templateConfig.text}`;
+  static #readMainLiquid(name) {
+    const mainPartPath = `./${this.TEMPLATE_FOLDER}/${name}/${name}.liquid`;
     return fs.readFileSync(mainPartPath, "utf-8");
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

The function readMainLiquid for a shared part was expecting the main part to be named 'main', but this should be the name of the shared part.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
