### PR TITLE
fix status only run-test to take the testsRun object + skip spinner in this case

### DIFF
--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -80,12 +80,15 @@ function buildTestParams(firmId, handle, testName = "", renderMode) {
   return testParams;
 }
 
-async function fetchResult(firmId, testRunId) {
+async function fetchResult(firmId, testRunId, skipSpinner = false) {
   let testRun = { status: "started" };
   let pollingDelay = 1000;
   const waitingLimit = 500000;
 
-  spinner.spin("Running tests..");
+  if (!skipSpinner) {
+    spinner.spin("Running tests..");
+  }
+
   let waitingTime = 0;
   while (testRun.status === "started") {
     await new Promise((resolve) => {
@@ -343,7 +346,8 @@ async function runTests(
   handle,
   testName = "",
   previewOnly = false,
-  renderMode = "none"
+  renderMode = "none",
+  skipSpinner = false
 ) {
   try {
     const testParams = buildTestParams(firmId, handle, testName, renderMode);
@@ -361,7 +365,7 @@ async function runTests(
     if (!previewOnly) {
       const testRunResponse = await SF.createTestRun(firmId, testParams);
       const testRunId = testRunResponse.data;
-      testRun = await fetchResult(firmId, testRunId);
+      testRun = await fetchResult(firmId, testRunId, skipSpinner);
     }
 
     return { testRun, previewRun };
@@ -409,9 +413,12 @@ async function runTestsWithOutput(
 // RETURN (AND LOG) ONLY PASSED OR FAILED
 // CAN BE USED BY GITHUB ACTIONS
 async function runTestsStatusOnly(firmId, handle, testName = "") {
-  const testRun = await runTests(firmId, handle, testName, false, "none");
-  if (testRun && testRun.status === "completed") {
-    const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
+  const testsRun = await runTests(firmId, handle, testName, false, "none", true);
+  const testResults = testsRun.testRun
+
+  if (testResults && testResults.status === "completed") {
+
+    const errorsPresent = checkAllTestsErrorsPresent(testResults.tests);
     if (errorsPresent === false) {
       console.log("\r\nPASSED");
       return "PASSED";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

The function for run-test with status only was not taking the updated object yet after the preview updates + skipped spinner in this case so the "Running tests" text isn't printed in the GitHub Actions output.

Fixes #68

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
