### PR TITLE
Make tests pass on an empty liquid testing YAML

### DIFF
--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -32,7 +32,7 @@ function buildTestParams(firmId, handle, testName = "", renderMode) {
   const relativePath = `./reconciliation_texts/${handle}`;
   const config = fsUtils.readConfig("reconciliationText", handle);
   const testPath = `${relativePath}/${config.test}`;
-  const testContent = fs.readFileSync(testPath, "utf-8");
+  const testContent = fs.readFileSync(testPath, "utf-8").trim();
 
   // Empty YAML check
   if (testContent.split("\n").length <= 1) {

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -409,17 +409,27 @@ async function runTestsWithOutput(
 // RETURN (AND LOG) ONLY PASSED OR FAILED
 // CAN BE USED BY GITHUB ACTIONS
 async function runTestsStatusOnly(firmId, handle, testName = "") {
+  let status = "FAILED";
   const testResult = await runTests(firmId, handle, testName, false, "none");
-  const testRun = testResult.testRun;
-  if (testRun && testRun.status === "completed") {
+
+  if (!testResult) {
+    status = "PASSED";
+    console.log(status);
+    return status;
+  }
+
+  const testRun = testResult?.testRun;
+
+  if (testRun && testRun?.status === "completed") {
     const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
     if (errorsPresent === false) {
-      console.log("\r\nPASSED");
-      return "PASSED";
+      status = "PASSED";
+      console.log(status);
+      return status;
     }
   }
-  console.log("\r\nFAILED");
-  return "FAILED";
+  console.log(status);
+  return status;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

The run-tests with --status were passing "FAILED" on an empty liquid testing YAML, but this caused actions to crash. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
