### PR TITLE
Fix: template id and Partners

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ async function fetchReconciliationByHandle(firmId, handle) {
 
 async function fetchReconciliationById(firmId, id) {
   const template = await SF.readReconciliationTextById(firmId, id);
-
   if (!template || !template.data) {
     throw `Reconciliation with id ${id} wasn't found`;
   }
@@ -47,13 +46,7 @@ async function publishReconciliationByHandle(
   try {
     const templateConfig = fsUtils.readConfig("reconciliationText", handle);
     if (!templateConfig || !templateConfig.id[firmId]) {
-      console.log(`Reconciliation ${handle}: ID is missing. Aborted`);
-      console.log(
-        `Try running: ${chalk.bold(
-          `silverfin get-reconciliation-id --handle ${handle}`
-        )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
-      );
-      process.exit(1);
+      errorUtils.missingReconciliationId(handle);
     }
     let templateId = templateConfig.id[firmId];
     console.log(`Updating ${handle}...`);
@@ -156,13 +149,7 @@ async function publishSharedPartByName(
   try {
     const templateConfig = fsUtils.readConfig("sharedPart", name);
     if (!templateConfig || !templateConfig.id[firmId]) {
-      console.log(`Shared part ${name}: ID is missing. Aborted`);
-      console.log(
-        `Try running: ${chalk.bold(
-          `silverfin get-shared-part-id --shared-part ${name}`
-        )} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`
-      );
-      process.exit(1);
+      errorUtils.missingSharedPartId(name);
     }
     console.log(`Updating shared part ${name}...`);
     const template = await SharedPart.read(name);

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function publishReconciliationByHandle(
       templateId,
       template
     );
-    if (response.data.handle) {
+    if (response && response.data && response.data.handle) {
       console.log(`Reconciliation updated: ${response.data.handle}`);
     } else {
       console.log(`Reconciliation update failed: ${handle}`);
@@ -159,7 +159,7 @@ async function publishSharedPartByName(
       templateConfig.id[firmId],
       template
     );
-    if (response.data.name) {
+    if (response && response.data && response.data.name) {
       console.log(`Shared part updated: ${response.data.name}`);
     } else {
       console.log(`Shared part update failed: ${name}`);

--- a/index.js
+++ b/index.js
@@ -59,7 +59,16 @@ async function publishReconciliationByHandle(
     console.log(`Updating ${handle}...`);
     const template = await ReconciliationText.read(handle);
     template.version_comment = message;
-    await SF.updateReconciliationText(firmId, templateId, template);
+    const response = await SF.updateReconciliationText(
+      firmId,
+      templateId,
+      template
+    );
+    if (response.data.handle) {
+      console.log(`Reconciliation updated: ${response.data.handle}`);
+    } else {
+      console.log(`Reconciliation update failed: ${handle}`);
+    }
   } catch (error) {
     errorUtils.errorHandler(error);
   }
@@ -158,7 +167,16 @@ async function publishSharedPartByName(
     console.log(`Updating shared part ${name}...`);
     const template = await SharedPart.read(name);
     template.version_comment = message;
-    await SF.updateSharedPart(firmId, templateConfig.id[firmId], template);
+    const response = await SF.updateSharedPart(
+      firmId,
+      templateConfig.id[firmId],
+      template
+    );
+    if (response.data.name) {
+      console.log(`Shared part updated: ${response.data.name}`);
+    } else {
+      console.log(`Shared part update failed: ${name}`);
+    }
   } catch (error) {
     errorUtils.errorHandler(error);
   }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -123,25 +123,44 @@ async function readReconciliationTextById(firmId, id, refreshToken = true) {
   }
 }
 
+/**
+ * Find reconciliation by handle. We only look for templates that are not from Partners (because tecnically they don't belong to the current firm). If we find a template from Partners we will skip it and continue looking for the next one (while we keep it's `marketplace_template_id` as a reference)
+ * @param {Number} firmId
+ * @param {String} handle
+ * @param {Number} page
+ * @returns {Object} Reconciliation Text object
+ */
 async function findReconciliationTextByHandle(firmId, handle, page = 1) {
+  let marketplace_template_id;
   const reconciliations = await readReconciliationTexts(firmId, page);
-  // No data
+  // No data. Not found
   if (reconciliations.length == 0) {
     console.log(`Reconciliation ${handle} not found`);
-    return;
+    return null;
   }
   let reconciliationTexts = reconciliations.filter(
     (element) => element["handle"] === handle
   );
-  if (reconciliationTexts.length != 0) {
-    for (let reconciliationText of reconciliationTexts) {
-      // Only return reconciliations were liquid code is not hidden
-      if (reconciliationText.hasOwnProperty("text")) {
-        return reconciliationText;
-      }
+  if (reconciliationTexts.length == 0) {
+    return findReconciliationTextByHandle(firmId, handle, page + 1);
+  }
+  for (let reconciliationText of reconciliationTexts) {
+    // Template from Partners. Skip it
+    if (
+      reconciliationText.hasOwnProperty("marketplace_template_id") &&
+      reconciliationText.marketplace_template_id != null
+    ) {
+      marketplace_template_id = reconciliationText.marketplace_template_id;
+      continue;
+    }
+    // Only return reconciliations were liquid code is not hidden
+    if (reconciliationText.hasOwnProperty("text")) {
+      marketplace_template_id
+        ? (reconciliationText.marketplace_template_id = marketplace_template_id)
+        : null;
+      return reconciliationText;
     }
   }
-  return findReconciliationTextByHandle(firmId, handle, page + 1);
 }
 
 async function updateReconciliationText(

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -79,7 +79,7 @@ async function readReconciliationTexts(firmId, page = 1, refreshToken = true) {
   apiUtils.setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`reconciliations`, {
-      params: { page: page, per_page: 2000 },
+      params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
@@ -124,14 +124,13 @@ async function readReconciliationTextById(firmId, id, refreshToken = true) {
 }
 
 /**
- * Find reconciliation by handle. We only look for templates that are not from Partners (because tecnically they don't belong to the current firm). If we find a template from Partners we will skip it and continue looking for the next one (while we keep it's `marketplace_template_id` as a reference)
+ * Find reconciliation by handle. We only look for templates that are not from Partners (because tecnically they don't belong to the current firm). If we find a template from Partners we will skip it and continue looking for the next one.
  * @param {Number} firmId
  * @param {String} handle
  * @param {Number} page
  * @returns {Object} Reconciliation Text object
  */
 async function findReconciliationTextByHandle(firmId, handle, page = 1) {
-  let marketplace_template_id;
   const reconciliations = await readReconciliationTexts(firmId, page);
   // No data. Not found
   if (reconciliations.length == 0) {
@@ -141,26 +140,22 @@ async function findReconciliationTextByHandle(firmId, handle, page = 1) {
   let reconciliationTexts = reconciliations.filter(
     (element) => element["handle"] === handle
   );
-  if (reconciliationTexts.length == 0) {
-    return findReconciliationTextByHandle(firmId, handle, page + 1);
-  }
-  for (let reconciliationText of reconciliationTexts) {
-    // Template from Partners. Skip it
-    if (
-      reconciliationText.hasOwnProperty("marketplace_template_id") &&
-      reconciliationText.marketplace_template_id != null
-    ) {
-      marketplace_template_id = reconciliationText.marketplace_template_id;
-      continue;
-    }
-    // Only return reconciliations were liquid code is not hidden
-    if (reconciliationText.hasOwnProperty("text")) {
-      marketplace_template_id
-        ? (reconciliationText.marketplace_template_id = marketplace_template_id)
-        : null;
-      return reconciliationText;
+  if (reconciliationTexts.length != 0) {
+    for (let reconciliationText of reconciliationTexts) {
+      // Template from Partners. Skip it
+      if (
+        reconciliationText.hasOwnProperty("marketplace_template_id") &&
+        reconciliationText.marketplace_template_id != null
+      ) {
+        continue;
+      }
+      // Only return reconciliations were liquid code is not hidden
+      if (reconciliationText.hasOwnProperty("text")) {
+        return reconciliationText;
+      }
     }
   }
+  return findReconciliationTextByHandle(firmId, handle, page + 1);
 }
 
 async function updateReconciliationText(
@@ -240,7 +235,7 @@ async function getReconciliationCustom(
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`,
-      { params: { page: page, per_page: 2000 } }
+      { params: { page: page, per_page: 200 } }
     );
     apiUtils.responseSuccessHandler(response);
     return response;
@@ -301,7 +296,7 @@ async function readSharedParts(firmId, page = 1, refreshToken = true) {
   apiUtils.setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`shared_parts`, {
-      params: { page: page, per_page: 2000 },
+      params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
@@ -549,7 +544,7 @@ async function getPeriods(firmId, companyId, page = 1, refreshToken = true) {
   apiUtils.setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/companies/${companyId}/periods`, {
-      params: { page: page, per_page: 2000 },
+      params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
@@ -659,7 +654,7 @@ async function getWorkflowInformation(
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`,
-      { params: { page: page, per_page: 2000 } }
+      { params: { page: page, per_page: 200 } }
     );
     apiUtils.responseSuccessHandler(response);
     return response;

--- a/lib/cli/devMode.js
+++ b/lib/cli/devMode.js
@@ -4,8 +4,13 @@ const toolkit = require("../../index");
 const liquidTestRunner = require("../liquidTestRunner");
 const fsUtils = require("../utils/fsUtils");
 
-// Watch for changes in an specific YAML and their related liquid files
-// Run a new test when file is saved
+/**
+ *  Watch for changes in an specific YAML and their related liquid files. Run a new test when file is saved.
+ * @param {Number} firmId - Firm ID
+ * @param {String} handle - template handle
+ * @param {String} testName - Test name (empty string to run all tests)
+ * @param {boolean} renderInput - Open browser and show the HTML from input view
+ */
 async function watchLiquidTest(firmId, handle, testName, renderInput) {
   console.log(
     `Watching for changes related to reconciliation "${handle}" to run a new test...`
@@ -68,9 +73,10 @@ async function watchLiquidTest(firmId, handle, testName, renderInput) {
   });
 }
 
-// Watch for changes in any file .liquid
-// Identify if it's a reconciliation or shared part
-// Publish updates when file is saved
+/**
+ * Watch for changes in any file `.liquid`. Identify if it's a `reconciliationText` or `sharedPart`. **Publish updates to Silverfin when file is saved**.
+ * @param {Number} firmId
+ */
 function watchLiquidFiles(firmId) {
   console.log(
     "Watching for changes in all liquid files to publish their updates..."
@@ -78,7 +84,7 @@ function watchLiquidFiles(firmId) {
   console.log(
     `Don't forget to terminate this process when you don't need it anymore! (Ctrl + C)`
   );
-  const files = fsUtils.listExistingFiles();
+  const files = fsUtils.listExistingFiles("liquid");
   const lastUpdates = {};
   files.forEach((filePath) => {
     fs.watch(filePath, (eventType, filename) => {
@@ -93,15 +99,12 @@ function watchLiquidFiles(firmId) {
       let fileStats = fs.statSync(filePath);
       if (lastUpdates[filename] === fileStats.mtimeMs) return;
       lastUpdates[filename] = fileStats.mtimeMs;
-
       // Update template
       if (details.type === "reconciliationText") {
         toolkit.publishReconciliationByHandle(firmId, details.handle);
-        console.log(`Reconciliation updated: ${details.handle}`);
       }
       if (details.type === "sharedPart") {
         toolkit.publishSharedPartByName(firmId, details.handle);
-        console.log(`Shared part updated: ${details.handle}`);
       }
     });
   });

--- a/lib/reconciliationText.js
+++ b/lib/reconciliationText.js
@@ -3,6 +3,7 @@ const fsUtils = require("./utils/fsUtils");
 const templateUtils = require("./utils/templateUtils");
 
 class ReconciliationText {
+  // To be added: marketplace_template_id
   static CONFIG_ITEMS = [
     "handle",
     "name_en",
@@ -175,6 +176,7 @@ class ReconciliationText {
 
   // Write handle & names if they are missing in the config
   static #checkHandleAndNameInConfig(templateConfig, templateHandle) {
+    // name_nl is required by Silverfin
     const items = ["handle", "name_en", "name_nl"];
     items.forEach((item) => {
       if (!templateConfig[item]) {

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -27,7 +27,29 @@ function errorHandler(error) {
   }
 }
 
+function missingReconciliationId(handle) {
+  console.log(`Reconciliation ${handle}: ID is missing. Aborted`);
+  console.log(
+    `Try running: ${chalk.bold(
+      `silverfin get-reconciliation-id --handle ${handle}`
+    )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
+  );
+  process.exit(1);
+}
+
+function missingSharedPartId(name) {
+  console.log(`Shared part ${name}: ID is missing. Aborted`);
+  console.log(
+    `Try running: ${chalk.bold(
+      `silverfin get-shared-part-id --shared-part ${name}`
+    )} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`
+  );
+  process.exit(1);
+}
+
 module.exports = {
   uncaughtErrors,
   errorHandler,
+  missingReconciliationId,
+  missingSharedPartId,
 };

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -1,4 +1,5 @@
 const pkg = require("../../package.json");
+const chalk = require("chalk");
 
 // Uncaught Errors. Open Issue in GitHub
 function uncaughtErrors(error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.21.0",
+  "version": "1.20.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

- Updating templates to Silverfin: fetch the result and log if it was updated or not.
- Modify the way we look for reconciliations. We skip a template if it's from Partners (before we relied on the visible text but that could be visible from partners, so now we rely on the marketplace_template_id present or not -> templates that have this value are certainly linked to partners). We still fetch the first non-partners template, so it's not possible to have multiple templates with the same handle (except partners) in the environment.
- Move missing template id errors to `errorUtils`

Fixes #74 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
