### PR TITLE
Check name stored in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function fetchReconciliationByHandle(firmId, handle) {
     consola.error(`Reconciliation "${handle}" wasn't found`);
     process.exit(1);
   }
-  const saved = ReconciliationText.save(firmId, template);
+  const saved = await ReconciliationText.save(firmId, template);
   if (saved) {
     consola.success(`Reconciliation "${handle}" imported`);
   }
@@ -40,7 +40,7 @@ async function fetchReconciliationById(firmId, id) {
     consola.error(`Reconciliation with id ${id} wasn't found`);
     process.exit(1);
   }
-  const saved = ReconciliationText.save(firmId, template.data);
+  const saved = await ReconciliationText.save(firmId, template.data);
   if (saved) {
     consola.success(`Reconciliation "${template.data.handle}" imported`);
   }
@@ -175,7 +175,7 @@ async function fetchExportFileByName(firmId, name) {
     consola.error(`Export file "${name}" wasn't found`);
     process.exit(1);
   }
-  const saved = ExportFile.save(firmId, template);
+  const saved = await ExportFile.save(firmId, template);
   if (saved) {
     consola.success(`Export file "${name}" imported`);
   }
@@ -187,7 +187,7 @@ async function fetchExportFileById(firmId, id) {
     consola.error(`Export file with id ${id} wasn't found`);
     process.exit(1);
   }
-  const saved = ExportFile.save(firmId, template);
+  const saved = await ExportFile.save(firmId, template);
   if (saved) {
     consola.success(`Export file "${template.name}" imported`);
   }
@@ -312,7 +312,7 @@ async function fetchAccountTemplateByName(firmId, name) {
     consola.error(`Account template "${name}" wasn't found`);
     process.exit(1);
   }
-  const saved = AccountTemplate.save(firmId, template);
+  const saved = await AccountTemplate.save(firmId, template);
   if (saved) {
     consola.success(`Account template "${template?.name_nl}" imported`);
   }
@@ -326,7 +326,7 @@ async function fetchAccountTemplateById(firmId, id) {
     process.exit(1);
   }
 
-  const saved = AccountTemplate.save(firmId, template);
+  const saved = await AccountTemplate.save(firmId, template);
   if (saved) {
     consola.success(`Account template "${template?.name_nl}" imported`);
   }
