### PR TITLE
Fix: check present attributes in config

### DIFF
--- a/lib/reconciliationText.js
+++ b/lib/reconciliationText.js
@@ -126,7 +126,7 @@ class ReconciliationText {
 
   static #filterConfigItems(templateConfig) {
     return this.CONFIG_ITEMS.reduce((acc, attribute) => {
-      if (templateConfig[attribute]) {
+      if (templateConfig.hasOwnProperty(attribute)) {
         acc[attribute] = templateConfig[attribute];
       }
       return acc;

--- a/lib/sharedPart.js
+++ b/lib/sharedPart.js
@@ -153,7 +153,7 @@ class SharedPart {
 
   static #filterConfigItems(templateConfig) {
     return this.CONFIG_ITEMS.reduce((acc, attribute) => {
-      if (templateConfig[attribute]) {
+      if (templateConfig.hasOwnProperty(attribute)) {
         acc[attribute] = templateConfig[attribute];
       }
       return acc;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

When we perform recreate a template's object, when we filter the items of the config json, we were avoiding the ones set to false. We should check if the attribute exists to include it or not rather than it's content

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
