### PR TITLE
Fix mkdir so complete path is always created + show success message on shared part import

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,6 +249,7 @@ async function fetchSharedPart(firmId, name) {
   } else {
     fetchSharedPartByName(firmId, name);
   }
+  consola.success(`Shared part "${templateConfig.name}" imported`);
 }
 
 async function fetchSharedPartById(firmId, id) {
@@ -258,7 +259,6 @@ async function fetchSharedPartById(firmId, id) {
     process.exit(1);
   }
   await SharedPart.save(firmId, template.data);
-  consola.success(`Shared part "${template.data.name}" imported`);
 }
 
 async function fetchSharedPartByName(firmId, name) {

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -97,11 +97,7 @@ class SharedPart {
 
   static async #findTemplateHandle(firmId, template) {
     // Search in repository
-    let handle = await fsUtils.findHandleByID(
-      firmId,
-      template.type,
-      template.id
-    );
+    let handle = fsUtils.findHandleByID(firmId, template.type, template.id);
     // Search through the API
     if (!handle) {
       switch (template.type) {

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -12,7 +12,7 @@ const TEMPLATE_TYPES = Object.keys(FOLDERS);
 
 function createFolder(path) {
   if (!fs.existsSync(path)) {
-    fs.mkdirSync(path);
+    fs.mkdirSync(path, { recursive: true });
   }
 }
 
@@ -37,7 +37,6 @@ function createTemplateFolders(templateType, handle, testFolder = true) {
 }
 
 function createSharedPartFolders(handle) {
-  createFolder(path.join(process.cwd(), `${FOLDERS.sharedPart}`));
   createFolder(path.join(process.cwd(), `${FOLDERS.sharedPart}`, `${handle}`));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

1. The create/import was throwing an error if the parent reconciliation_texts or shared_parts folder didn't exist yet. 

2. Import a shared part didn't give any success messages

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- ~~README updated (if needed)~~
- [x] Version updated (if needed)
- ~~Documentation updated (if needed)~~