@@ -341,7 +341,7 @@ async function fetchAllAccountTemplates(firmId, page = 1) {
     return;
   }
   templates.forEach(async (template) => {
-    const saved = AccountTemplate.save(firmId, template);
+    const saved = await AccountTemplate.save(firmId, template);
     if (saved) {
       consola.success(`Account template "${template?.name_nl}" imported`);
     }

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ const { AccountTemplate } = require("./lib/templates/accountTemplate");
 const { consola } = require("consola");
 
 async function fetchReconciliation(firmId, handle) {
-  const configPresent = fsUtils.configExists("reconciliationText", handle);
   let templateConfig;
+  const configPresent = fsUtils.configExists("reconciliationText", handle);
   if (configPresent) {
     templateConfig = fsUtils.readConfig("reconciliationText", handle);
   }
-  if (templateConfig?.id[firmId]) {
+  if (configPresent && templateConfig && templateConfig.id[firmId]) {
     await fetchReconciliationById(firmId, templateConfig.id[firmId]);
   } else {
     await fetchReconciliationByHandle(firmId, handle);
@@ -157,12 +157,12 @@ async function newAllReconciliations(firmId) {
 }
 
 async function fetchExportFile(firmId, name) {
-  const configPresent = fsUtils.configExists("exportFile", name);
   let templateConfig;
+  const configPresent = fsUtils.configExists("exportFile", name);
   if (configPresent) {
     templateConfig = fsUtils.readConfig("exportFile", name);
   }
-  if (templateConfig?.id[firmId]) {
+  if (configPresent && templateConfig && templateConfig.id[firmId]) {
     await fetchExportFileById(firmId, templateConfig.id[firmId]);
   } else {
     await fetchExportFileByName(firmId, name);
@@ -294,12 +294,12 @@ async function newAllExportFiles(firmId) {
 }
 
 async function fetchAccountTemplate(firmId, name) {
-  const configPresent = fsUtils.configExists("accountTemplate", name);
   let templateConfig;
+  const configPresent = fsUtils.configExists("accountTemplate", name);
   if (configPresent) {
     templateConfig = fsUtils.readConfig("accountTemplate", name);
   }
-  if (templateConfig?.id[firmId]) {
+  if (configPresent && templateConfig && templateConfig.id[firmId]) {
     await fetchAccountTemplateById(firmId, templateConfig.id[firmId]);
   } else {
     await fetchAccountTemplateByName(firmId, name);
@@ -441,12 +441,12 @@ async function newAllAccountTemplates(firmId) {
 }
 
 async function fetchSharedPart(firmId, name) {
-  const configPresent = fsUtils.configExists("sharedPart", name);
   let templateConfig;
+  const configPresent = fsUtils.configExists("sharedPart", name);
   if (configPresent) {
     templateConfig = fsUtils.readConfig("sharedPart", name);
   }
-  if (templateConfig?.id[firmId]) {
+  if (configPresent && templateConfig && templateConfig.id[firmId]) {
     await fetchSharedPartById(firmId, templateConfig.id[firmId]);
   } else {
     await fetchSharedPartByName(firmId, name);

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -23,10 +23,12 @@ class AccountTemplate {
    * @param {number} firmId
    * @param {object} template
    */
-  static save(firmId, template) {
+  static async save(firmId, template) {
     if (!template.name_nl) return false; // NL must be enabled in "Advance Settings" in Silverfin
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.name_nl, this.TEMPLATE_TYPE))
+      return false;
+    if (!fsUtils.checkNameAligned(template.name_nl, this.TEMPLATE_TYPE))
       return false;
 
     const name = template.name_nl;
@@ -65,8 +67,9 @@ class AccountTemplate {
    * @param {string} name The name of the template to read
    * @returns {object} The object to be sent to the Silverfin API
    */
-  static read(name) {
+  static async read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
+    if (!fsUtils.checkNameAligned(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name);
     // Config.json
     const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -20,9 +20,11 @@ class ExportFile {
    * @param {number} firmId
    * @param {object} template
    */
-  static save(firmId, template) {
+  static async save(firmId, template) {
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
+      return false;
+    if (!fsUtils.checkNameAligned(template.name, this.TEMPLATE_TYPE))
       return false;
 
     const name = template.name;
@@ -56,8 +58,9 @@ class ExportFile {
    * @param {string} name The name of the template to read
    * @returns {object} The object to be sent to the Silverfin API
    */
-  static read(name) {
+  static async read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
+    if (!fsUtils.checkNameAligned(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name, false);
     // Config.json
     const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -40,6 +40,8 @@ class ReconciliationText {
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.handle, this.TEMPLATE_TYPE))
       return false;
+    if (!fsUtils.checkNameAligned(template.handle, this.TEMPLATE_TYPE))
+      return false;
 
     const handle = template.handle;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, handle, true);
@@ -85,8 +87,9 @@ class ReconciliationText {
    * @param {string} handle The handle of the template to read
    * @returns {object} The object to be sent to the Silverfin API
    */
-  static read(handle) {
+  static async read(handle) {
     if (!templateUtils.checkValidName(handle, this.TEMPLATE_TYPE)) return false;
+    if (!fsUtils.checkNameAligned(handle, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, handle, true);
     // Config.json
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -17,6 +17,8 @@ class SharedPart {
   static async save(firmId, template) {
     if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
       return false;
+    if (!fsUtils.checkNameAligned(template.name, this.TEMPLATE_TYPE))
+      return false;
 
     fsUtils.createSharedPartFolders(template.name);
 
@@ -50,6 +52,7 @@ class SharedPart {
 
   static async read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
+    if (!fsUtils.checkNameAligned(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createSharedPartFolders(name);
     // Config.json
     const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { consola } = require("consola");
+const templateUtils = require("./templateUtils");
 
 const FOLDERS = {
   reconciliationText: "reconciliation_texts",
@@ -403,6 +404,22 @@ function identifyTypeAndHandle(filePath) {
   return false;
 }
 
+/** Compare the template's name used in the directory structure with the name in the config file */
+function checkNameAligned(name, templateType) {
+  const templateConfig = readConfig(templateType, name);
+  const templateName = templateUtils.getTemplateName(
+    templateConfig,
+    templateType
+  );
+  if (templateName !== name) {
+    consola.warn(
+      `Template name ("${name}") does not match the name stored in the config file ("${templateName}"). `
+    );
+    return false;
+  }
+  return true;
+}
+
 module.exports = {
   FOLDERS,
   TEMPLATE_TYPES,
@@ -423,4 +440,5 @@ module.exports = {
   listExistingFiles,
   listExistingRelatedLiquidFiles,
   identifyTypeAndHandle,
+  checkNameAligned,
 };

--- a/lib/utils/templateUtils.js
+++ b/lib/utils/templateUtils.js
@@ -79,4 +79,5 @@ module.exports = {
   checkValidName,
   filterParts,
   missingLiquidCode,
+  getTemplateName,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.25.7",
+  "version": "1.25.8",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

- Check if the name stored in the config is still aligned with the one used to run commands and name directories
- Avoid creating new directories and config if the name/handle used in import commands is related to a template that doesn't exist

Fixes #88 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
