### PR TITLE
New commands: update firm name & refresh tokens

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -379,9 +379,15 @@ program
       "Update the name of the firm (fetched from Silverfin)"
     ).preset(firmIdDefault)
   )
+  .addOption(
+    new Option(
+      "-r, --refresh-token [firmId]",
+      "Get a new pair of credentials using the stored refresh token"
+    ).preset(firmIdDefault)
+  )
   .action((options) => {
     cliUtils.checkUniqueOption(
-      ["setFirm", "getFirm", "listAll", "updateName"],
+      ["setFirm", "getFirm", "listAll", "updateName", "refreshToken"],
       options
     );
     if (options.setFirm) {
@@ -409,6 +415,10 @@ program
     if (options.updateName) {
       cliUtils.checkDefaultFirm(options.updateName, firmIdDefault);
       toolkit.updateFirmName(options.updateName);
+    }
+    if (options.refreshToken) {
+      cliUtils.checkDefaultFirm(options.refreshToken, firmIdDefault);
+      SF.refreshTokens(options.refreshToken);
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ const toolkit = require("../index");
 const liquidTestGenerator = require("../lib/liquidTestGenerator");
 const liquidTestRunner = require("../lib/liquidTestRunner");
 const stats = require("../lib/cli/stats");
-const { Command } = require("commander");
+const { Command, Option } = require("commander");
 const pkg = require("../package.json");
 const cliUpdates = require("../lib/cli/cliUpdates");
 const cliUtils = require("../lib/cli/utils");
@@ -373,8 +373,17 @@ program
   )
   .option("-g, --get-firm", "Check if there is any firm id already stored")
   .option("-l, --list-all", "List all the firm IDs stored")
+  .addOption(
+    new Option(
+      "-n, --update-name [firmId]",
+      "Update the name of the firm (fetched from Silverfin)"
+    ).preset(firmIdDefault)
+  )
   .action((options) => {
-    cliUtils.checkUniqueOption(["setFirm", "getFirm", "listAll"], options);
+    cliUtils.checkUniqueOption(
+      ["setFirm", "getFirm", "listAll", "updateName"],
+      options
+    );
     if (options.setFirm) {
       firmCredentials.setDefaultFirmId(options.setFirm);
       const currentDirectory = path.basename(process.cwd());
@@ -396,6 +405,10 @@ program
           console.log(`- ${element[0]}${element[1] ? ` (${element[1]})` : ""}`)
         );
       }
+    }
+    if (options.updateName) {
+      cliUtils.checkDefaultFirm(options.updateName, firmIdDefault);
+      toolkit.updateFirmName(options.updateName);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const chalk = require("chalk");
 const errorUtils = require("./lib/utils/errorUtils");
 const { ReconciliationText } = require("./lib/reconciliationText");
 const { SharedPart } = require("./lib/sharedPart");
+const { firmCredentials } = require("./lib/api/firmCredentials");
 
 async function fetchReconciliationByHandle(firmId, handle) {
   const template = await SF.findReconciliationTextByHandle(firmId, handle);
@@ -417,6 +418,21 @@ async function getAllTemplatesId(firmId, type) {
   }
 }
 
+async function updateFirmName(firmId) {
+  try {
+    const firmDetails = await SF.getFirmDetails(firmId);
+    if (!firmDetails) {
+      console.log(`Firm ${firmId} not found.`);
+      return false;
+    }
+    firmCredentials.storeFirmName(firmId, firmDetails.name);
+    console.log(`Firm ${firmId} name set to ${firmDetails.name}`);
+    return true;
+  } catch (error) {
+    errorUtils.errorHandler(error);
+  }
+}
+
 module.exports = {
   fetchReconciliationByHandle,
   fetchReconciliationById,
@@ -436,4 +452,5 @@ module.exports = {
   addAllSharedPartsToAllReconciliation,
   getTemplateId,
   getAllTemplatesId,
+  updateFirmName,
 };

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -789,6 +789,28 @@ async function verifyLiquid(firmId, attributes, refreshToken = true) {
   }
 }
 
+async function getFirmDetails(firmId, refreshToken = true) {
+  apiUtils.setAxiosDefaults(firmId);
+  try {
+    const response = await axios.get(`/user/firm`);
+    apiUtils.responseSuccessHandler(response);
+    return response.data;
+  } catch (error) {
+    const callbackParameters = {
+      firmId,
+      refreshToken: false,
+    };
+    const response = await apiUtils.responseErrorHandler(
+      firmId,
+      error,
+      refreshToken,
+      getFirmDetails,
+      callbackParameters
+    );
+    return response;
+  }
+}
+
 module.exports = {
   authorizeApp,
   createReconciliationText,
@@ -819,4 +841,5 @@ module.exports = {
   findReconciliationInWorkflows,
   getAccountDetails,
   verifyLiquid,
+  getFirmDetails,
 };

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -44,6 +44,11 @@ async function authorizeApp(firmId = undefined) {
   }
 }
 
+async function refreshTokens(firmId) {
+  apiUtils.setAxiosDefaults(firmId);
+  await apiUtils.refreshTokens(firmId);
+}
+
 async function createReconciliationText(
   firmId,
   attributes,
@@ -813,6 +818,7 @@ async function getFirmDetails(firmId, refreshToken = true) {
 
 module.exports = {
   authorizeApp,
+  refreshTokens,
   createReconciliationText,
   readReconciliationTexts,
   readReconciliationTextById,

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -30,6 +30,7 @@ async function getAccessToken(firmId, authCode) {
     };
     const response = await axios(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);
+    await getFirmName(firmId);
     return true;
   } catch (error) {
     console.log(
@@ -64,7 +65,7 @@ async function refreshTokens(firmId, accessToken, refreshToken) {
     // firm name
     const firmName = firmCredentials.getFirmName(firmId);
     if (!firmName) {
-      await getFirmDetails(firmId);
+      await getFirmName(firmId);
     }
   } catch (error) {
     console.log(
@@ -168,7 +169,7 @@ async function responseErrorHandler(
  * Retrieve firm details and store the firm name in the credentials file
  * @param {Number} firmId
  */
-async function getFirmDetails(firmId) {
+async function getFirmName(firmId) {
   setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/user/firm`);
@@ -185,5 +186,5 @@ module.exports = {
   setAxiosDefaults,
   responseSuccessHandler,
   responseErrorHandler,
-  getFirmDetails,
+  getFirmName,
 };

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -46,16 +46,17 @@ async function getAccessToken(firmId, authCode) {
 }
 
 // Get a new pair of tokens
-async function refreshTokens(firmId, accessToken, refreshToken) {
+async function refreshTokens(firmId) {
   try {
+    const firmTokens = firmCredentials.getTokenPair(firmId);
     console.log(`Requesting new pair of tokens`);
     let data = {
       client_id: process.env.SF_API_CLIENT_ID,
       client_secret: process.env.SF_API_SECRET,
       redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
       grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      access_token: accessToken,
+      refresh_token: firmTokens.refreshToken,
+      access_token: firmTokens.accessToken,
     };
     const response = await axios.post(
       `https://api.getsilverfin.com/f/${firmId}/oauth/token`,
@@ -134,13 +135,8 @@ async function responseErrorHandler(
       `Response Error (401): ${JSON.stringify(error.response.data.error)}`
     );
     if (refreshToken) {
-      const firmTokens = firmCredentials.getTokenPair(firmId);
       // Get a new pair of tokens
-      await refreshTokens(
-        firmId,
-        firmTokens.accessToken,
-        firmTokens.refreshToken
-      );
+      await refreshTokens(firmId);
       //  Call the original function again
       return callbackFunction(...Object.values(callbackParameters));
     } else {
@@ -186,5 +182,6 @@ module.exports = {
   setAxiosDefaults,
   responseSuccessHandler,
   responseErrorHandler,
+  refreshTokens,
   getFirmName,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Two new commands:
- `silverfin config --update-name [firmid]` -> to get the firm name from silverfin and store it next to the credentials
- `silverfin config --refresh-token [firmid]` -> to get a new pair of access/refresh token using the existing refresh token (intended to be used by github workflows)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
