### PR TITLE
Support partner API endpoints

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,11 +80,8 @@ program
 program
   .command("update-reconciliation")
   .description("Update an existing reconciliation template")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option(
     "-h, --handle <handle>",
     "Specify the reconcilation to be used (mandatory)"
@@ -98,18 +95,29 @@ program
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkUniqueOption(["handle", "all"], options);
+    cliUtils.checkRequiredFirmOrPartner(options, ["handle", "all"]);
+    const settings = cliUtils.getCommandSettings(options);
     if (!options.yes) {
       cliUtils.promptConfirmation();
     }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+
+    if (settings.type == "firm") {
+      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+    }
+
     if (options.handle) {
       toolkit.publishReconciliationByHandle(
-        options.firm,
+        settings.type,
+        settings.envId,
         options.handle,
         options.message
       );
     } else if (options.all) {
-      toolkit.publishAllReconciliations(options.firm, options.message);
+      toolkit.publishAllReconciliations(
+        settings.type,
+        settings.envId,
+        options.message
+      );
     }
   });
 
@@ -122,7 +130,6 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-
   .option(
     "-h, --handle <handle>",
     "Specify the handle of the reconciliation text to be created"
@@ -808,24 +815,37 @@ program
 program
   .command("get-reconciliation-id")
   .description("Fetch the ID of the reconciliation from Silverfin")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-h, --handle <handle>", "Fetch the reconciliation ID by handle")
   .option("-a, --all", "Fetch the ID for every reconciliation")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkUniqueOption(["handle", "all"], options);
+    cliUtils.checkRequiredFirmOrPartner(options, ["handle", "all"]);
+    const settings = cliUtils.getCommandSettings(options);
+
     if (!options.yes) {
       cliUtils.promptConfirmation();
     }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+
+    if (settings.type == "firm") {
+      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+    }
+
     if (options.handle) {
-      toolkit.getTemplateId(options.firm, "reconciliationText", options.handle);
+      toolkit.getTemplateId(
+        settings.type,
+        settings.envId,
+        "reconciliationText",
+        options.handle
+      );
     } else if (options.all) {
-      toolkit.getAllTemplatesId(options.firm, "reconciliationText");
+      toolkit.getAllTemplatesId(
+        settings.type,
+        settings.envId,
+        "reconciliationText"
+      );
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,7 +276,7 @@ program
     }
 
     if (options.name) {
-      toolkit.fetchAccountTemplate(settings.type, settings.envId, options.name);
+      toolkit.fetchAccountTemplateByName(settings.type, settings.envId, options.name);
     } else if (options.id) {
       toolkit.fetchAccountTemplateById(
         settings.type,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -345,12 +345,10 @@ program
 program
   .command("import-shared-part")
   .description("Import an existing shared part")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-s, --shared-part <name>", "Import a specific shared part")
+  .option("-i, --id <id>", "Import a specific shared part by id")
   .option("-a, --all", "Import all shared parts")
   .option(
     "-e, --existing",
@@ -358,15 +356,36 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(["sharedPart", "all", "existing"], options);
+    cliUtils.checkUniqueOption(
+      ["sharedPart", "id", "all", "existing"],
+      options
+    );
+    cliUtils.checkRequiredFirmOrPartner(options, [
+      "sharedPart",
+      "id",
+      "all",
+      "existing",
+    ]);
+    const settings = cliUtils.getCommandSettings(options);
+
     if (!options.yes) {
       cliUtils.promptConfirmation();
     }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+
+    if (settings.type == "firm") {
+      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+    }
+
     if (options.sharedPart) {
-      toolkit.fetchSharedPart(options.firm, options.sharedPart);
+      toolkit.fetchSharedPartByName(
+        settings.type,
+        settings.envId,
+        options.sharedPart
+      );
+    } else if (options.id) {
+      toolkit.fetchSharedPartById(settings.type, settings.envId, options.id);
     } else if (options.all) {
-      toolkit.fetchAllSharedParts(options.firm);
+      toolkit.fetchAllSharedParts(settings.type, settings.envId);
     } else if (options.existing) {
       toolkit.fetchExistingSharedParts(options.firm);
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -247,11 +247,8 @@ program
 program
   .command("import-account-template")
   .description("Import account templates")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Import a specific account template by name")
   .option("-i, --id <id>", "Import a specific account template by id")
   .option("-a, --all", "Import all existing account templates")
@@ -262,14 +259,30 @@ program
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkUniqueOption(["name", "id", "all", "existing"], options);
+    cliUtils.checkRequiredFirmOrPartner(options, [
+      "name",
+      "id",
+      "all",
+      "existing",
+    ]);
+    const settings = cliUtils.getCommandSettings(options);
+
     if (!options.yes) {
       cliUtils.promptConfirmation();
     }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+
+    if (settings.type == "firm") {
+      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+    }
+
     if (options.name) {
-      toolkit.fetchAccountTemplate(options.firm, options.name);
+      toolkit.fetchAccountTemplate(settings.type, settings.envId, options.name);
     } else if (options.id) {
-      toolkit.fetchAccountTemplateById(options.firm, options.id);
+      toolkit.fetchAccountTemplateById(
+        settings.type,
+        settings.envId,
+        options.id
+      );
     } else if (options.all) {
       toolkit.fetchAllAccountTemplates(options.firm);
     } else if (options.existing) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -142,11 +142,8 @@ program
 program
   .command("import-export-file")
   .description("Import export file templates")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Import a specific export file by name")
   .option("-i, --id <id>", "Import a specific export file by id")
   .option("-a, --all", "Import all existing export files")
@@ -156,11 +153,6 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(["name", "id", "all", "existing"], options);
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     const settings = runCommandChecks(
       ["name", "id", "all", "existing"],
       options,
@@ -186,11 +178,8 @@ program
 program
   .command("update-export-file")
   .description("Update an existing export file template")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Specify the export file to be used (mandatory)")
   .option("-a, --all", "Update all export files")
   .option(
@@ -260,22 +249,11 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(["name", "id", "all", "existing"], options);
-    cliUtils.checkRequiredFirmOrPartner(options, [
-      "name",
-      "id",
-      "all",
-      "existing",
-    ]);
-    const settings = cliUtils.getCommandSettings(options);
-
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-
-    if (settings.type == "firm") {
-      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
-    }
+    const settings = runCommandChecks(
+      ["name", "id", "all", "existing"],
+      options,
+      firmIdDefault
+    );
 
     if (options.name) {
       toolkit.fetchAccountTemplateByName(
@@ -314,26 +292,21 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(["name", "all"], options);
-    cliUtils.checkRequiredFirmOrPartner(options, ["name", "all"]);
-    const settings = cliUtils.getCommandSettings(options);
-
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-
-    if (settings.type == "firm") {
-      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
-    }
+    const settings = runCommandChecks(["name", "all"], options, firmIdDefault);
 
     if (options.name) {
       toolkit.publishAccountTemplateByName(
-        options.firm,
+        settings.type,
+        settings.envId,
         options.name,
         options.message
       );
     } else if (options.all) {
-      toolkit.publishAllAccountTemplates(options.firm, options.message);
+      toolkit.publishAllAccountTemplates(
+        settings.type,
+        settings.envId,
+        options.message
+      );
     }
   });
 
@@ -379,25 +352,11 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(
+    const settings = runCommandChecks(
       ["sharedPart", "id", "all", "existing"],
-      options
+      options,
+      firmIdDefault
     );
-    cliUtils.checkRequiredFirmOrPartner(options, [
-      "sharedPart",
-      "id",
-      "all",
-      "existing",
-    ]);
-    const settings = cliUtils.getCommandSettings(options);
-
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-
-    if (settings.type == "firm") {
-      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
-    }
 
     if (options.sharedPart) {
       toolkit.fetchSharedPartByName(
@@ -432,17 +391,11 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    cliUtils.checkUniqueOption(["sharedPart", "all"], options);
-    cliUtils.checkRequiredFirmOrPartner(options, ["sharedPart", "all"]);
-    const settings = cliUtils.getCommandSettings(options);
-
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-
-    if (settings.type == "firm") {
-      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
-    }
+    const settings = runCommandChecks(
+      ["sharedPart", "all"],
+      options,
+      firmIdDefault
+    );
 
     if (options.sharedPart) {
       toolkit.publishSharedPartByName(
@@ -523,11 +476,12 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    if (!options.yes) {
-      cliUtils.promptConfirmation();
-    }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
-    cliUtils.checkUniqueOption(["sharedPart", "all"], options);
+    const settings = runCommandChecks(
+      ["sharedPart", "all"],
+      options,
+      firmIdDefault
+    );
+
     if (options.sharedPart) {
       cliUtils.checkUniqueOption(
         ["handle", "exportFile", "accountTemplate"],
@@ -541,27 +495,30 @@ program
     }
     if (options.handle) {
       toolkit.addSharedPart(
-        options.firm,
+        settings.type,
+        settings.envId,
         options.sharedPart,
         options.handle,
         "reconciliationText"
       );
     } else if (options.exportFile) {
       toolkit.addSharedPart(
-        options.firm,
+        settings.type,
+        settings.envId,
         options.sharedPart,
         options.exportFile,
         "exportFile"
       );
     } else if (options.accountTemplate) {
       toolkit.addSharedPart(
-        options.firm,
+        settings.type,
+        settings.envId,
         options.sharedPart,
         options.accountTemplate,
         "accountTemplate"
       );
     } else if (options.all) {
-      toolkit.addAllSharedParts(options.firm, options.force);
+      toolkit.addAllSharedParts(settings.type, settings.envId, options.force);
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -703,7 +703,7 @@ program
   )
   .action((options) => {
     const stored = firmCredentials.storePartnerApiKey(
-      options.partnerId,
+      options.partner_id,
       options.apiKey,
       options.partnerName
     );
@@ -748,7 +748,7 @@ program
   )
   .addOption(
     new Option(
-      "--refresh-partner-token [partnerId]",
+      "--refresh-partner-token [partner_id]",
       "Get a new partner api key using the stored api key"
     )
   )
@@ -819,9 +819,9 @@ program
         options.refreshPartnerToken
       );
 
-      if (refreshedTokens && refreshedTokens.partnerId) {
+      if (refreshedTokens && refreshedTokens.partner_id) {
         consola.success(
-          `Partner API key refreshed for partner ID: ${refreshedTokens.partnerId}`
+          `Partner API key refreshed for partner ID: ${refreshedTokens.partner_id}`
         );
       }
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -104,7 +104,7 @@ program
       );
     } else if (options.all) {
       toolkit.publishAllReconciliations(
-        settings.type,
+        "firm",
         settings.envId,
         options.message
       );
@@ -307,7 +307,7 @@ program
       );
     } else if (options.all) {
       toolkit.publishAllAccountTemplates(
-        settings.type,
+        "firm",
         settings.envId,
         options.message
       );
@@ -414,7 +414,7 @@ program
       );
     } else if (options.all) {
       toolkit.publishAllSharedParts(
-        settings.type,
+        "firm",
         settings.envId,
         options.message
       );

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,7 +276,11 @@ program
     }
 
     if (options.name) {
-      toolkit.fetchAccountTemplateByName(settings.type, settings.envId, options.name);
+      toolkit.fetchAccountTemplateByName(
+        settings.type,
+        settings.envId,
+        options.name
+      );
     } else if (options.id) {
       toolkit.fetchAccountTemplateById(
         settings.type,
@@ -284,7 +288,7 @@ program
         options.id
       );
     } else if (options.all) {
-      toolkit.fetchAllAccountTemplates(options.firm);
+      toolkit.fetchAllAccountTemplates(settings.type, settings.envId);
     } else if (options.existing) {
       toolkit.fetchExistingAccountTemplates(options.firm);
     }
@@ -294,11 +298,8 @@ program
 program
   .command("update-account-template")
   .description("Update an existing account template")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option(
     "-n, --name <name>",
     "Specify the account template to be used (mandatory)"
@@ -312,10 +313,17 @@ program
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkUniqueOption(["name", "all"], options);
+    cliUtils.checkRequiredFirmOrPartner(options, ["name", "all"]);
+    const settings = cliUtils.getCommandSettings(options);
+
     if (!options.yes) {
       cliUtils.promptConfirmation();
     }
-    cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+
+    if (settings.type == "firm") {
+      cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
+    }
+
     if (options.name) {
       toolkit.publishAccountTemplateByName(
         options.firm,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -687,7 +687,7 @@ program
 program
   .command("authorize-partner")
   .description(
-    "Authorize a Silverfin partner environment by entering the API key and credentials"
+    "Authorize a Silverfin partner environment by entering the API key and partner information"
   )
   .requiredOption(
     "-i, --partner-id <partner-id>",

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,7 +65,7 @@ program
         options.id
       );
     } else if (options.all) {
-      toolkit.fetchAllReconciliations(options.firm);
+      toolkit.fetchAllReconciliations(settings.type, settings.envId);
     } else if (options.existing) {
       toolkit.fetchExistingReconciliations(options.firm);
     }
@@ -143,7 +143,6 @@ program
   .command("import-export-file")
   .description("Import export file templates")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
-  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Import a specific export file by name")
   .option("-i, --id <id>", "Import a specific export file by id")
   .option("-a, --all", "Import all existing export files")
@@ -156,7 +155,8 @@ program
     const settings = runCommandChecks(
       ["name", "id", "all", "existing"],
       options,
-      firmIdDefault
+      firmIdDefault,
+      false
     );
 
     if (options.name) {
@@ -179,7 +179,6 @@ program
   .command("update-export-file")
   .description("Update an existing export file template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
-  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Specify the export file to be used (mandatory)")
   .option("-a, --all", "Update all export files")
   .option(
@@ -189,7 +188,12 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(["name", "all"], options, firmIdDefault);
+    const settings = runCommandChecks(
+      ["name", "all"],
+      options,
+      firmIdDefault,
+      false
+    );
 
     if (options.name) {
       toolkit.publishExportFileByName(
@@ -351,7 +355,7 @@ program
     "Import all shared parts (already stored in the repository)"
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
-  .action((options) => {
+  .action(async (options) => {
     const settings = runCommandChecks(
       ["sharedPart", "id", "all", "existing"],
       options,
@@ -359,15 +363,19 @@ program
     );
 
     if (options.sharedPart) {
-      toolkit.fetchSharedPartByName(
+      await toolkit.fetchSharedPartByName(
         settings.type,
         settings.envId,
         options.sharedPart
       );
     } else if (options.id) {
-      toolkit.fetchSharedPartById(settings.type, settings.envId, options.id);
+      await toolkit.fetchSharedPartById(
+        settings.type,
+        settings.envId,
+        options.id
+      );
     } else if (options.all) {
-      toolkit.fetchAllSharedParts(settings.type, settings.envId);
+      await toolkit.fetchAllSharedParts(settings.type, settings.envId);
     } else if (options.existing) {
       toolkit.fetchExistingSharedParts(options.firm);
     }
@@ -444,11 +452,8 @@ program
 program
   .command("add-shared-part")
   .description("Add an existing shared part to an existing template")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option(
     "-s, --shared-part <name>",
     `Specify the shared part to be added (used together with "--handle" or "--export-file")`
@@ -476,10 +481,12 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
+    const partnerSupported = options.exportFile ? false : true;
     const settings = runCommandChecks(
       ["sharedPart", "all"],
       options,
-      firmIdDefault
+      firmIdDefault,
+      partnerSupported
     );
 
     if (options.sharedPart) {
@@ -546,10 +553,12 @@ program
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
+    const partnerSupported = options.exportFile ? false : true;
     const settings = runCommandChecks(
       ["handle", "exportFile", "accountTemplate"],
       options,
-      firmIdDefault
+      firmIdDefault,
+      partnerSupported
     );
 
     if (options.handle) {
@@ -853,12 +862,16 @@ program
   .command("get-export-file-id")
   .description("Fetch the ID of an export file from Silverfin")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
-  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Fetch the export file ID by name")
   .option("-a, --all", "Fetch the ID for every export file")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(["name", "all"], options, firmIdDefault);
+    const settings = runCommandChecks(
+      ["name", "all"],
+      options,
+      firmIdDefault,
+      false
+    );
 
     if (options.name) {
       toolkit.getTemplateId(

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -67,7 +67,7 @@ program
     } else if (options.all) {
       toolkit.fetchAllReconciliations(settings.type, settings.envId);
     } else if (options.existing) {
-      toolkit.fetchExistingReconciliations(options.firm);
+      toolkit.fetchExistingReconciliations(settings.type, settings.envId);
     }
   });
 
@@ -274,7 +274,7 @@ program
     } else if (options.all) {
       toolkit.fetchAllAccountTemplates(settings.type, settings.envId);
     } else if (options.existing) {
-      toolkit.fetchExistingAccountTemplates(options.firm);
+      toolkit.fetchExistingAccountTemplates(settings.type, settings.envId);
     }
   });
 
@@ -377,7 +377,7 @@ program
     } else if (options.all) {
       await toolkit.fetchAllSharedParts(settings.type, settings.envId);
     } else if (options.existing) {
-      toolkit.fetchExistingSharedParts(options.firm);
+      toolkit.fetchExistingSharedParts(settings.type, settings.envId);
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -712,8 +712,6 @@ program
     new Option(
       "--refresh-partner-token [partnerId]",
       "Get a new partner api key using the stored api key"
-    ).choices(
-      firmCredentials.listAuthorizedPartners().map((partner) => partner.id)
     )
   )
   .action((options) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -645,6 +645,36 @@ program
     SF.authorizeApp(firmIdDefault);
   });
 
+// Authorize PARTNER
+program
+  .command("authorize-partner")
+  .description(
+    "Authorize a Silverfin partner environment by entering the API key and credentials"
+  )
+  .requiredOption(
+    "-i, --partner-id <partner-id>",
+    "Specify the partner environment id to be added"
+  )
+  .requiredOption(
+    "-k, --api-key <api-key>",
+    "Specify the api key of the partner environment to be added"
+  )
+  .option(
+    "-n, --partner-name <partner-name>",
+    "Specify the partner environment name to be added"
+  )
+  .action((options) => {
+    const stored = firmCredentials.storePartnerApiKey(
+      options.partnerId,
+      options.partnerName,
+      options.apiKey
+    );
+
+    if (stored) {
+      consola.success("Partner API key succesfully stored");
+    }
+  });
+
 // Repositories Statistics
 program
   .command("stats")
@@ -678,9 +708,24 @@ program
       "Get a new pair of credentials using the stored refresh token"
     ).preset(firmIdDefault)
   )
+  .addOption(
+    new Option(
+      "--refresh-partner-token [partnerId]",
+      "Get a new partner api key using the stored api key"
+    ).choices(
+      firmCredentials.listAuthorizedPartners().map((partner) => partner.id)
+    )
+  )
   .action((options) => {
     cliUtils.checkUniqueOption(
-      ["setFirm", "getFirm", "listAll", "updateName", "refreshToken"],
+      [
+        "setFirm",
+        "getFirm",
+        "listAll",
+        "updateName",
+        "refreshToken",
+        "refreshPartnerToken",
+      ],
       options
     );
     if (options.setFirm) {
@@ -704,6 +749,17 @@ program
           consola.log(`- ${element[0]}${element[1] ? ` (${element[1]})` : ""}`)
         );
       }
+
+      const partners = firmCredentials.listAuthorizedPartners();
+      if (partners.length > 0) {
+        console.log("\n");
+        consola.info("List of authorized partners");
+        partners.forEach((element) =>
+          consola.log(
+            `- ${element.id}${element.name ? ` (${element.name})` : ""}`
+          )
+        );
+      }
     }
     if (options.updateName) {
       cliUtils.checkDefaultFirm(options.updateName, firmIdDefault);
@@ -712,6 +768,9 @@ program
     if (options.refreshToken) {
       cliUtils.checkDefaultFirm(options.refreshToken, firmIdDefault);
       SF.refreshTokens(options.refreshToken);
+    }
+    if (options.refreshPartnerToken) {
+      SF.refreshPartnerToken(options.refreshPartnerToken);
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -703,7 +703,7 @@ program
   )
   .action((options) => {
     const stored = firmCredentials.storePartnerApiKey(
-      options.partner_id,
+      options.partnerId,
       options.apiKey,
       options.partnerName
     );

--- a/index.js
+++ b/index.js
@@ -359,17 +359,22 @@ async function fetchAccountTemplateByName(firmId, name) {
   }
 }
 
-async function fetchAccountTemplateById(firmId, id) {
-  const template = await SF.readAccountTemplateById(firmId, id);
+async function fetchAccountTemplateById(type, envId, id) {
+  try {
+    const template = await SF.readAccountTemplateById(type, envId, id);
 
-  if (!template) {
-    consola.error(`Account template ${id} wasn't found`);
-    process.exit(1);
-  }
+    if (!template) {
+      consola.error(`Account template ${id} wasn't found`);
+      process.exit(1);
+    }
 
   const saved = AccountTemplate.save(firmId, template);
   if (saved) {
     consola.success(`Account template "${template?.name_nl}" imported`);
+  } 
+  } catch (error) {
+    consola.error(error);
+    process.exit(1);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1027,12 +1027,12 @@ async function removeSharedPart(
 
       // In case there's only one id & partner_id in the template config, remove the whole template config
       const totalIds =
-        Object.keys(usedInTemplateConfig.id).length +
-        Object.keys(usedInTemplateConfig.partner_id).length;
+        Object.keys(usedInTemplateConfig?.id || []).length +
+        Object.keys(usedInTemplateConfig?.partner_id || []).length;
       const targetId =
         type == "firm"
-          ? usedInTemplateConfig.id[envId]
-          : usedInTemplateConfig.partner_id[envId];
+          ? usedInTemplateConfig?.id[envId]
+          : usedInTemplateConfig?.partner_id[envId];
 
       // Remove reference of specific firm or partner id in the template config in the shared part used in array
       if (targetId) {

--- a/index.js
+++ b/index.js
@@ -823,8 +823,6 @@ async function addSharedPart(
 
       if (type == "firm") {
         usedInTemplateConfig.id[envId] = templateConfig.id[envId];
-        console.log("usedInTemplateConfig.id", usedInTemplateConfig.id);
-        console.log("templateConfig.id", templateConfig.id);
       }
 
       if (type == "partner") {

--- a/index.js
+++ b/index.js
@@ -605,20 +605,23 @@ async function fetchAllSharedParts(type, envId, page = 1) {
     }
     return;
   }
-  sharedParts.forEach(async (sharedPart) => {
+
+  for (let sharedPart of sharedParts) {
     try {
       await fetchSharedPartById(type, envId, sharedPart.id);
     } catch (error) {
       consola.error(error);
     }
-  });
+  }
+
   await fetchAllSharedParts(type, envId, page + 1);
 }
 
 async function fetchExistingSharedParts(type, envId) {
   const templates = fsUtils.getAllTemplatesOfAType("sharedPart");
   if (!templates) return;
-  templates.forEach(async (name) => {
+
+  for (let name of templates) {
     const configPresent = fsUtils.configExists("sharedPart", name);
 
     if (!configPresent) return;
@@ -637,7 +640,7 @@ async function fetchExistingSharedParts(type, envId) {
 
     if (!templateConfig || !templateId) return;
     await fetchSharedPartById(type, envId, templateId);
-  });
+  }
 }
 
 async function publishSharedPartByName(

--- a/index.js
+++ b/index.js
@@ -334,28 +334,18 @@ async function newAllExportFiles(firmId) {
   }
 }
 
-async function fetchAccountTemplate(firmId, name) {
-  const configPresent = fsUtils.configExists("accountTemplate", name);
-  let templateConfig;
-  if (configPresent) {
-    templateConfig = fsUtils.readConfig("accountTemplate", name);
-  }
-  if (templateConfig?.id[firmId]) {
-    await fetchAccountTemplateById(firmId, templateConfig.id[firmId]);
-  } else {
-    await fetchAccountTemplateByName(firmId, name);
-  }
-}
-
-async function fetchAccountTemplateByName(firmId, name) {
-  const template = await SF.findAccountTemplateByName(firmId, name);
-  if (!template) {
-    consola.error(`Account template "${name}" wasn't found`);
-    process.exit(1);
-  }
-  const saved = AccountTemplate.save(firmId, template);
-  if (saved) {
+async function fetchAccountTemplateByName(type, envId, name) {
+  try {
+    const template = await SF.findAccountTemplateByName(type, envId, name);
+    if (!template) {
+      consola.error(`Account template "${name}" wasn't found`);
+      process.exit(1);
+    }
+    AccountTemplate.save(type, envId, template);
     consola.success(`Account template "${template?.name_nl}" imported`);
+  } catch (error) {
+    consola.error(error);
+    process.exit(1);
   }
 }
 
@@ -368,10 +358,10 @@ async function fetchAccountTemplateById(type, envId, id) {
       process.exit(1);
     }
 
-  const saved = AccountTemplate.save(firmId, template);
-  if (saved) {
-    consola.success(`Account template "${template?.name_nl}" imported`);
-  } 
+    const saved = AccountTemplate.save(type, envId, template);
+    if (saved) {
+      consola.success(`Account template "${template?.name_nl}" imported`);
+    }
   } catch (error) {
     consola.error(error);
     process.exit(1);
@@ -958,7 +948,6 @@ module.exports = {
   publishAllExportFiles,
   newExportFile,
   newAllExportFiles,
-  fetchAccountTemplate,
   fetchAccountTemplateByName,
   fetchAccountTemplateById,
   fetchAllAccountTemplates,

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function fetchReconciliationByHandle(type, envId, handle) {
       id =
         type == "firm"
           ? templateConfig?.id?.[envId]
-          : templateConfig?.partnerId?.[envId];
+          : templateConfig?.partner_id?.[envId];
     }
 
     if (!id) {
@@ -98,7 +98,8 @@ async function fetchAllReconciliations(type, envId, page = 1) {
 async function fetchExistingReconciliations(type, envId) {
   const templates = fsUtils.getAllTemplatesOfAType("reconciliationText");
   if (!templates) return;
-  templates.forEach(async (handle) => {
+
+  for (let handle of templates) {
     const configPresent = fsUtils.configExists("reconciliationText", handle);
 
     if (!configPresent) return;
@@ -108,16 +109,14 @@ async function fetchExistingReconciliations(type, envId) {
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateId) {
       errorUtils.missingReconciliationId(handle);
-      return false;
+    } else {
+      await fetchReconciliationById(type, envId, templateId);
     }
-
-    if (!templateConfig || !templateId) return;
-    await fetchReconciliationById(type, envId, templateId);
-  });
+  }
 }
 
 async function publishReconciliationByHandle(
@@ -139,7 +138,7 @@ async function publishReconciliationByHandle(
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateId) {
       errorUtils.missingReconciliationId(handle);
@@ -305,7 +304,7 @@ async function publishExportFileByName(
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateConfig || !templateId) {
       errorUtils.missingExportFileId(name);
@@ -451,7 +450,7 @@ async function fetchExistingAccountTemplates(type, envId) {
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateId) {
       errorUtils.missingAccountTemplateId(name);
@@ -481,7 +480,7 @@ async function publishAccountTemplateByName(
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateConfig || !templateId) {
       errorUtils.missingAccountTemplateId(name);
@@ -629,7 +628,7 @@ async function fetchExistingSharedParts(type, envId) {
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateId) {
       errorUtils.missingSharedPartId(name);
@@ -658,7 +657,7 @@ async function publishSharedPartByName(
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateConfig || !templateId) {
       errorUtils.missingSharedPartId(name);
@@ -775,12 +774,12 @@ async function addSharedPart(
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     let sharedPartId =
       type == "firm"
         ? sharedPartConfig?.id?.[envId]
-        : sharedPartConfig?.partnerId?.[envId];
+        : sharedPartConfig?.partner_id?.[envId];
 
     // Missing Reconciliation ID. Try to identify it based on the handle
     if (!templateId) {
@@ -795,7 +794,7 @@ async function addSharedPart(
       templateId =
         type == "firm"
           ? templateConfig?.id?.[envId]
-          : templateConfig?.partnerId?.[envId];
+          : templateConfig?.partner_id?.[envId];
     }
 
     // Missing Shared Part ID. Try to identify it based on the name
@@ -811,7 +810,7 @@ async function addSharedPart(
       sharedPartId =
         type == "firm"
           ? sharedPartConfig?.id?.[envId]
-          : sharedPartConfig?.partnerId?.[envId];
+          : sharedPartConfig?.partner_id?.[envId];
     }
 
     // Add shared part to template
@@ -860,7 +859,7 @@ async function addSharedPart(
       // Not stored yet
       sharedPartConfig.used_in.push({
         id: type == "firm" ? templateConfig?.id : {},
-        partnerId: type == "partner" ? templateConfig?.partnerId : {},
+        partner_id: type == "partner" ? templateConfig?.partner_id : {},
         type: templateType,
         handle: templateHandle,
       });
@@ -873,8 +872,8 @@ async function addSharedPart(
       }
 
       if (type == "partner") {
-        usedInTemplateConfig.partnerId[envId] =
-          templateConfig?.partnerId[envId];
+        usedInTemplateConfig.partner_id[envId] =
+          templateConfig?.partner_id[envId];
       }
 
       sharedPartConfig.used_in[templateIndex] = usedInTemplateConfig;
@@ -954,7 +953,7 @@ async function removeSharedPart(
     const templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
-        : templateConfig?.partnerId?.[envId];
+        : templateConfig?.partner_id?.[envId];
 
     if (!templateConfig || !templateId) {
       consola.warn(
@@ -966,7 +965,7 @@ async function removeSharedPart(
     const sharedPartId =
       type == "firm"
         ? sharedPartConfig?.id?.[envId]
-        : sharedPartConfig?.partnerId?.[envId];
+        : sharedPartConfig?.partner_id?.[envId];
 
     if (!sharedPartId) {
       consola.warn(`Shared part id not found for ${templateHandle}. Skipping.`);
@@ -1013,25 +1012,25 @@ async function removeSharedPart(
     } else {
       const usedInTemplateConfig = sharedPartConfig.used_in[templateIndex];
 
-      // In case there's only one id & partnerId in the template config, remove the whole template config
+      // In case there's only one id & partner_id in the template config, remove the whole template config
       const totalIds =
         Object.keys(usedInTemplateConfig.id).length +
-        Object.keys(usedInTemplateConfig.partnerId).length;
+        Object.keys(usedInTemplateConfig.partner_id).length;
       const targetId =
         type == "firm"
           ? usedInTemplateConfig.id[envId]
-          : usedInTemplateConfig.partnerId[envId];
+          : usedInTemplateConfig.partner_id[envId];
 
       // Remove reference of specific firm or partner id in the template config in the shared part used in array
       if (targetId) {
         if (totalIds <= 1 && templateId.toString() === targetId.toString()) {
           sharedPartConfig.used_in.splice(templateIndex, 1);
         } else {
-          // Only delete the specific id or partnerId if other ids exist in the template config
+          // Only delete the specific id or partner_id if other ids exist in the template config
           if (type == "firm") {
             delete usedInTemplateConfig.id[envId];
           } else {
-            delete usedInTemplateConfig.partnerId[envId];
+            delete usedInTemplateConfig.partner_id[envId];
           }
 
           sharedPartConfig.used_in[templateIndex] = usedInTemplateConfig;
@@ -1083,14 +1082,14 @@ async function getTemplateId(type, envId, templateType, handle) {
     config.id = {};
   }
 
-  if (typeof config.partnerId !== "object") {
-    config.partnerId = {};
+  if (typeof config.partner_id !== "object") {
+    config.partner_id = {};
   }
 
   if (type == "firm") {
     config.id[envId] = templateText.id;
   } else {
-    config.partnerId[envId] = templateText.id;
+    config.partner_id[envId] = templateText.id;
   }
 
   fsUtils.writeConfig(templateType, handle, config);

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ async function fetchReconciliationByHandle(type, envId, handle) {
 
     let id =
       type == "firm"
-        ? templateConfig?.id[envId]
-        : templateConfig?.partnerId[envId];
+        ? templateConfig?.id?.[envId]
+        : templateConfig?.partnerId?.[envId];
     let existingTemplate;
 
     if (!id) {
@@ -812,8 +812,8 @@ async function addSharedPart(
     if (templateIndex === -1) {
       // Not stored yet
       sharedPartConfig.used_in.push({
-        id: type == "firm" ? templateConfig.id : {},
-        partnerId: type == "partner" ? templateConfig.partnerId : {},
+        id: type == "firm" ? templateConfig?.id : {},
+        partnerId: type == "partner" ? templateConfig?.partnerId : {},
         type: templateType,
         handle: templateHandle,
       });
@@ -828,7 +828,8 @@ async function addSharedPart(
       }
 
       if (type == "partner") {
-        usedInTemplateConfig.partnerId[envId] = templateConfig.partnerId[envId];
+        usedInTemplateConfig.partnerId[envId] =
+          templateConfig?.partnerId[envId];
       }
 
       sharedPartConfig.used_in[templateIndex] = usedInTemplateConfig;

--- a/index.js
+++ b/index.js
@@ -155,6 +155,7 @@ async function publishReconciliationByHandle(
 
     if (type == "partner") {
       template.version_significant_change = false;
+      delete template.is_active;
     }
 
     const response = await SF.updateReconciliationText(

--- a/index.js
+++ b/index.js
@@ -556,6 +556,14 @@ async function newAccountTemplate(firmId, name) {
     const template = await AccountTemplate.read(name);
     if (!template) return;
     template.version_comment = "Created through the Silverfin CLI";
+
+    // Only keep the mapping_list_ranges that belong to this firm or partner for the request
+    template.mapping_list_ranges = template.mapping_list_ranges.filter(
+      (range) => {
+        return range.type === "firm" && range.env_id === firmId;
+      }
+    );
+
     const response = await SF.createAccountTemplate(firmId, template);
     const handle = response.data.name_nl;
 

--- a/index.js
+++ b/index.js
@@ -368,8 +368,8 @@ async function fetchAccountTemplateById(type, envId, id) {
   }
 }
 
-async function fetchAllAccountTemplates(firmId, page = 1) {
-  const templates = await SF.readAccountTemplates(firmId, page);
+async function fetchAllAccountTemplates(type, envId, page = 1) {
+  const templates = await SF.readAccountTemplates(type, envId, page);
   if (templates.length == 0) {
     if (page == 1) {
       consola.warn("No account templates found");
@@ -382,7 +382,7 @@ async function fetchAllAccountTemplates(firmId, page = 1) {
       consola.success(`Account template "${template?.name_nl}" imported`);
     }
   });
-  fetchAllAccountTemplates(firmId, page + 1);
+  fetchAllAccountTemplates(type, envId, page + 1);
 }
 
 async function fetchExistingAccountTemplates(firmId) {

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -130,15 +130,15 @@ class FirmCredentials {
    *
    * @returns {Boolean} `true` if the credentials were stored successfully, `false` otherwise
    */
-  storePartnerApiKey(partner_id, apiKey, partnerName = null) {
+  storePartnerApiKey(partnerId, apiKey, partnerName = null) {
     try {
       if (!this.data.hasOwnProperty("partnerCredentials")) {
         this.data.partnerCredentials = {};
       }
 
-      const storedPartnerName = this.data.partnerCredentials[partner_id]?.name;
+      const storedPartnerName = this.data.partnerCredentials[partnerId]?.name;
 
-      this.data.partnerCredentials[partner_id] = {
+      this.data.partnerCredentials[partnerId] = {
         name: partnerName ? partnerName : storedPartnerName,
         token: apiKey,
       };

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -124,21 +124,21 @@ class FirmCredentials {
   // PARTNER CREDENTIALS
 
   /** Store new tokens to credentials. It will replace already stored tokens for the firm
-   * @param {Number} partnerId - Partner environment ID
+   * @param {Number} partner_id - Partner environment ID
    * @param {string} partnerName - Partner environment name
    * @param {string} apiKey - string containing the api_key from the partner environment (user specific)
    *
    * @returns {Boolean} `true` if the credentials were stored successfully, `false` otherwise
    */
-  storePartnerApiKey(partnerId, apiKey, partnerName = null) {
+  storePartnerApiKey(partner_id, apiKey, partnerName = null) {
     try {
       if (!this.data.hasOwnProperty("partnerCredentials")) {
         this.data.partnerCredentials = {};
       }
 
-      const storedPartnerName = this.data.partnerCredentials[partnerId]?.name;
+      const storedPartnerName = this.data.partnerCredentials[partner_id]?.name;
 
-      this.data.partnerCredentials[partnerId] = {
+      this.data.partnerCredentials[partner_id] = {
         name: partnerName ? partnerName : storedPartnerName,
         token: apiKey,
       };
@@ -153,16 +153,16 @@ class FirmCredentials {
 
   /**
    * Get the token (api_key) and name stored for a particular partner environment
-   * @param {Number} partnerId
+   * @param {Number} partner_id
    * @returns {Object} Object containing `name` and `token` or `null` if they don't exist
    */
-  getPartnerCredentials(partnerId) {
+  getPartnerCredentials(partner_id) {
     if (
       !this.data.hasOwnProperty("partnerCredentials") ||
-      !this.data.partnerCredentials.hasOwnProperty(partnerId)
+      !this.data.partnerCredentials.hasOwnProperty(partner_id)
     ) {
       const existingPartners = this.listAuthorizedPartners();
-      consola.error(`Missing authorization for partner id: ${partnerId}`);
+      consola.error(`Missing authorization for partner id: ${partner_id}`);
       consola.log(`Only found partner ids for:`);
       existingPartners.forEach((item) =>
         consola.log(`${item.id}${item.name ? " - " + item.name : ""}`)
@@ -171,8 +171,8 @@ class FirmCredentials {
     }
 
     return {
-      id: partnerId,
-      ...this.data.partnerCredentials[partnerId],
+      id: partner_id,
+      ...this.data.partnerCredentials[partner_id],
     };
   }
 

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -130,7 +130,7 @@ class FirmCredentials {
    *
    * @returns {Boolean} `true` if the credentials were stored successfully, `false` otherwise
    */
-  storePartnerApiKey(partnerId, partnerName, apiKey) {
+  storePartnerApiKey(partnerId, apiKey, partnerName = null) {
     try {
       if (!this.data.hasOwnProperty("partnerCredentials")) {
         this.data.partnerCredentials = {};
@@ -147,24 +147,33 @@ class FirmCredentials {
       return true;
     } catch (err) {
       consola.error(`Error while storing partner credentials: ${err}`);
-      return false;
+      process.exit(1);
     }
   }
 
   /**
-   * Get the pair of tokens (`access_token` and `refresh_token`) stored for a particular firm
+   * Get the token (api_key) and name stored for a particular partner environment
    * @param {Number} partnerId
-   * @returns {Object} Object containing `name` and `apiKey` or `null` if they don't exist
+   * @returns {Object} Object containing `name` and `token` or `null` if they don't exist
    */
   getPartnerCredentials(partnerId) {
     if (
-      !this.data.hasOwnProperty("partnerCredentials") &&
+      !this.data.hasOwnProperty("partnerCredentials") ||
       !this.data.partnerCredentials.hasOwnProperty(partnerId)
     ) {
-      return null;
+      const existingPartners = this.listAuthorizedPartners();
+      consola.error(`Missing authorization for partner id: ${partnerId}`);
+      consola.log(`Only found partner ids for:`);
+      existingPartners.forEach((item) =>
+        consola.log(`${item.id}${item.name ? " - " + item.name : ""}`)
+      );
+      process.exit(1);
     }
 
-    return this.data.partnerCredentials[partnerId];
+    return {
+      id: partnerId,
+      ...this.data.partnerCredentials[partnerId],
+    };
   }
 
   /**

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -48,6 +48,8 @@ class FirmCredentials {
     );
   }
 
+  // FIRM CREDENTIALS
+
   /** Store new tokens to credentials. It will replace already stored tokens for the firm
    * @param {string} firmId - Firm ID
    * @param {Object} tokens - Object containing `access_token` and `refresh_token`
@@ -112,9 +114,82 @@ class FirmCredentials {
    */
   listAuthorizedFirms() {
     return Object.keys(this.data)
-      .filter((element) => element !== "defaultFirmIDs")
+      .filter(
+        (element) =>
+          element !== "defaultFirmIDs" && element !== "partnerCredentials"
+      )
       .map((element) => [element, this.data[element].firmName]);
   }
+
+  // PARTNER CREDENTIALS
+
+  /** Store new tokens to credentials. It will replace already stored tokens for the firm
+   * @param {Number} partnerId - Partner environment ID
+   * @param {string} partnerName - Partner environment name
+   * @param {string} apiKey - string containing the api_key from the partner environment (user specific)
+   *
+   * @returns {Boolean} `true` if the credentials were stored successfully, `false` otherwise
+   */
+  storePartnerApiKey(partnerId, partnerName, apiKey) {
+    try {
+      if (!this.data.hasOwnProperty("partnerCredentials")) {
+        this.data.partnerCredentials = {};
+      }
+
+      const storedPartnerName = this.data.partnerCredentials[partnerId]?.name;
+
+      this.data.partnerCredentials[partnerId] = {
+        name: partnerName ? partnerName : storedPartnerName,
+        token: apiKey,
+      };
+      this.saveCredentials();
+
+      return true;
+    } catch (err) {
+      consola.error(`Error while storing partner credentials: ${err}`);
+      return false;
+    }
+  }
+
+  /**
+   * Get the pair of tokens (`access_token` and `refresh_token`) stored for a particular firm
+   * @param {Number} partnerId
+   * @returns {Object} Object containing `name` and `apiKey` or `null` if they don't exist
+   */
+  getPartnerCredentials(partnerId) {
+    if (
+      !this.data.hasOwnProperty("partnerCredentials") &&
+      !this.data.partnerCredentials.hasOwnProperty(partnerId)
+    ) {
+      return null;
+    }
+
+    return this.data.partnerCredentials[partnerId];
+  }
+
+  /**
+   * Get all partners which have API keys stored
+   * @returns {Array} Array of [`partner ID`, `partner name`]
+   */
+  listAuthorizedPartners() {
+    if (this.data.hasOwnProperty("partnerCredentials")) {
+      const partners = Object.keys(this.data.partnerCredentials).map(
+        (element) => {
+          const partnerInfo = {
+            id: element,
+            name: this.data.partnerCredentials[element].name,
+          };
+          return partnerInfo;
+        }
+      );
+
+      return partners;
+    }
+
+    return [];
+  }
+
+  // PRIVATE METHODS
 
   /** Create `.silverfin` folder in home directory if it doesn't exist yet
    * @private

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -563,27 +563,20 @@ async function updateAccountTemplate(
   }
 }
 
-async function readAccountTemplates(firmId, page = 1, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readAccountTemplates(
+  type,
+  envId,
+  page = 1,
+) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`account_templates`, {
+    const response = await instance.get(`account_templates`, {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      page: page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readAccountTemplates,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -603,11 +596,12 @@ async function readAccountTemplateById(type, envId, accountTemplateId) {
 }
 
 async function findAccountTemplateByName(
-  firmId,
+  type,
+  envId,
   accountTemplateName,
   page = 1
 ) {
-  const accountTemplates = await readAccountTemplates(firmId, page);
+  const accountTemplates = await readAccountTemplates(type, envId, page);
   // No data
   if (accountTemplates.length == 0) {
     //console.log(`Account Template "${accountTemplateName}" not found`);
@@ -617,9 +611,14 @@ async function findAccountTemplateByName(
     (element) => element["name_nl"] === accountTemplateName
   );
   if (accountTemplate) {
-    return await readAccountTemplateById(firmId, accountTemplate.id);
+    return await readAccountTemplateById(type, envId, accountTemplate.id);
   } else {
-    return findAccountTemplateByName(firmId, accountTemplateName, page + 1);
+    return findAccountTemplateByName(
+      type,
+      envId,
+      accountTemplateName,
+      page + 1
+    );
   }
 }
 

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -46,36 +46,34 @@ async function authorizeApp(firmId = undefined) {
   }
 }
 
-async function refreshTokens(firmId) {
-  apiUtils.setAxiosDefaults(firmId);
-  await apiUtils.refreshTokens(firmId);
+async function refreshTokens(type, firmId) {
+  const instance = apiUtils.setAxiosDefaults(type, firmId);
+  await apiUtils.refreshTokens(instance, firmId);
+
+  return true;
 }
 
 async function refreshPartnerToken(partnerId) {
   try {
-    const partnerCredentials = firmCredentials.getPartnerCredentials(partnerId);
+    const partnerCredentials = apiUtils.checkAuthorizePartners(partnerId);
 
-    if (!partnerCredentials) {
-      const existingPartners = firmCredentials.listAuthorizedPartners();
-      consola.error(`Missing authorization for partner id: ${partnerId}`);
-      consola.log(`Only found partner ids for:`);
-      existingPartners.forEach((item) =>
-        console.log(`${item.id}${item.name ? " - " + item.name : ""}`)
+    if (partnerCredentials) {
+      const response = await axios.post(
+        `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
       );
-      process.exit(1);
+
+      firmCredentials.storePartnerApiKey(
+        partnerId,
+        response.data.api_key,
+        partnerCredentials?.name
+      );
+
+      return {
+        partnerId,
+        partnerName: partnerCredentials?.name,
+        token: response.data.api_key,
+      };
     }
-
-    const response = await axios.post(
-      `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
-    );
-
-    firmCredentials.storePartnerApiKey(
-      partnerId,
-      partnerCredentials?.name,
-      response.data.api_key
-    );
-
-    consola.success(`Partner API key refreshed for partner ID: ${partnerId}`);
   } catch (error) {
     consola.error(
       `Response Status: ${error.response.status} (${error.response.statusText})`
@@ -112,10 +110,15 @@ async function createReconciliationText(
   }
 }
 
-async function readReconciliationTexts(firmId, page = 1, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readReconciliationTexts(
+  type,
+  envId,
+  page = 1,
+  refreshToken = true
+) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`reconciliations`, {
+    const response = await instance.get(`reconciliations`, {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
@@ -137,20 +140,26 @@ async function readReconciliationTexts(firmId, page = 1, refreshToken = true) {
   }
 }
 
-async function readReconciliationTextById(firmId, id, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readReconciliationTextById(
+  type,
+  envId,
+  id,
+  refreshToken = true
+) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
+
   try {
-    const response = await axios.get(`reconciliations/${id}`);
+    const response = await instance.get(`reconciliations/${id}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
     const callbackParameters = {
-      firmId,
+      envId,
       id,
       refreshToken: false,
     };
     const response = await apiUtils.responseErrorHandler(
-      firmId,
+      envId,
       error,
       refreshToken,
       readReconciliationTextById,
@@ -167,8 +176,9 @@ async function readReconciliationTextById(firmId, id, refreshToken = true) {
  * @param {Number} page
  * @returns {Object} Reconciliation Text object
  */
-async function findReconciliationTextByHandle(firmId, handle, page = 1) {
-  const reconciliations = await readReconciliationTexts(firmId, page);
+async function findReconciliationTextByHandle(type, envId, handle, page = 1) {
+  const reconciliations = await readReconciliationTexts(type, envId, page);
+
   // No data. Not found
   if (reconciliations.length == 0) {
     //consola.warn(`Reconciliation "${handle}" not found`);
@@ -192,7 +202,7 @@ async function findReconciliationTextByHandle(firmId, handle, page = 1) {
       }
     }
   }
-  return findReconciliationTextByHandle(firmId, handle, page + 1);
+  return findReconciliationTextByHandle(type, envId, handle, page + 1);
 }
 
 async function updateReconciliationText(

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -315,7 +315,7 @@ async function addSharedPartToReconciliation(
   type,
   envId,
   sharedPartId,
-  reconciliationId
+  reconciliationId,
 ) {
   const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
@@ -383,6 +383,7 @@ async function readExportFiles(type, envId, page = 1) {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
+    console.log(response.data)
     return response.data;
   } catch (error) {
     const response = await apiUtils.responseErrorHandler(error);
@@ -525,7 +526,6 @@ async function findAccountTemplateByName(
   const accountTemplates = await readAccountTemplates(type, envId, page);
   // No data
   if (accountTemplates.length == 0) {
-    //console.log(`Account Template "${accountTemplateName}" not found`);
     return null;
   }
   const accountTemplate = accountTemplates.find(

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -135,12 +135,12 @@ async function findReconciliationTextByHandle(type, envId, handle, page = 1) {
 
   // No data. Not found
   if (reconciliations.length == 0) {
-    //consola.warn(`Reconciliation "${handle}" not found`);
     return null;
   }
   let reconciliationTexts = reconciliations.filter(
     (element) => element["handle"] === handle
   );
+
   if (reconciliationTexts.length != 0) {
     for (let reconciliationText of reconciliationTexts) {
       // Template from Partners. Skip it
@@ -194,12 +194,6 @@ async function readReconciliationTextDetails(
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      envId,
-      companyId,
-      periodId,
-      reconciliationId,
-    };
     const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
@@ -797,68 +791,35 @@ async function removeSharedPartFromAccountTemplate(
   }
 }
 
-async function createTestRun(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createTestRun(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.post("reconciliations/test", attributes);
+    const response = await instance.post("reconciliations/test", attributes);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      createTestRun,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function createPreviewRun(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createPreviewRun(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.post("reconciliations/render", attributes);
+    const response = await instance.post("reconciliations/render", attributes);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      createPreviewRun,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readTestRun(firmId, testId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readTestRun(firmId, testId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(`reconciliations/test_runs/${testId}`);
+    const response = await instance.get(`reconciliations/test_runs/${testId}`);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      testId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readTestRun,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -57,13 +57,11 @@ async function refreshPartnerToken(partnerId) {
 
     if (!partnerCredentials) {
       const existingPartners = firmCredentials.listAuthorizedPartners();
-      const existingPartnersList = array
-        .map((item) => `${item.id}${item.name ? " - " + item.name : ""}`)
-        .join("\n");
-
-      console.log("existingPartners", existingPartners);
       consola.error(`Missing authorization for partner id: ${partnerId}`);
-      consola.error(`Only found partner ids for: ${existingPartnersList}`);
+      consola.log(`Only found partner ids for:`);
+      existingPartners.forEach((item) =>
+        console.log(`${item.id}${item.name ? " - " + item.name : ""}`)
+      );
       process.exit(1);
     }
 

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -3,6 +3,7 @@ const open = require("open");
 const prompt = require("prompt-sync")({ sigint: true });
 const apiUtils = require("../utils/apiUtils");
 const { consola } = require("consola");
+const { firmCredentials } = require("../api/firmCredentials");
 
 apiUtils.checkRequiredEnvVariables();
 
@@ -48,6 +49,43 @@ async function authorizeApp(firmId = undefined) {
 async function refreshTokens(firmId) {
   apiUtils.setAxiosDefaults(firmId);
   await apiUtils.refreshTokens(firmId);
+}
+
+async function refreshPartnerToken(partnerId) {
+  try {
+    const partnerCredentials = firmCredentials.getPartnerCredentials(partnerId);
+
+    if (!partnerCredentials) {
+      const existingPartners = firmCredentials.listAuthorizedPartners();
+      const existingPartnersList = array
+        .map((item) => `${item.id}${item.name ? " - " + item.name : ""}`)
+        .join("\n");
+
+      console.log("existingPartners", existingPartners);
+      consola.error(`Missing authorization for partner id: ${partnerId}`);
+      consola.error(`Only found partner ids for: ${existingPartnersList}`);
+      process.exit(1);
+    }
+
+    const response = await axios.post(
+      `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
+    );
+
+    firmCredentials.storePartnerApiKey(
+      partnerId,
+      partnerCredentials?.name,
+      response.data.api_key
+    );
+
+    consola.success(`Partner API key refreshed for partner ID: ${partnerId}`);
+  } catch (error) {
+    consola.error(
+      `Response Status: ${error.response.status} (${error.response.statusText})`
+    );
+    consola.error("An error occurred trying to refresh the partner API key");
+    consola.error(error);
+    process.exit(1);
+  }
 }
 
 async function createReconciliationText(
@@ -1202,6 +1240,7 @@ async function getFirmDetails(firmId, refreshToken = true) {
 module.exports = {
   authorizeApp,
   refreshTokens,
+  refreshPartnerToken,
   createReconciliationText,
   readReconciliationTexts,
   readReconciliationTextById,

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -272,7 +272,6 @@ async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
   const sharedParts = response.data;
   // No data
   if (sharedParts.length == 0) {
-    //consola.warn(`Shared part "${sharedPartName}" not found`);
     return null;
   }
   const sharedPart = sharedParts.find(
@@ -281,7 +280,7 @@ async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
   if (sharedPart) {
     return sharedPart;
   } else {
-    return findSharedPartByName(firmId, sharedPartName, page + 1);
+    return findSharedPartByName(type, envId, sharedPartName, page + 1);
   }
 }
 
@@ -362,59 +361,31 @@ async function createExportFile(firmId, attributes) {
   }
 }
 
-async function updateExportFile(
-  firmId,
-  exportFileId,
-  attributes,
-  refreshToken = true
-) {
-  apiUtils.setAxiosDefaults(firmId);
+async function updateExportFile(type, envId, exportFileId, attributes) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `export_files/${exportFileId}`,
       attributes
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      exportFileId: exportFileId,
-      attributes: attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      updateExportFile,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readExportFiles(firmId, page = 1, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readExportFiles(type, envId, page = 1) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`export_files`, {
+    const response = await instance.get(`export_files`, {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      page: page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readExportFiles,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -431,143 +402,93 @@ async function readExportFileById(type, envId, exportFileId) {
   }
 }
 
-async function findExportFileByName(firmId, exportFileName, page = 1) {
-  const exportFiles = await readExportFiles(firmId, page);
+async function findExportFileByName(type, envId, exportFileName, page = 1) {
+  const exportFiles = await readExportFiles(type, envId, page);
   // No data
   if (exportFiles.length == 0) {
-    //consola.warn(`Export file "${exportFileName}" not found`);
     return null;
   }
   const exportFile = exportFiles.find(
     (element) => element["name"] === exportFileName
   );
   if (exportFile) {
-    return await readExportFileById(firmId, exportFile.id);
+    return await readExportFileById(type, envId, exportFile.id);
   } else {
-    return findExportFileByName(firmId, exportFileName, page + 1);
+    return findExportFileByName(type, envId, exportFileName, page + 1);
   }
 }
 
 async function addSharedPartToExportFile(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  exportFileId,
-  refreshToken = true
+  exportFileId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `export_files/${exportFileId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      sharedPartId: sharedPartId,
-      exportFileId: exportFileId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      addSharedPartToExportFile,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function removeSharedPartFromExportFile(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  exportFileId,
-  refreshToken = true
+  exportFileId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.delete(
+    const response = await instance.delete(
       `export_files/${exportFileId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      sharedPartId: sharedPartId,
-      exportFileId: exportFileId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      removeSharedPartFromExportFile,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function createAccountTemplate(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createAccountTemplate(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.post(`account_templates`, attributes);
+    const response = await instance.post(`account_templates`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      attributes: attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      error,
-      refreshToken,
-      createAccountTemplate,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function updateAccountTemplate(
-  firmId,
+  type,
+  envId,
   accountTemplateId,
-  attributes,
-  refreshToken = true
+  attributes
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `account_templates/${accountTemplateId}`,
       attributes
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      accountTemplateId: accountTemplateId,
-      attributes: attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      updateAccountTemplate,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readAccountTemplates(
-  type,
-  envId,
-  page = 1,
-) {
+async function readAccountTemplates(type, envId, page = 1) {
   const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
     const response = await instance.get(`account_templates`, {
@@ -623,63 +544,39 @@ async function findAccountTemplateByName(
 }
 
 async function addSharedPartToAccountTemplate(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  accountTemplateId,
-  refreshToken = true
+  accountTemplateId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      sharedPartId: sharedPartId,
-      accountTemplateId: accountTemplateId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      addSharedPartToAccountTemplate,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function removeSharedPartFromAccountTemplate(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  accountTemplateId,
-  refreshToken = true
+  accountTemplateId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.delete(
+    const response = await instance.delete(
       `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      sharedPartId: sharedPartId,
-      accountTemplateId: accountTemplateId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      removeSharedPartFromAccountTemplate,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -717,28 +614,16 @@ async function readTestRun(firmId, testId) {
   }
 }
 
-async function getPeriods(firmId, companyId, page = 1, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getPeriods(firmId, companyId, page = 1) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(`/companies/${companyId}/periods`, {
+    const response = await instance.get(`/companies/${companyId}/periods`, {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getPeriods,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -747,74 +632,40 @@ function findPeriod(periodId, periodsArray) {
   return periodsArray.find((period) => period.id == periodId);
 }
 
-async function getCompanyDrop(firmId, companyId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getCompanyDrop(firmId, companyId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(`/companies/${companyId}`);
+    const response = await instance.get(`/companies/${companyId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getCompanyDrop,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function getCompanyCustom(firmId, companyId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getCompanyCustom(firmId, companyId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(`/companies/${companyId}/custom`);
+    const response = await instance.get(`/companies/${companyId}/custom`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getCompanyCustom,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function getWorkflows(firmId, companyId, periodId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getWorkflows(firmId, companyId, periodId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/workflows`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      periodId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getWorkflows,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -824,33 +675,18 @@ async function getWorkflowInformation(
   companyId,
   periodId,
   workflowId,
-  page = 1,
-  refreshToken = true
+  page = 1
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`,
       { params: { page: page, per_page: 200 } }
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      periodId,
-      workflowId,
-      page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getWorkflowInformation,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -923,86 +759,46 @@ async function findReconciliationInWorkflows(
   );
 }
 
-async function getAccountDetails(
-  firmId,
-  companyId,
-  periodId,
-  accountId,
-  refreshToken = true
-) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getAccountDetails(firmId, companyId, periodId, accountId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `companies/${companyId}/periods/${periodId}/accounts/${accountId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      periodId,
-      accountId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getAccountDetails,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 // Liquid Linter
 // attributes should be JSON
-async function verifyLiquid(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function verifyLiquid(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
     const config = { headers: { "Content-Type": "application/json" } };
-    const response = await axios.post(
+    const response = await instance.post(
       "reconciliations/verify_liquid",
       attributes,
       config
     );
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      verifyLiquid,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function getFirmDetails(firmId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function getFirmDetails(firmId) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.get(`/user/firm`);
+    const response = await instance.get(`/user/firm`);
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getFirmDetails,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -53,9 +53,9 @@ async function refreshTokens(type, firmId) {
   return true;
 }
 
-async function refreshPartnerToken(partnerId) {
+async function refreshPartnerToken(partner_id) {
   try {
-    const partnerCredentials = apiUtils.checkAuthorizePartners(partnerId);
+    const partnerCredentials = apiUtils.checkAuthorizePartners(partner_id);
 
     if (partnerCredentials) {
       const response = await axios.post(
@@ -63,13 +63,13 @@ async function refreshPartnerToken(partnerId) {
       );
 
       firmCredentials.storePartnerApiKey(
-        partnerId,
+        partner_id,
         response.data.api_key,
         partnerCredentials?.name
       );
 
       return {
-        partnerId,
+        partner_id,
         partnerName: partnerCredentials?.name,
         token: response.data.api_key,
       };

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -315,7 +315,7 @@ async function addSharedPartToReconciliation(
   type,
   envId,
   sharedPartId,
-  reconciliationId,
+  reconciliationId
 ) {
   const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
@@ -383,7 +383,6 @@ async function readExportFiles(type, envId, page = 1) {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
-    console.log(response.data)
     return response.data;
   } catch (error) {
     const response = await apiUtils.responseErrorHandler(error);

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -84,38 +84,19 @@ async function refreshPartnerToken(partnerId) {
   }
 }
 
-async function createReconciliationText(
-  firmId,
-  attributes,
-  refreshToken = true
-) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createReconciliationText(type, envId, attributes) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(`reconciliations`, attributes);
+    const response = await instance.post(`reconciliations`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      createReconciliationText,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readReconciliationTexts(
-  type,
-  envId,
-  page = 1,
-  refreshToken = true
-) {
+async function readReconciliationTexts(type, envId, page = 1) {
   const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
     const response = await instance.get(`reconciliations`, {
@@ -124,28 +105,12 @@ async function readReconciliationTexts(
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readReconciliationTexts,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readReconciliationTextById(
-  type,
-  envId,
-  id,
-  refreshToken = true
-) {
+async function readReconciliationTextById(type, envId, id) {
   const instance = apiUtils.setAxiosDefaults(type, envId);
 
   try {
@@ -153,18 +118,7 @@ async function readReconciliationTextById(
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      envId,
-      id,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      envId,
-      error,
-      refreshToken,
-      readReconciliationTextById,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -206,135 +160,89 @@ async function findReconciliationTextByHandle(type, envId, handle, page = 1) {
 }
 
 async function updateReconciliationText(
-  firmId,
+  type,
+  envId,
   reconciliationId,
-  attributes,
-  refreshToken = true
+  attributes
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `reconciliations/${reconciliationId}`,
       attributes
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      reconciliationId,
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      updateReconciliationText,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function readReconciliationTextDetails(
-  firmId,
+  type,
+  envId,
   companyId,
   periodId,
-  reconciliationId,
-  refreshToken = true
+  reconciliationId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
     const callbackParameters = {
-      firmId,
+      envId,
       companyId,
       periodId,
       reconciliationId,
-      refreshToken: false,
     };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readReconciliationTextDetails,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function getReconciliationCustom(
-  firmId,
+  type,
+  envId,
   companyId,
   periodId,
   reconciliationId,
-  page = 1,
-  refreshToken = true
+  page = 1
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`,
       { params: { page: page, per_page: 200 } }
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      periodId,
-      reconciliationId,
-      page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getReconciliationCustom,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function getReconciliationResults(
-  firmId,
+  type,
+  envId,
   companyId,
   periodId,
-  reconciliationId,
-  refreshToken = true
+  reconciliationId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(
+    const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/results`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      companyId,
-      periodId,
-      reconciliationId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      getReconciliationResults,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -241,56 +241,34 @@ async function getReconciliationResults(
   }
 }
 
-async function readSharedParts(firmId, page = 1, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readSharedParts(type, envId, page = 1) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`shared_parts`, {
+    const response = await instance.get(`shared_parts`, {
       params: { page: page, per_page: 200 },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      page,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readSharedParts,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function readSharedPartById(firmId, sharedPartId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readSharedPartById(type, envId, sharedPartId) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`shared_parts/${sharedPartId}`);
+    const response = await instance.get(`shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      sharedPartId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readSharedPartById,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function findSharedPartByName(firmId, sharedPartName, page = 1) {
-  const response = await readSharedParts(firmId, page);
+async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
+  const response = await readSharedParts(type, envId, page);
   const sharedParts = response.data;
   // No data
   if (sharedParts.length == 0) {
@@ -307,139 +285,79 @@ async function findSharedPartByName(firmId, sharedPartName, page = 1) {
   }
 }
 
-async function updateSharedPart(
-  firmId,
-  sharedPartId,
-  attributes,
-  refreshToken = true
-) {
-  apiUtils.setAxiosDefaults(firmId);
+async function updateSharedPart(type, envId, sharedPartId, attributes) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `shared_parts/${sharedPartId}`,
       attributes
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      sharedPartId,
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      updateSharedPart,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function createSharedPart(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createSharedPart(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.post(`shared_parts`, attributes);
+    const response = await instance.post(`shared_parts`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      createSharedPart,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function addSharedPartToReconciliation(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  reconciliationId,
-  refreshToken = true
+  reconciliationId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.post(
+    const response = await instance.post(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      sharedPartId,
-      reconciliationId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      addSharedPartToReconciliation,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
 async function removeSharedPartFromReconciliation(
-  firmId,
+  type,
+  envId,
   sharedPartId,
-  reconciliationId,
-  refreshToken = true
+  reconciliationId
 ) {
-  apiUtils.setAxiosDefaults(firmId);
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.delete(
+    const response = await instance.delete(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
     );
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      firmId,
-      sharedPartId,
-      reconciliationId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      removeSharedPartFromReconciliation,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
 
-async function createExportFile(firmId, attributes, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function createExportFile(firmId, attributes) {
+  const instance = apiUtils.setAxiosDefaults("firm", firmId);
   try {
-    const response = await axios.post(`export_files`, attributes);
+    const response = await instance.post(`export_files`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = {
-      attributes: attributes,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      error,
-      refreshToken,
-      createExportFile,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -501,25 +419,14 @@ async function readExportFiles(firmId, page = 1, refreshToken = true) {
   }
 }
 
-async function readExportFileById(firmId, exportFileId, refreshToken = true) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readExportFileById(type, envId, exportFileId) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`export_files/${exportFileId}`);
+    const response = await instance.get(`export_files/${exportFileId}`);
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      exportFileId: exportFileId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readExportFileById,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }
@@ -681,29 +588,16 @@ async function readAccountTemplates(firmId, page = 1, refreshToken = true) {
   }
 }
 
-async function readAccountTemplateById(
-  firmId,
-  accountTemplateId,
-  refreshToken = true
-) {
-  apiUtils.setAxiosDefaults(firmId);
+async function readAccountTemplateById(type, envId, accountTemplateId) {
+  const instance = apiUtils.setAxiosDefaults(type, envId);
   try {
-    const response = await axios.get(`account_templates/${accountTemplateId}`);
+    const response = await instance.get(
+      `account_templates/${accountTemplateId}`
+    );
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
-    const callbackParameters = {
-      firmId: firmId,
-      accountTemplateId: accountTemplateId,
-      refreshToken: false,
-    };
-    const response = await apiUtils.responseErrorHandler(
-      firmId,
-      error,
-      refreshToken,
-      readAccountTemplateById,
-      callbackParameters
-    );
+    const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
 }

--- a/lib/cli/devMode.js
+++ b/lib/cli/devMode.js
@@ -87,7 +87,7 @@ function watchLiquidFiles(firmId) {
   );
   const files = fsUtils.listExistingFiles("liquid");
   const lastUpdates = {};
-  files.forEach((filePath) => {
+  for (let filePath of files) {
     fs.watch(filePath, (eventType, filename) => {
       if (eventType !== "change") {
         return;
@@ -102,19 +102,19 @@ function watchLiquidFiles(firmId) {
       lastUpdates[filename] = fileStats.mtimeMs;
       // Update template
       if (details.type === "reconciliationText") {
-        toolkit.publishReconciliationByHandle(firmId, details.handle);
+        toolkit.publishReconciliationByHandle("firm", firmId, details.handle);
       }
       if (details.type === "sharedPart") {
-        toolkit.publishSharedPartByName(firmId, details.handle);
+        toolkit.publishSharedPartByName("firm", firmId, details.handle);
       }
       if (details.type === "exportFile") {
-        toolkit.publishExportFileByName(firmId, details.handle);
+        toolkit.publishExportFileByName("firm", firmId, details.handle);
       }
       if (details.type === "accountTemplate") {
-        toolkit.publishAccountTemplateByName(firmId, details.handle);
+        toolkit.publishAccountTemplateByName("firm", firmId, details.handle);
       }
     });
-  });
+  }
 }
 
 module.exports = { watchLiquidTest, watchLiquidFiles };

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -80,7 +80,7 @@ function checkUniqueOption(uniqueParameters = [], options) {
 }
 
 // Check which options are required in combination with a firm id
-function checkRequiredFirmOrPartner(options, requiredOptions) {
+function checkRequiredFirmOrPartner(options, requiredOptions, partnerSupported = true) {
   const firmOrPartnerOptionsUsed = Object.keys(options).some((option) =>
     requiredOptions.includes(option)
   );
@@ -88,7 +88,7 @@ function checkRequiredFirmOrPartner(options, requiredOptions) {
 
   if (firmOrPartnerOptionsUsed && !firm && !partner) {
     consola.error(
-      "A firm or partner id is required, please use --firm, --partner or set a default firm id when using this command"
+      `A firm${partnerSupported ? " or partner id" : "" } is required, please use --firm${partnerSupported ? " , --partner" : "" } or set a default firm id when using this command`
     );
 
     process.exit(1);
@@ -109,8 +109,8 @@ function getCommandSettings(options) {
   return commandSettings;
 }
 
-function runCommandChecks (requiredTemplateOptions, options, firmIdDefault) {
-  checkRequiredFirmOrPartner(options, requiredTemplateOptions);
+function runCommandChecks (requiredTemplateOptions, options, firmIdDefault, partnerSupported = true) {
+  checkRequiredFirmOrPartner(options, requiredTemplateOptions, partnerSupported);
   checkUniqueOption(requiredTemplateOptions, options);
   const settings = getCommandSettings(options);
 

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -79,26 +79,34 @@ function checkUniqueOption(uniqueParameters = [], options) {
   }
 }
 
-// Check all options are used together (or none)
-function checkUsedTogether(parameters = [], options) {
-  const optionsToCheck = Object.keys(options).filter((element) => {
-    if (parameters.includes(element)) {
-      return true;
-    }
-  });
-  if (
-    optionsToCheck.length !== parameters.length &&
-    optionsToCheck.length !== 0
-  ) {
-    let formattedParameters = parameters.map((parameter) =>
-      formatOption(parameter)
-    );
+// Check which options are required in combination with a firm id
+function checkRequiredFirmOrPartner(options, requiredOptions) {
+  const firmOrPartnerOptionsUsed = Object.keys(options).some((option) =>
+    requiredOptions.includes(option)
+  );
+  const { firm, partner } = options;
+
+  if (firmOrPartnerOptionsUsed && !firm && !partner) {
     consola.error(
-      "The following options must be used together: " +
-        formattedParameters.join(", ")
+      "A firm or partner id is required, please use --firm, --partner or set a default firm id when using this command"
     );
+
     process.exit(1);
   }
+
+  return true;
+}
+
+function getCommandSettings(options) {
+  const type = options.partner ? "partner" : "firm";
+  const envId = options.partner ? options.partner : options.firm;
+
+  const commandSettings = {
+    type,
+    envId,
+  };
+
+  return commandSettings;
 }
 
 module.exports = {
@@ -108,5 +116,6 @@ module.exports = {
   promptConfirmation,
   formatOption,
   checkUniqueOption,
-  checkUsedTogether,
+  checkRequiredFirmOrPartner,
+  getCommandSettings,
 };

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -109,6 +109,22 @@ function getCommandSettings(options) {
   return commandSettings;
 }
 
+function runCommandChecks (requiredTemplateOptions, options, firmIdDefault) {
+  checkRequiredFirmOrPartner(options, requiredTemplateOptions);
+  checkUniqueOption(requiredTemplateOptions, options);
+  const settings = getCommandSettings(options);
+
+  if (!options.yes) {
+    promptConfirmation();
+  }
+
+  if (settings.type == "firm") {
+    checkDefaultFirm(options.firm, firmIdDefault);
+  }
+
+  return settings;
+}
+
 module.exports = {
   loadDefaultFirmId,
   checkDefaultFirm,
@@ -118,4 +134,5 @@ module.exports = {
   checkUniqueOption,
   checkRequiredFirmOrPartner,
   getCommandSettings,
+  runCommandChecks
 };

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -67,20 +67,41 @@ function checkUniqueOption(uniqueParameters = [], options) {
       return true;
     }
   });
+
+  // Check if minimum one of the options is used
+  if (optionsToCheck.length === 0) {
+    let formattedParameters = uniqueParameters.map((parameter) =>
+      formatOption(parameter)
+    );
+    consola.error(
+      `One of the following options must be used: ${formattedParameters.join(
+        ", "
+      )}`
+    );
+    process.exit(1);
+  }
+
+  // Check if the options aren't used together
   if (optionsToCheck.length !== 1) {
     let formattedParameters = uniqueParameters.map((parameter) =>
       formatOption(parameter)
     );
     consola.error(
-      "Only one of the following options must be used: " +
+      "Used incompatible options. Only one of the following options must be used: " +
         formattedParameters.join(", ")
     );
     process.exit(1);
   }
+
+  return true;
 }
 
 // Check which options are required in combination with a firm id
-function checkRequiredFirmOrPartner(options, requiredOptions, partnerSupported = true) {
+function checkRequiredFirmOrPartner(
+  options,
+  requiredOptions,
+  partnerSupported = true
+) {
   const firmOrPartnerOptionsUsed = Object.keys(options).some((option) =>
     requiredOptions.includes(option)
   );
@@ -88,7 +109,11 @@ function checkRequiredFirmOrPartner(options, requiredOptions, partnerSupported =
 
   if (firmOrPartnerOptionsUsed && !firm && !partner) {
     consola.error(
-      `A firm${partnerSupported ? " or partner id" : "" } is required, please use --firm${partnerSupported ? " , --partner" : "" } or set a default firm id when using this command`
+      `A firm${
+        partnerSupported ? " or partner id" : ""
+      } is required, please use --firm${
+        partnerSupported ? " , --partner" : ""
+      } or set a default firm id when using this command`
     );
 
     process.exit(1);
@@ -109,8 +134,24 @@ function getCommandSettings(options) {
   return commandSettings;
 }
 
-function runCommandChecks (requiredTemplateOptions, options, firmIdDefault, partnerSupported = true) {
-  checkRequiredFirmOrPartner(options, requiredTemplateOptions, partnerSupported);
+function runCommandChecks(
+  requiredTemplateOptions,
+  options,
+  firmIdDefault,
+  partnerSupported = true
+) {
+  if (!partnerSupported && options.partner) {
+    consola.error(
+      `The option "--partner" is not supported when using "--export-file"`
+    );
+    process.exit(1);
+  }
+
+  checkRequiredFirmOrPartner(
+    options,
+    requiredTemplateOptions,
+    partnerSupported
+  );
   checkUniqueOption(requiredTemplateOptions, options);
   const settings = getCommandSettings(options);
 
@@ -134,5 +175,5 @@ module.exports = {
   checkUniqueOption,
   checkRequiredFirmOrPartner,
   getCommandSettings,
-  runCommandChecks
+  runCommandChecks,
 };

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -43,7 +43,7 @@ class AccountTemplate {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
 
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
@@ -59,6 +59,7 @@ class AccountTemplate {
       },
       test: `tests/${name}_liquid_test.yml`,
       ...configDetails,
+      
     };
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, configContent);
 
@@ -100,6 +101,25 @@ class AccountTemplate {
       }
       return acc;
     }, {});
+    
+    // For update to partner, we also need to add partner_account_mapping_list_id
+    const mappingListRanges = template.mapping_list_ranges.map((mapping_list_range, i) => {
+      // If a value exists in the config, keep the same value
+      const existingPartnerAccountMappingList = existingConfig.mapping_list_ranges[i]?.partner_account_mapping_list_id
+      if (existingConfig?.mapping_list_ranges && existingPartnerAccountMappingList) {
+        return {
+          partner_account_mapping_list_id: existingPartnerAccountMappingList,
+          ...mapping_list_range,
+        };
+      } else {
+        // Otherwise, add the partner_account_mapping_list_id
+        return {
+          partner_account_mapping_list_id: null,
+          ...mapping_list_range,
+        };
+      }
+    });
+
     const textParts = templateUtils.filterParts(template);
     const configTextParts = Object.keys(textParts).reduce((acc, name) => {
       if (name) {
@@ -107,7 +127,7 @@ class AccountTemplate {
       }
       return acc;
     }, {});
-    return { ...attributes, text: "main.liquid", text_parts: configTextParts };
+    return { ...attributes, text: "main.liquid", text_parts: configTextParts, mapping_list_ranges: mappingListRanges };
   }
 
   static #filterConfigItems(templateConfig) {

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -59,7 +59,6 @@ class AccountTemplate {
       },
       test: `tests/${name}_liquid_test.yml`,
       ...configDetails,
-      
     };
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, configContent);
 
@@ -99,26 +98,32 @@ class AccountTemplate {
       } else if (existingConfig?.hasOwnProperty(attribute)) {
         acc[attribute] = existingConfig[attribute];
       }
-      return acc;
     }, {});
-    
+
     // For update to partner, we also need to add partner_account_mapping_list_id
-    const mappingListRanges = template.mapping_list_ranges.map((mapping_list_range, i) => {
-      // If a value exists in the config, keep the same value
-      const existingPartnerAccountMappingList = existingConfig.mapping_list_ranges[i]?.partner_account_mapping_list_id
-      if (existingConfig?.mapping_list_ranges && existingPartnerAccountMappingList) {
-        return {
-          partner_account_mapping_list_id: existingPartnerAccountMappingList,
-          ...mapping_list_range,
-        };
-      } else {
-        // Otherwise, add the partner_account_mapping_list_id
-        return {
-          partner_account_mapping_list_id: null,
-          ...mapping_list_range,
-        };
+    const mappingListRanges = template.mapping_list_ranges.map(
+      (mapping_list_range, i) => {
+        // If a value exists in the config, keep the same value
+        const existingPartnerAccountMappingList =
+          existingConfig.mapping_list_ranges[i]
+            ?.partner_account_mapping_list_id;
+        if (
+          existingConfig?.mapping_list_ranges &&
+          existingPartnerAccountMappingList
+        ) {
+          return {
+            partner_account_mapping_list_id: existingPartnerAccountMappingList,
+            ...mapping_list_range,
+          };
+        } else {
+          // Otherwise, add the partner_account_mapping_list_id
+          return {
+            partner_account_mapping_list_id: null,
+            ...mapping_list_range,
+          };
+        }
       }
-    });
+    );
 
     const textParts = templateUtils.filterParts(template);
     const configTextParts = Object.keys(textParts).reduce((acc, name) => {
@@ -127,7 +132,12 @@ class AccountTemplate {
       }
       return acc;
     }, {});
-    return { ...attributes, text: "main.liquid", text_parts: configTextParts, mapping_list_ranges: mappingListRanges };
+    return {
+      ...attributes,
+      text: "main.liquid",
+      text_parts: configTextParts,
+      mapping_list_ranges: mappingListRanges,
+    };
   }
 
   static #filterConfigItems(templateConfig) {

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -98,6 +98,8 @@ class AccountTemplate {
       } else if (existingConfig?.hasOwnProperty(attribute)) {
         acc[attribute] = existingConfig[attribute];
       }
+
+      return acc;
     }, {});
 
     // For update to partner, we also need to add partner_account_mapping_list_id

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -23,8 +23,8 @@ class AccountTemplate {
    * @param {number} firmId
    * @param {object} template
    */
-  static save(firmId, template) {
-    if (!template.name_nl) return false; // NL must be enabled in "Advance Settings" in Silverfin
+  static save(type, envId, template) {
+    if (!template.name_nl) return false; // NL must be enabled in "Advanced Settings" in Silverfin
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.name_nl, this.TEMPLATE_TYPE))
       return false;
@@ -43,11 +43,16 @@ class AccountTemplate {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template, existingConfig);
+    const configDetails = this.#prepareConfigDetails(template);
+
+    const addNewId = (currentType, typeCheck, envId, template) =>
+      currentType == typeCheck ? { [envId]: template.id } : {};
+
     const configContent = {
-      id: {
-        ...existingConfig?.id,
-        [firmId]: template.id,
+      id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
+      partnerId: {
+        ...existingConfig?.partnerId,
+        ...addNewId(type, "partner", envId, template),
       },
       partnerId: {
         ...existingConfig?.partnerId,

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -50,12 +50,12 @@ class AccountTemplate {
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
         ...addNewId(type, "partner", envId, template),
       },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
       },
       test: `tests/${name}_liquid_test.yml`,
       ...configDetails,

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -130,7 +130,7 @@ class AccountTemplate {
     */
 
     const existingMappingRanges = existingConfig.mapping_list_ranges || [];
-    const mappingListIds = template.mapping_list_ranges.map((range) =>
+    const latestMappingListIds = template.mapping_list_ranges.map((range) =>
       type == "partner"
         ? range.partner_account_mapping_list_id
         : range.account_mapping_list_id
@@ -141,14 +141,14 @@ class AccountTemplate {
     // Remove the mapping list ranges from this partner / firm env_id which are no longer part of the response
     updatedMappingRanges = updatedMappingRanges.filter(
       (range) =>
-        mappingListIds.includes(
+        latestMappingListIds.includes(
           type == "partner"
             ? range.partner_account_mapping_list_id
             : range.account_mapping_list_id
         ) || range.env_id !== envId
     );
 
-    for (let mappingListRange of template.mapping_list_ranges) {
+    for (let latestMappingListRange of template.mapping_list_ranges) {
       // Find the existing mapping list range, if any
       let existingIndex;
 
@@ -156,27 +156,27 @@ class AccountTemplate {
         existingIndex = existingMappingRanges.findIndex(
           (existingMappingListRange) =>
             existingMappingListRange.partner_account_mapping_list_id ===
-            mappingListRange.partner_account_mapping_list_id
+            latestMappingListRange.partner_account_mapping_list_id
         );
       } else {
         existingIndex = existingMappingRanges.findIndex(
           (existingMappingListRange) =>
             existingMappingListRange.account_mapping_list_id ===
-            mappingListRange.account_mapping_list_id
+            latestMappingListRange.account_mapping_list_id
         );
       }
 
       if (existingIndex !== -1) {
         // If it exists, update existing properties
         updatedMappingRanges[existingIndex] = {
-          ...mappingListRange,
+          ...latestMappingListRange,
           type: type,
           env_id: envId,
         };
       } else {
         // If it doesn't exist, add a new object with the necessary properties
         updatedMappingRanges.push({
-          ...mappingListRange,
+          ...latestMappingListRange,
           type: type,
           env_id: envId,
         });

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -20,8 +20,9 @@ class AccountTemplate {
 
   /**
    * Process the response provided by the Silverfin API and store every detail in its corresponding file (liquid files, config file, etc)
-   * @param {number} firmId
-   * @param {object} template
+   * @param {string} type The type of the template (firm or partner)
+   * @param {string} envId The id of the environment (firm or partner)
+   * @param {object} template The object to be processed and saved
    */
   static save(type, envId, template) {
     if (!template.name_nl) return false; // NL must be enabled in "Advanced Settings" in Silverfin
@@ -43,7 +44,12 @@ class AccountTemplate {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template, existingConfig);
+    const configDetails = this.#prepareConfigDetails(
+      type,
+      envId,
+      template,
+      existingConfig
+    );
 
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
@@ -54,12 +60,10 @@ class AccountTemplate {
         ...existingConfig?.partner_id,
         ...addNewId(type, "partner", envId, template),
       },
-      partner_id: {
-        ...existingConfig?.partner_id,
-      },
       test: `tests/${name}_liquid_test.yml`,
       ...configDetails,
     };
+
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, configContent);
 
     return true;
@@ -91,7 +95,7 @@ class AccountTemplate {
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
-  static #prepareConfigDetails(template, existingConfig = {}) {
+  static #prepareConfigDetails(type, envId, template, existingConfig = {}) {
     const attributes = this.CONFIG_ITEMS.reduce((acc, attribute) => {
       if (template.hasOwnProperty(attribute)) {
         acc[attribute] = template[attribute];
@@ -102,30 +106,34 @@ class AccountTemplate {
       return acc;
     }, {});
 
-    // For update to partner, we also need to add partner_account_mapping_list_id
-    const mappingListRanges = template.mapping_list_ranges.map(
-      (mapping_list_range, i) => {
-        // If a value exists in the config, keep the same value
-        const existingPartnerAccountMappingList =
-          existingConfig.mapping_list_ranges[i]
-            ?.partner_account_mapping_list_id;
-        if (
-          existingConfig?.mapping_list_ranges &&
-          existingPartnerAccountMappingList
-        ) {
-          return {
-            partner_account_mapping_list_id: existingPartnerAccountMappingList,
-            ...mapping_list_range,
-          };
-        } else {
-          // Otherwise, add the partner_account_mapping_list_id
-          return {
-            partner_account_mapping_list_id: null,
-            ...mapping_list_range,
-          };
-        }
+    // We need to also create the mapping_list_ranges, which could be different per firm & partner
+    const existingMappingRanges = existingConfig.mapping_list_ranges || [];
+    const updatedMappingRanges = [...existingMappingRanges];
+
+    for (let mappingListRange of template.mapping_list_ranges) {
+      // Find the existing mapping list range, if any
+      const existingIndex = existingMappingRanges.findIndex(
+        (existingMappingListRange) =>
+          existingMappingListRange.account_mapping_list_id ===
+          mappingListRange.account_mapping_list_id
+      );
+
+      if (existingIndex !== -1) {
+        // If it exists, retain existing properties and update "type" and "env_id"
+        updatedMappingRanges[existingIndex] = {
+          ...existingMappingRanges[existingIndex], // Use the existing range as a base
+          type: type,
+          env_id: envId,
+        };
+      } else {
+        // If it doesn't exist, add a new object with the necessary properties
+        updatedMappingRanges.push({
+          ...mappingListRange,
+          type: type,
+          env_id: envId,
+        });
       }
-    );
+    }
 
     const textParts = templateUtils.filterParts(template);
     const configTextParts = Object.keys(textParts).reduce((acc, name) => {
@@ -138,7 +146,7 @@ class AccountTemplate {
       ...attributes,
       text: "main.liquid",
       text_parts: configTextParts,
-      mapping_list_ranges: mappingListRanges,
+      mapping_list_ranges: updatedMappingRanges,
     };
   }
 

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -107,21 +107,69 @@ class AccountTemplate {
     }, {});
 
     // We need to also create the mapping_list_ranges, which could be different per firm & partner
+
+    /* 
+      Mapping list ranges sample in config.json:
+      ...
+    "account_range": "280,282", // This is the "no mapping list" range
+    "mapping_list_ranges": [
+      {
+        "partner_account_mapping_list_id": 2,
+        "account_range": "280,282",
+        "type": "partner",
+        "env_id": "84"
+      },
+      {
+        "account_mapping_list_id": 8957,
+        "account_range": "280,282,284",
+        "type": "firm",
+        "env_id": "13827"
+      }
+    ],
+    ...
+    */
+
     const existingMappingRanges = existingConfig.mapping_list_ranges || [];
-    const updatedMappingRanges = [...existingMappingRanges];
+    const mappingListIds = template.mapping_list_ranges.map((range) =>
+      type == "partner"
+        ? range.partner_account_mapping_list_id
+        : range.account_mapping_list_id
+    );
+
+    let updatedMappingRanges = [...existingMappingRanges];
+
+    // Remove the mapping list ranges from this partner / firm env_id which are no longer part of the response
+    updatedMappingRanges = updatedMappingRanges.filter(
+      (range) =>
+        mappingListIds.includes(
+          type == "partner"
+            ? range.partner_account_mapping_list_id
+            : range.account_mapping_list_id
+        ) || range.env_id !== envId
+    );
 
     for (let mappingListRange of template.mapping_list_ranges) {
       // Find the existing mapping list range, if any
-      const existingIndex = existingMappingRanges.findIndex(
-        (existingMappingListRange) =>
-          existingMappingListRange.account_mapping_list_id ===
-          mappingListRange.account_mapping_list_id
-      );
+      let existingIndex;
+
+      if (type == "partner") {
+        existingIndex = existingMappingRanges.findIndex(
+          (existingMappingListRange) =>
+            existingMappingListRange.partner_account_mapping_list_id ===
+            mappingListRange.partner_account_mapping_list_id
+        );
+      } else {
+        existingIndex = existingMappingRanges.findIndex(
+          (existingMappingListRange) =>
+            existingMappingListRange.account_mapping_list_id ===
+            mappingListRange.account_mapping_list_id
+        );
+      }
 
       if (existingIndex !== -1) {
-        // If it exists, retain existing properties and update "type" and "env_id"
+        // If it exists, update existing properties
         updatedMappingRanges[existingIndex] = {
-          ...existingMappingRanges[existingIndex], // Use the existing range as a base
+          ...mappingListRange,
           type: type,
           env_id: envId,
         };

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -35,7 +35,7 @@ class ExportFile {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
 
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
@@ -82,14 +82,13 @@ class ExportFile {
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
-  static #prepareConfigDetails(template, existingConfig = {}) {
+  static #prepareConfigDetails(template, existingConfig) {
     const attributes = this.CONFIG_ITEMS.reduce((acc, attribute) => {
       if (template.hasOwnProperty(attribute)) {
         acc[attribute] = template[attribute];
       } else if (existingConfig?.hasOwnProperty(attribute)) {
         acc[attribute] = existingConfig[attribute];
       }
-      return acc;
     }, {});
     const textParts = templateUtils.filterParts(template);
     const configTextParts = Object.keys(textParts).reduce((acc, name) => {

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -20,7 +20,7 @@ class ExportFile {
    * @param {number} firmId
    * @param {object} template
    */
-  static save(firmId, template) {
+  static save(type, envId, template) {
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
       return false;
@@ -35,11 +35,16 @@ class ExportFile {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template, existingConfig);
+    const configDetails = this.#prepareConfigDetails(template);
+
+    const addNewId = (currentType, typeCheck, envId, template) =>
+      currentType == typeCheck ? { [envId]: template.id } : {};
+
     const configContent = {
-      id: {
-        ...existingConfig?.id,
-        [firmId]: template.id,
+      id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
+      partnerId: {
+        ...existingConfig?.partnerId,
+        ...addNewId(type, "partner", envId, template),
       },
       partnerId: {
         ...existingConfig?.partnerId,

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -89,6 +89,8 @@ class ExportFile {
       } else if (existingConfig?.hasOwnProperty(attribute)) {
         acc[attribute] = existingConfig[attribute];
       }
+
+      return acc;
     }, {});
     const textParts = templateUtils.filterParts(template);
     const configTextParts = Object.keys(textParts).reduce((acc, name) => {

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -42,12 +42,12 @@ class ExportFile {
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
         ...addNewId(type, "partner", envId, template),
       },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
       },
       ...configDetails,
     };

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -80,7 +80,7 @@ class ReconciliationText {
       test: `tests/${handle}_liquid_test.yml`,
       ...configDetails,
     };
-    
+
     fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, configContent);
 
     return true;
@@ -155,18 +155,18 @@ class ReconciliationText {
     }, {});
   }
 
-  static #checkReconciliationType(attributes) {
+  static #checkReconciliationType(template) {
     if (
-      !this.RECONCILIATION_TYPE_OPTIONS.includes(attributes.reconciliation_type)
+      !this.RECONCILIATION_TYPE_OPTIONS.includes(template.reconciliation_type)
     ) {
       consola.warn(
         `Wrong reconciliation type. It must be one of the following: ${this.RECONCILIATION_TYPE_OPTIONS.join(
           ", "
-        )}. Skipping it's definition.`
+        )}. Skipping its definition.`
       );
-      delete attributes.reconciliation_type;
+      delete template.reconciliation_type;
     }
-    return attributes;
+    return template;
   }
 
   static #createMainLiquid(handle) {

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -20,6 +20,8 @@ class ReconciliationText {
     "externally_managed",
     "published",
     "hide_code",
+    "use_full_width",
+    "downloadable_as_docx",
   ];
   static RECONCILIATION_TYPE_OPTIONS = [
     "reconciliation_not_necessary",

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -64,7 +64,7 @@ class ReconciliationText {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
 

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -80,6 +80,7 @@ class ReconciliationText {
       test: `tests/${handle}_liquid_test.yml`,
       ...configDetails,
     };
+    
     fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, configContent);
 
     return true;

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -70,12 +70,9 @@ class ReconciliationText {
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
         ...addNewId(type, "partner", envId, template),
-      },
-      partnerId: {
-        ...existingConfig?.partnerId,
       },
       test: `tests/${handle}_liquid_test.yml`,
       ...configDetails,

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -32,8 +32,9 @@ class ReconciliationText {
 
   /**
    * Process the response provided by the Silverfin API and store every detail in its corresponding file (liquid files, config file, etc)
-   * @param {number} firmId
-   * @param {object} template
+   * @param {string} type firm or partner
+   * @param {number} envId  The id of the firm or partner environment where the template is going to be imported from
+   * @param {object} template The template object provided by the Silverfin API
    */
   static async save(type, envId, template) {
     if (this.#missingHandle(template)) return;

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -35,9 +35,9 @@ class ReconciliationText {
    * @param {number} firmId
    * @param {object} template
    */
-  static async save(firmId, template) {
-    if (this.#missingHandle(template)) return false;
-    if (templateUtils.missingLiquidCode(template)) return false;
+  static async save(type, envId, template) {
+    if (this.#missingHandle(template)) return;
+    if (templateUtils.missingLiquidCode(template)) return;
     if (!templateUtils.checkValidName(template.handle, this.TEMPLATE_TYPE))
       return false;
 
@@ -63,11 +63,15 @@ class ReconciliationText {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-    const configDetails = this.#prepareConfigDetails(template, existingConfig);
+    const configDetails = this.#prepareConfigDetails(template);
+    const addNewId = (currentType, typeCheck, envId, template) =>
+      currentType == typeCheck ? { [envId]: template.id } : {};
+
     const configContent = {
-      id: {
-        ...existingConfig?.id,
-        [firmId]: template.id,
+      id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
+      partnerId: {
+        ...existingConfig?.partnerId,
+        ...addNewId(type, "partner", envId, template),
       },
       partnerId: {
         ...existingConfig?.partnerId,

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -97,7 +97,7 @@ class SharedPart {
       if (existingUsedTemplate) {
         // Template already exists in usedIn array
         if (type === "firm") {
-          existingUsedTemplate.id[envId] = {
+          existingUsedTemplate.id = {
             ...existingUsedTemplate.id,
             [envId]: template.id,
           };

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -167,19 +167,17 @@ class SharedPart {
             handle = exportFile[handle_attribute];
           }
           break;
+        case "accountTemplate":
+          let accountTemplate = await SF.readAccountTemplateById(
+            type,
+            envId,
+            template.id
+          );
 
-        // TODO: STILL OUTSTANDING API BUG FROM THE PLATFORM WHERE ACCOUNT TEMPLATES IN THE USED_IN ARRAY DON'T RETURN THE CORRECT ID, WHICH IS BLOCKING THE FURTHER EXECUTION
-        // case "accountTemplate":
-        //   let accountTemplate = await SF.readAccountTemplateById(
-        //     type,
-        //     envId,
-        //     template.id
-        //   );
-
-        //   if (accountTemplate) {
-        //     handle = accountTemplate?.name_nl;
-        //   }
-        //   break;
+          if (accountTemplate) {
+            handle = accountTemplate?.name_nl;
+          }
+          break;
       }
     }
 

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -41,8 +41,8 @@ class SharedPart {
 
     const config = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
-      partnerId: {
-        ...existingConfig?.partnerId,
+      partner_id: {
+        ...existingConfig?.partner_id,
         ...addNewId(type, "partner", envId, template),
       },
       name: template.name,
@@ -104,8 +104,8 @@ class SharedPart {
         }
 
         if (type === "partner") {
-          existingUsedTemplate.partnerId = {
-            ...existingUsedTemplate.partnerId,
+          existingUsedTemplate.partner_id = {
+            ...existingUsedTemplate.partner_id,
             [envId]: template.id,
           };
         }
@@ -113,7 +113,7 @@ class SharedPart {
         // Template doesn't exist in usedIn array yet
         const usedTemplate = {
           id: {},
-          partnerId: {},
+          partner_id: {},
           handle,
           type: template.type,
         };
@@ -123,7 +123,7 @@ class SharedPart {
         }
 
         if (type === "partner") {
-          usedTemplate.partnerId[envId] = template.id;
+          usedTemplate.partner_id[envId] = template.id;
         }
 
         usedIn.push(usedTemplate);

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -146,6 +146,7 @@ class SharedPart {
             envId,
             template.id
           );
+
           if (reconciliationText) {
             handle = reconciliationText.data[handle_attribute];
           }
@@ -160,18 +161,22 @@ class SharedPart {
             handle = exportFile[handle_attribute];
           }
           break;
-        case "accountTemplate":
-          let accountTemplate = SF.readAccountTemplateById(
-            type,
-            envId,
-            template.id
-          );
-          if (accountTemplate) {
-            handle = accountTemplate.name_nl;
-          }
-          break;
+
+        // TODO: STILL OUTSTANDING API BUG FROM THE PLATFORM WHERE ACCOUNT TEMPLATES IN THE USED_IN ARRAY DON'T RETURN THE CORRECT ID, WHICH IS BLOCKING THE FURTHER EXECUTION
+        // case "accountTemplate":
+        //   let accountTemplate = await SF.readAccountTemplateById(
+        //     type,
+        //     envId,
+        //     template.id
+        //   );
+          
+        //   if (accountTemplate) {
+        //     handle = accountTemplate?.name_nl;
+        //   }
+        //   break;
       }
     }
+    
     return handle;
   }
 

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -106,10 +106,10 @@ class SharedPart {
       } else {
         // Template doesn't exist in usedIn array yet
         const usedTemplate = {
-          handle,
-          type: template.type,
           id: {},
           partnerId: {},
+          handle,
+          type: template.type,
         };
 
         if (type === "firm") {
@@ -169,14 +169,14 @@ class SharedPart {
         //     envId,
         //     template.id
         //   );
-          
+
         //   if (accountTemplate) {
         //     handle = accountTemplate?.name_nl;
         //   }
         //   break;
       }
     }
-    
+
     return handle;
   }
 

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const fsUtils = require("../utils/fsUtils");
 const templateUtils = require("../utils/templateUtils");
 const SF = require("../api/sfApi");
+const { default: consola } = require("consola");
 
 class SharedPart {
   static CONFIG_ITEMS = ["name", "externally_managed", "hide_code"];
@@ -11,10 +12,11 @@ class SharedPart {
 
   /**
    * Process the response provided by the Silverfin API and store every detail in its corresponding file (liquid files, config file, etc)
-   * @param {number} firmId
-   * @param {object} template
+   * @param {string} type firm or partner
+   * @param {number} envId  The id of the firm or partner environment where the template is going to be imported fro
+   * @param {object} template The template object provided by the Silverfin API
    */
-  static async save(firmId, template) {
+  static async save(type, envId, template) {
     if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
       return false;
 
@@ -26,16 +28,22 @@ class SharedPart {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, template.name);
+
     let usedIn = await this.#processUsedIn(
-      firmId,
+      type,
+      envId,
       template.used_in,
       existingConfig
     );
 
+    const addNewId = (currentType, typeCheck, envId, template) =>
+      currentType == typeCheck ? { [envId]: template.id } : {};
+
     const config = {
-      id: { ...existingConfig.id, [firmId]: template.id },
+      id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
       partnerId: {
         ...existingConfig?.partnerId,
+        ...addNewId(type, "partner", envId, template),
       },
       name: template.name,
       text: `${template.name}.liquid`,
@@ -67,7 +75,7 @@ class SharedPart {
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
-  static async #processUsedIn(firmId, templateUsedIn, existingConfig) {
+  static async #processUsedIn(type, envId, templateUsedIn, existingConfig) {
     // Adjust IDs and find templates handle
     let usedIn = existingConfig.used_in ? existingConfig.used_in : [];
     // Remove old format IDs
@@ -75,45 +83,67 @@ class SharedPart {
     // NEW: "id": { "100": 1234 }
     usedIn = usedIn.filter((template) => typeof template.id !== "number");
 
-    for await (let template of templateUsedIn) {
+    for (let template of templateUsedIn) {
       template = this.checkTemplateType(template);
-      const handle = await this.#findTemplateHandle(firmId, template);
+      const handle = await this.#findTemplateHandle(type, envId, template);
       if (!handle) continue;
 
-      template.handle = handle;
-      // Check if there's already an existing used_in configuration for other firms
+      // Check if there's already an existing used_in configuration for other firms/partners
       const templateExistingInConfig = usedIn.findIndex(
-        (existingUsedTemplate) => existingUsedTemplate.handle == template.handle
+        (existingUsedTemplate) => existingUsedTemplate.handle == handle
       );
-      if (templateExistingInConfig !== -1) {
-        // Update existing
-        template.id = {
-          ...usedIn[templateExistingInConfig].id,
-          [firmId]: template.id,
-        };
-        template.partnerId = { ...usedIn[templateExistingInConfig].partnerId };
-        usedIn[templateExistingInConfig] = template;
-        // New entry
+      let existingUsedTemplate = usedIn[templateExistingInConfig];
+
+      if (existingUsedTemplate) {
+        // Template already exists in usedIn array
+        if (type === "firm") {
+          existingUsedTemplate.id[envId] = template.id;
+        }
+
+        if (type === "partner") {
+          existingUsedTemplate.partnerId[envId] = template.id;
+        }
       } else {
-        template.id = { [firmId]: template.id };
-        template.partnerId = {};
-        usedIn.push(template);
+        // Template doesn't exist in usedIn array yet
+        const usedTemplate = {
+          handle,
+          type: template.type,
+          id: {},
+          partnerId: {},
+        };
+
+        if (type === "firm") {
+          usedTemplate.id[envId] = template.id;
+        }
+
+        if (type === "partner") {
+          usedTemplate.partnerId[envId] = template.id;
+        }
+
+        usedIn.push(usedTemplate);
       }
     }
+
     return usedIn;
   }
 
-  static async #findTemplateHandle(firmId, template) {
+  static async #findTemplateHandle(type, envId, template) {
     // Search in repository
-    let handle = fsUtils.findHandleByID(firmId, template.type, template.id);
-    // Search through the API
+    let handle = fsUtils.findHandleByID(
+      type,
+      envId,
+      template.type,
+      template.id
+    );
+
     if (!handle) {
       const handle_attribute =
         templateUtils.TEMPLATES_NAME_ATTRIBUTE[template.type];
       switch (template.type) {
         case "reconciliationText":
           let reconciliationText = await SF.readReconciliationTextById(
-            firmId,
+            type,
+            envId,
             template.id
           );
           if (reconciliationText) {
@@ -121,18 +151,23 @@ class SharedPart {
           }
           break;
         case "exportFile":
-          let exportFile = await SF.readExportFileById(firmId, template.id);
+          let exportFile = await SF.readExportFileById(
+            type,
+            envId,
+            template.id
+          );
           if (exportFile) {
             handle = exportFile[handle_attribute];
           }
           break;
         case "accountTemplate":
-          let accountTemplate = await SF.readAccountTemplateById(
-            firmId,
+          let accountTemplate = SF.readAccountTemplateById(
+            type,
+            envId,
             template.id
           );
           if (accountTemplate) {
-            handle = accountTemplate[handle_attribute];
+            handle = accountTemplate.name_nl;
           }
           break;
       }
@@ -165,6 +200,7 @@ class SharedPart {
     }, {});
   }
 
+  /** For legacy compatibility. Originally we stored `type` as `reconciliation` or 'account_detail_template', but it should aligned to `reconciliationText` & 'accountTemplate' */
   static checkTemplateType(template) {
     if (fsUtils.TEMPLATE_TYPES.includes(template.type)) {
       return template;

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -97,11 +97,17 @@ class SharedPart {
       if (existingUsedTemplate) {
         // Template already exists in usedIn array
         if (type === "firm") {
-          existingUsedTemplate.id[envId] = template.id;
+          existingUsedTemplate.id[envId] = {
+            ...existingUsedTemplate.id,
+            [envId]: template.id,
+          };
         }
 
         if (type === "partner") {
-          existingUsedTemplate.partnerId[envId] = template.id;
+          existingUsedTemplate.partnerId = {
+            ...existingUsedTemplate.partnerId,
+            [envId]: template.id,
+          };
         }
       } else {
         // Template doesn't exist in usedIn array yet

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -5,6 +5,12 @@ const { consola } = require("consola");
 
 const BASE_URL = process.env.SF_HOST || "https://live.getsilverfin.com";
 
+function checkAuthorizePartners(partnerId) {
+  const partnerCredentials = firmCredentials.getPartnerCredentials(partnerId);
+
+  return partnerCredentials;
+}
+
 function checkRequiredEnvVariables() {
   const missingVariables = ["SF_API_CLIENT_ID", "SF_API_SECRET"].filter(
     (key) => !process.env[key]
@@ -47,10 +53,10 @@ async function getAccessToken(firmId, authCode) {
 }
 
 // Get a new pair of tokens
-async function refreshTokens(firmId) {
+async function refreshTokens(instance, firmId) {
   try {
+    consola.debug(`refreshing tokens for firm ${firmId}`);
     const firmTokens = firmCredentials.getTokenPair(firmId);
-    consola.debug(`Requesting new pair of tokens`);
     let data = {
       client_id: process.env.SF_API_CLIENT_ID,
       client_secret: process.env.SF_API_SECRET,
@@ -59,22 +65,26 @@ async function refreshTokens(firmId) {
       refresh_token: firmTokens.refreshToken,
       access_token: firmTokens.accessToken,
     };
-    const response = await axios.post(
+    const response = await instance.post(
       `https://api.getsilverfin.com/f/${firmId}/oauth/token`,
       data
     );
     firmCredentials.storeNewTokenPair(firmId, response.data);
     // firm name
     const firmName = firmCredentials.getFirmName(firmId);
+
     if (!firmName) {
       await getFirmName(firmId);
     }
+
+    return true;
   } catch (error) {
-    const description = JSON.stringify(error.response.data.error_description);
+    const description =
+      error?.response?.data?.error_description || error?.request?.data;
+
     consola.error(
       `Response Status: ${error.response.status} (${error.response.statusText})`,
-      "\n",
-      `Error description: ${description}`,
+      description ? `\nError description: ${description}` : "",
       "\n",
       `Error refreshing the tokens. Try running the authentication process again`
     );
@@ -82,23 +92,150 @@ async function refreshTokens(firmId) {
   }
 }
 
-function setAxiosDefaults(firmId) {
-  const firmTokens = firmCredentials.getTokenPair(firmId);
-  if (!firmTokens) {
-    consola.error(`Missing authorization for firm id: ${firmId}`);
-    process.exit(1);
+function setAxiosDefaults(type, envId) {
+  let axiosInstance;
+
+  if (type == "firm") {
+    const firmTokens = firmCredentials.getTokenPair(envId);
+    if (!firmTokens) {
+      consola.error(`Missing authorization for firm id: ${envId}`);
+      process.exit(1);
+    }
+
+    axiosInstance = axios.create({
+      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
+      headers: {
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+        Authorization: `Bearer ${firmTokens.accessToken}`,
+      },
+    });
+
+    axiosInstance.interceptors.response.use(
+      (res) => {
+        return res;
+      },
+      async (error) => {
+        const originalConfig = error.config;
+        if (error.response) {
+          if (error.response.status === 401 && !originalConfig._retry) {
+            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+            originalConfig._retry = true;
+
+            try {
+              // Get a refreshed set of tokens
+              const firmId = originalConfig.baseURL.split("/").pop();
+              await refreshTokens(axiosInstance, firmId);
+
+              // Set the Authorization header with the new access token
+              const firmTokens = firmCredentials.getTokenPair(firmId);
+              consola.debug(`refreshed tokens for firm ${firmId}`);
+
+              axios.defaults.headers.common[
+                "Authorization"
+              ] = `Bearer ${firmTokens.accessToken}`;
+
+              originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+
+              return axiosInstance(originalConfig);
+            } catch (_error) {
+              consola.error(
+                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
+              );
+
+              if (_error.response && _error.response.data) {
+                return Promise.reject(_error.response.data);
+              }
+
+              return Promise.reject(_error);
+            }
+          }
+        }
+
+        return Promise.reject(error);
+      }
+    );
+  } else if (type == "partner") {
+    axiosInstance = axios.create({
+      baseURL: `${BASE_URL}/api/partner/v1`,
+      headers: {
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+      },
+    });
+
+    axiosInstance.interceptors.request.use((config) => {
+      // Fetch the stored partner api key
+      const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
+
+      // Set the partner api key and id as a query param to every request
+      config.params = {
+        ...config.params,
+        partner_id: envId,
+        api_key: partnerToken,
+      };
+
+      return config;
+    });
+
+    axiosInstance.interceptors.response.use(
+      (res) => {
+        return res;
+      },
+      async (error) => {
+        const originalConfig = error.config;
+        if (error.response) {
+          if (error.response.status === 401 && !originalConfig._retry) {
+            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+            originalConfig._retry = true;
+
+            try {
+              // Get a refresh API key
+              const originalPartnerId = originalConfig.params.partner_id;
+              const originalPartnerApiKey = originalConfig.params.api_key;
+
+              const response = await axios.post(
+                `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
+              );
+
+              firmCredentials.storePartnerApiKey(
+                originalPartnerId,
+                response.data.api_key
+              );
+
+              console.debug("refreshed partner api key", response.data);
+
+              return axios(originalConfig);
+            } catch (_error) {
+              consola.error(
+                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
+              );
+
+              if (_error.response && _error.response.data) {
+                return Promise.reject(_error.response.data);
+              }
+
+              return Promise.reject(_error);
+            }
+          }
+        }
+
+        return Promise.reject(error);
+      }
+    );
   }
-  axios.defaults.baseURL = `${BASE_URL}/api/v4/f/${firmId}`;
-  axios.defaults.headers["User-Agent"] = `silverfin-cli/${pkg.version}`;
-  axios.defaults.headers.common[
-    "Authorization"
-  ] = `Bearer ${firmTokens.accessToken}`;
+
+  return axiosInstance;
 }
 
 function responseSuccessHandler(response) {
-  consola.debug(
-    `Response Status: ${response.status} (${response.statusText}) - method: ${response.config.method} - url: ${response.config.url}`
-  );
+  if (response?.status) {
+    consola.debug(
+      `Response Status: ${response.status} (${
+        response?.statusText
+      }) - method: ${response?.config?.method || response?.method} - url: ${
+        response?.config?.url || response?.url
+      }`
+    );
+  }
 }
 
 async function responseErrorHandler(
@@ -113,50 +250,40 @@ async function responseErrorHandler(
       `Response Status: ${error.response.status} (${error.response.statusText}) - method: ${error.response.config.method} - url: ${error.response.config.url}`
     );
   }
-  // Valid Request. Not Found
-  if (error?.response?.status && error.response.status === 404) {
-    consola.error(
-      `Response Error (404): ${JSON.stringify(error.response.data.error)}`
-    );
-    return;
-  }
-  // Bad Request
-  if (error?.response?.status && error.response.status === 400) {
-    consola.error(
-      `Response Error (400): ${JSON.stringify(error.response.data.error)}`
-    );
-    return;
-  }
-  // No access credentials
-  if (error?.response?.status && error.response.status === 401) {
-    consola.debug(
-      `Response Error (401): ${JSON.stringify(error.response.data.error)}`
-    );
-    if (refreshToken) {
-      // Get a new pair of tokens
-      await refreshTokens(firmId);
-      //  Call the original function again
-      return callbackFunction(...Object.values(callbackParameters));
-    } else {
+  if (error?.response) {
+    // Valid Request. Not Found
+    if (error.response.status === 404) {
       consola.error(
-        `Error 401: API calls failed, try to run the authorization process again`
+        `Response Error (404): ${JSON.stringify(error.response.data.error)}`
+      );
+      return;
+    }
+    // Bad Request
+    if (error.response.status === 400) {
+      consola.error(
+        `Response Error (400): ${JSON.stringify(error.response.data.error)}`
+      );
+      return;
+    }
+    // Unprocessable Entity
+    if (error.response.status === 422) {
+      consola.error(
+        `Response Error (422): ${JSON.stringify(error.response.data)}`,
+        "\n",
+        `You don't have the rights to update the previous parameters`
       );
       process.exit(1);
     }
-  }
-  // Unprocessable Entity
-  if (error?.response?.status && error.response.status === 422) {
-    consola.error(
-      `Response Error (422): ${JSON.stringify(error.response.data)}`,
-      "\n",
-      `You don't have the rights to update the previous parameters`
-    );
-    process.exit(1);
-  }
-  // Forbidden
-  if (error?.response?.status && error.response.status === 403) {
-    consola.error("Error (403): Forbidden access. Terminating process");
-    process.exit(1);
+    if (error.response.status === 401) {
+      consola.debug(
+        `Response Error (401): ${JSON.stringify(error.response.data)}`
+      );
+    }
+    // Forbidden
+    if (error.response.status === 403) {
+      consola.error("Error (403): Forbidden access. Terminating process");
+      process.exit(1);
+    }
   }
   // Not handled
   throw error;
@@ -185,4 +312,5 @@ module.exports = {
   responseErrorHandler,
   refreshTokens,
   getFirmName,
+  checkAuthorizePartners,
 };

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -206,7 +206,7 @@ function setAxiosDefaults(type, envId) {
               return axiosInstance(originalConfig);
             } catch (_error) {
               consola.error(
-                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
+                `Error 401: Failed to refresh the partner api key automatically, try to manually authorize the partner again with the authorize-partner command`
               );
 
               if (_error.response && _error.response.data) {
@@ -238,14 +238,8 @@ function responseSuccessHandler(response) {
   }
 }
 
-async function responseErrorHandler(
-  firmId,
-  error,
-  refreshToken = false,
-  callbackFunction,
-  callbackParameters
-) {
-  if (error?.response?.status && error?.response?.config) {
+async function responseErrorHandler(error) {
+  if (error && error.response) {
     consola.debug(
       `Response Status: ${error.response.status} (${error.response.statusText}) - method: ${error.response.config.method} - url: ${error.response.config.url}`
     );

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -201,7 +201,7 @@ function setAxiosDefaults(type, envId) {
                 response.data.api_key
               );
 
-              console.debug("refreshed partner api key", response.data);
+              consola.debug("refreshed partner api key");
 
               return axiosInstance(originalConfig);
             } catch (_error) {

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -110,6 +110,7 @@ function setAxiosDefaults(type, envId) {
       },
     });
 
+    // Add a response interceptor to refresh the access token if it's expired
     axiosInstance.interceptors.response.use(
       (res) => {
         return res;
@@ -162,6 +163,7 @@ function setAxiosDefaults(type, envId) {
       },
     });
 
+    // Add a request interceptor to add the partner api key and id to every request
     axiosInstance.interceptors.request.use((config) => {
       // Fetch the stored partner api key
       const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
@@ -176,6 +178,7 @@ function setAxiosDefaults(type, envId) {
       return config;
     });
 
+    // Add a response interceptor to refresh the partner api key if it's expired
     axiosInstance.interceptors.response.use(
       (res) => {
         return res;

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -5,8 +5,8 @@ const { consola } = require("consola");
 
 const BASE_URL = process.env.SF_HOST || "https://live.getsilverfin.com";
 
-function checkAuthorizePartners(partnerId) {
-  const partnerCredentials = firmCredentials.getPartnerCredentials(partnerId);
+function checkAuthorizePartners(partner_id) {
+  const partnerCredentials = firmCredentials.getPartnerCredentials(partner_id);
 
   return partnerCredentials;
 }

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -130,7 +130,7 @@ function setAxiosDefaults(type, envId) {
               const firmTokens = firmCredentials.getTokenPair(firmId);
               consola.debug(`refreshed tokens for firm ${firmId}`);
 
-              axios.defaults.headers.common[
+              axiosInstance.defaults.headers.common[
                 "Authorization"
               ] = `Bearer ${firmTokens.accessToken}`;
 
@@ -203,7 +203,7 @@ function setAxiosDefaults(type, envId) {
 
               console.debug("refreshed partner api key", response.data);
 
-              return axios(originalConfig);
+              return axiosInstance(originalConfig);
             } catch (_error) {
               consola.error(
                 `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -30,9 +30,14 @@ function errorHandler(error) {
   }
 }
 
+function missingConfig(identifier) {
+  consola.error(`Missing config file for "${identifier}"`);
+  process.exit(1);
+}
+
 function missingReconciliationId(handle) {
-  consola.error(`Reconciliation ${handle}: ID is missing. Aborted`);
-  consola.info(
+  consola.error(`Reconciliation ${handle}: ID is missing.`);
+  consola.log(
     `Try running: ${chalk.bold(
       `silverfin get-reconciliation-id --handle ${handle}`
     )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
@@ -63,6 +68,7 @@ function missingAccountTemplateId(name) {
 module.exports = {
   uncaughtErrors,
   errorHandler,
+  missingConfig,
   missingReconciliationId,
   missingSharedPartId,
   missingExportFileId,

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -164,15 +164,20 @@ function configExists(templateType, handle) {
 }
 
 function readConfig(templateType, handle) {
-  createConfigIfMissing(templateType, handle);
-  const configPath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "config.json"
-  );
-  const configData = fs.readFileSync(configPath).toString();
-  return JSON.parse(configData);
+  try {
+    createConfigIfMissing(templateType, handle);
+    const configPath = path.join(
+      process.cwd(),
+      `${FOLDERS[templateType]}`,
+      `${handle}`,
+      "config.json"
+    );
+    const configData = fs.readFileSync(configPath).toString();
+    return JSON.parse(configData);
+  } catch (error) {
+    consola.error(error);
+    process.exit(1);
+  }
 }
 
 /**
@@ -193,6 +198,7 @@ function createConfigIfMissing(templateType, handle) {
 
   const config = {};
   config.id = {};
+  config.partnerId = {};
   config.externally_managed = true;
   switch (templateType) {
     case "reconciliationText":

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -211,6 +211,7 @@ function createConfigIfMissing(templateType, handle) {
       config.allow_duplicate_reconciliation = false;
       config.is_active = true;
       config.use_full_width = true;
+      config.downloadable_as_docx = false;
       config.hide_code = true;
       config.published = true;
       config.text = "main.liquid";

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -210,12 +210,17 @@ function createConfigIfMissing(templateType, handle) {
       config.public = false;
       config.allow_duplicate_reconciliation = false;
       config.is_active = true;
+      config.use_full_width = true;
+      config.hide_code = true;
+      config.published = true;
       config.text = "main.liquid";
       config.text_parts = {};
       break;
     case "sharedPart":
       config.name = `${handle}`;
       config.text = `${handle}.liquid`;
+      config.hide_code = true;
+      config.published = true;
       config.used_in = [];
       break;
     case "exportFile":
@@ -226,14 +231,16 @@ function createConfigIfMissing(templateType, handle) {
       config.text_parts = {};
       break;
     case "accountTemplate":
+      config.name_nl = `${handle}`;
+      config.name_fr = `${handle}`;
+      config.name_en = `${handle}`;
       config.text_configuration = null;
       config.account_range = null;
       config.mapping_list_ranges = [];
       config.text = "main.liquid";
       config.text_parts = {};
-      config.name_nl = `${handle}`;
-      config.name_fr = `${handle}`;
-      config.name_en = `${handle}`;
+      config.hide_code = true;
+      config.published = true;
       break;
   }
   writeConfig(templateType, handle, config);

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -198,7 +198,7 @@ function createConfigIfMissing(templateType, handle) {
 
   const config = {};
   config.id = {};
-  config.partnerId = {};
+  config.partner_id = {};
   config.externally_managed = true;
   switch (templateType) {
     case "reconciliationText":
@@ -292,7 +292,7 @@ function findHandleByID(type, envId, templateType, id) {
       const checkId =
         type == "firm"
           ? templateConfig.id && templateConfig.id[envId]
-          : templateConfig.partnerId && templateConfig.partnerId[envId];
+          : templateConfig.partner_id && templateConfig.partner_id[envId];
 
       if (checkId == id) {
         const handle =

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -238,11 +238,11 @@ function createConfigIfMissing(templateType, handle) {
  * @param {string} type Options: `reconciliationText`, `accountTemplate`, `exportFile` or `sharedPart`
  * @returns {Array<string>} Array with all the handles of the templates of the given type
  */
-function getAllTemplatesOfAType(type) {
-  if (!TEMPLATE_TYPES.includes(type)) {
+function getAllTemplatesOfAType(templateType) {
+  if (!TEMPLATE_TYPES.includes(templateType)) {
     throw `Template type should be one of ${TEMPLATE_TYPES.join(", ")}`;
   }
-  const relativePath = FOLDERS[type];
+  const relativePath = FOLDERS[templateType];
   let templatesArray = [];
   if (!fs.existsSync(`./${relativePath}`)) {
     return templatesArray;

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -266,23 +266,40 @@ function getAllTemplatesOfAType(templateType) {
 
 /**
  * Try to identify a template by it's ID
- * @param {number} firmId Firm ID where the template is used
+ * @param {string} type firm or partner
+ * @param {number} envId  The id of the firm or partner environment where the template is going to be imported from
  * @param {string} type Options: `reconciliationText`, `accountTemplate`, `exportFile` or `sharedPart`
  * @param {number} id Template ID
  * @returns {string|undefined} `handle` or `name` of the template
  */
-function findHandleByID(firmId, type, id) {
-  if (!TEMPLATE_TYPES.includes(type)) {
-    throw `Template type should be one of ${TEMPLATE_TYPES.join(", ")}`;
-  }
-  let templatesArray = getAllTemplatesOfAType(type);
-  for (let templateHandle of templatesArray) {
-    let templateConfig = readConfig(type, templateHandle);
-    if (templateConfig.id[firmId] === id) {
-      return templateConfig.handle || templateConfig.name;
+function findHandleByID(type, envId, templateType, id) {
+  try {
+    if (!TEMPLATE_TYPES.includes(templateType)) {
+      throw `Error on id ${id} with template type ${templateType}: template type should be one of ${TEMPLATE_TYPES.join(
+        ", "
+      )}`;
     }
+    let templatesArray = getAllTemplatesOfAType(templateType);
+    for (let templateHandle of templatesArray) {
+      let templateConfig = readConfig(templateType, templateHandle);
+
+      const checkId =
+        type == "firm"
+          ? templateConfig.id && templateConfig.id[envId]
+          : templateConfig.partnerId && templateConfig.partnerId[envId];
+
+      if (checkId == id) {
+        const handle =
+          templateConfig.handle ||
+          templateConfig.name ||
+          templateConfig.name_nl;
+        return handle;
+      }
+    }
+    return undefined;
+  } catch (error) {
+    consola.error(error);
   }
-  return undefined;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.25.7",
+  "version": "1.26.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Adds support for the partner API authentication and endpoints

### Partner for testing
Partner id: 84
Partner name: "BE - controlled releases"
List of all partners [https://metabase.getsilverfin.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXR[…]yI6W251bGwsMTYxXX0sIm9yaWdpbmFsX2NhcmRfaWQiOjg1MDV9](https://metabase.getsilverfin.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKlxuRlJPTVxucGFydG5lcl9vcmdhbmlzYXRpb25zXG5PUkRFUiBCWSBpZCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjR9LCJkaXNwbGF5IjoidGFibGUiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InRhYmxlLnBpdm90X2NvbHVtbiI6ImlkIiwidGFibGUuY2VsbF9jb2x1bW4iOiJ1cGRhdGVkX2F0IiwidGFibGUuY29sdW1uX3dpZHRocyI6W251bGwsMTYxXX0sIm9yaWdpbmFsX2NhcmRfaWQiOjg1MDV9)

### Partner API endpoints will be supported for the following actions:

1. Fetching the ID of the template
2. Manually refreshing the token
3. Importing
4. Updating
5. Managing shared parts

### Supported template types
- Reconciliations
- Account templates
- Shared parts

⚠️ Export files not supported because partner API endpoints do not exist yet for export files

### These actions will stay firm-only:
1. Running liquid tests
2. Creating templates (since on partner, you can't delete templates anymore after creation so don't want to make this too easy & creation of new recons can already be done by special action in the admin if needed)


Tested all these commands for partner id 84 & firm id 13827:

### firm-level commands:

```
bin/cli.js authorize
```

With an invalid firm id:
```
bin/cli.js config --refresh-token 138
```

With a valid firm id
```
bin/cli.js config --refresh-token 13827
```

`import-reconciliation`:

With a non-authorized/invalid firm id:
```
bin/cli.js import-reconciliation --verbose -h test_copy_code --yes -f 138
```

With an authorized API key (valid & expired) --> non-existing reconciliation
```
bin/cli.js import-reconciliation --verbose -h testing_copy_code --yes -f 13827
```

With an authorized API key (valid & expired) --> existing reconciliation
```
bin/cli.js import-reconciliation --verbose -h test_template --yes -f 13827
```

Import by handle or id:
```
bin/cli.js import-reconciliation --verbose --yes -f 13827 --id 74067152
````


### partner-level commands:

`authorize-partner`

```
bin/cli.js authorize-partner --partner-id 84 -k <api_key> -n "BE - Testing partner"
```

With an invalid partner id:
```
bin/cli.js config --refresh-partner-token 8
```

With a valid partner id:
```
bin/cli.js config --refresh-partner-token 84
```

`import-reconciliation`:

With a non-authorized/invalid partner id:
```
bin/cli.js import-reconciliation --verbose --yes -h test_copy_code --partner 8
```

With an authorized API key (valid & expired) --> non-existing reconciliation

```
bin/cli.js import-reconciliation --verbose --yes -h test_copy_code --partner 84
```

With an authorized API key (valid & expired) --> existing reconciliation

```
bin/cli.js import-reconciliation --verbose --yes -h test_template --partner 84
```

Import by handle or id:
```
bin/cli.js import-reconciliation --verbose --yes --partner 84 --id 1540
```

Other test commands:

#### Reconciliations

```
bin/cli.js import-reconciliation --all --yes --firm 13827
```

```
bin/cli.js import-reconciliation --yes --firm 13827 --existing
```

```
bin/cli.js import-reconciliation --all --yes --partner 84
```

```
bin/cli.js import-reconciliation --yes --partner 84 --existing
```

```
bin/cli.js create-reconciliation -h test_template --firm 14400
```
#### Shared parts

(the test_shared_part is linked to a reconciliation, account template & export file in both the firm 13827 & partner 84, so it should be able to test the used_in for all cases)

⚠️ API bug found in this update: 
The shared part GET API endpoints, don't return the linked export files in the `used_in` array (applicable to both firm & partner API)

```
bin/cli.js import-shared-part --yes --shared-part test_shared_part --partner 84
```

```
bin/cli.js import-shared-part --yes --id 334 --partner 84
```

```
bin/cli.js import-shared-part --yes --shared-part test_shared_part --firm 13827
```

```
bin/cli.js import-shared-part --yes --id 1729 --firm 13827
```

```
bin/cli.js get-shared-part-id -s test_shared_part --yes --firm 13827
```

```
bin/cli.js get-shared-part-id -s test_shared_part --yes --partner 84
```

```
bin/cli.js get-shared-part-id --all --yes --firm 13827
```

```
bin/cli.js get-shared-part-id --all --yes --partner 84
```

```
bin/cli.js update-shared-part -s test_shared_part --yes --firm 13827
```

```
bin/cli.js update-shared-part -s test_shared_part --yes --partner 84
```

```
bin/cli.js update-shared-part --all --yes --firm 13827
```

```
bin/cli.js update-shared-part --all --yes --partner 84
```


```
bin/cli.js create-shared-part -s test_shared_part --firm 14400
```


Add a shared part to a template in partner & firm:

```
bin/cli.js add-shared-part -s test_shared_part -h test_template --yes --firm 13827
```

```
bin/cli.js add-shared-part -s test_shared_part -h test_template --yes --partner 84
```

```
bin/cli.js add-shared-part -s test_shared_part --yes -at "Test account template - partner" --firm 13827
```

```
bin/cli.js add-shared-part -s test_shared_part --yes -at "Test account template - partner" -p 84
```

```
bin/cli.js add-shared-part -s test_shared_part --yes --export-file "Test export file - partner" --firm 13827
```

```
bin/cli.js add-shared-part --yes --all --firm 14400
```

```
bin/cli.js add-shared-part --yes --all --partner 84
```

Not supported to add to export file (no API endpoint):
```
bin/cli.js add-shared-part -s test_shared_part --yes --export-file "Test export file - partner" --partner 84
```

##### Shared part adding different cases testing

Add a shared part to firm template only:
```
bin/cli.js add-shared-part -s test_shared_part --yes -h liquid_demo -f 13827
```

Add a shared part to partner template only:
```
bin/cli.js add-shared-part -s test_shared_part --yes -h test_cli_template -p 84
```

Add a shared part to a reconciliation in a second firm
```
bin/cli.js add-shared-part --firm 14400 -h test_template -s test_shared_part --ye
```

```
bin/cli.js remove-shared-part -s test_shared_part -h test_template --yes --firm 13827
```

```
bin/cli.js remove-shared-part -s test_shared_part -h test_template --yes --partner 84
```

```
bin/cli.js remove-shared-part -s test_shared_part --account-template "Test account template - partner"  --yes --firm 13827
```

```
bin/cli.js remove-shared-part -s test_shared_part --account-template "Test account template - partner"  --yes --partner 84
```

```
bin/cli.js remove-shared-part -s test_shared_part --yes --export-file "Test export file - partner" --firm 13827
```

```
bin/cli.js remove-shared-part -s test_shared_part --yes --export-file "Test export file - partner" --firm 13827
```
##### Shared part removing different cases testing
Remove a shared part if multiple ids exist --> templateConfig in usedIn should still exist and only remove that specific id
Remove a shared part and there's only 1 id left in the templateConfig --> complete item of this templateConfig should be removed from the used_in array
Remove a shared part with a firm / partner id that's already removed from the templateConfig and only id exists --> this shouldn't delete the complete templateConfig item
Remove a shared part with a firm / partner where this shared part is already removed --> this shouldn't throw an error and instead just succeed
```
bin/cli.js remove-shared-part -s test_shared_part -h test_template --yes --firm 14400
```


#### Account templates
```
bin/cli.js import-account-template -n "Test account template - partner" --yes -f 13827
```

```
bin/cli.js import-account-template --id 499106 --yes -f 13827 
```

```
bin/cli.js import-account-template --yes --all -f 13827 
```

```
bin/cli.js import-account-template -n "Test account template - partner" --yes --partner 84
```

```
bin/cli.js import-account-template --id 291 --yes --partner 84
```

```
bin/cli.js import-account-template --all --yes --partner 84
```

```
bin/cli.js import-account-template --yes --existing --firm 13827
```

```
bin/cli.js import-account-template --yes --existing --partner 84
```

```
bin/cli.js get-account-template-id --name "Test account template - partner" --yes --firm 13827
```

```
bin/cli.js get-account-template-id --name "Test account template - partner" --yes --partner 84
```

```
bin/cli.js get-account-template-id --yes --all --firm 13827
```

```
bin/cli.js get-account-template-id --yes --all --partner 84
```

```
bin/cli.js update-account-template -n "Test account template - partner" --yes --firm 13827
```

```
bin/cli.js update-account-template -n "Test account template - partner" --yes --partner 84
```

```
bin/cli.js update-account-template --all --yes --firm 13827
```

```
bin/cli.js update-account-template --all --yes --partner 84
```



#### Export files
Not supported for partner because partner API endpoints do not exist to manage export files

```
bin/cli.js create-export-file --name "Test export file - partner" --firm 14400
```

#### Development mode

```
bin/cli.js development-mode --yes --firm 13827 --update-templates 
```

###  Liquid tests

```
bin/cli.js development-mode --yes --firm 13827 --test sample_test --handle test_template --html
```

```
bin/cli.js run-test -h test_template --firm 13827
```

```
bin/cli.js run-test -h test_template --firm 13827 --html-input --html-preview
```


## Type of change

- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
