### PR TITLE
run update command as sudo by default

### DIFF
--- a/lib/cli/cliUpdates.js
+++ b/lib/cli/cliUpdates.js
@@ -46,7 +46,7 @@ async function performUpdate() {
 
   try {
     // Exec output contains both stderr and stdout outputs
-    const updateCommand = `npm install -g ${pkg.repository.url}`;
+    const updateCommand = `sudo npm install -g ${pkg.repository.url}`;
     console.log(`Running command: ${chalk.italic(updateCommand)}`);
     const updateOutput = await exec(updateCommand);
     const updatedPkgVersion = await exec("silverfin --version");
@@ -66,7 +66,7 @@ async function performUpdate() {
     console.error(`${chalk.red("ERROR.")} Update of Silverfin CLI failed`);
     console.log(
       `You can try running the following command: ${chalk.bold(
-        `sudo npm install -g ${pkg.repository.url}`
+        `npm install -g ${pkg.repository.url}`
       )}`
     );
     console.log(`If that still fails, try updating NPM first.`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Run update command as sudo by default as running it without sudo gives an error for mac users. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
