### PR TITLE
Keep existing config parameters

### DIFF
--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -11,6 +11,8 @@ class AccountTemplate {
     "externally_managed",
     "account_range",
     "mapping_list_ranges",
+    "published",
+    "hide_code",
   ];
   static TEMPLATE_TYPE = "accountTemplate";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
@@ -41,11 +43,14 @@ class AccountTemplate {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const configContent = {
       id: {
         ...existingConfig?.id,
         [firmId]: template.id,
+      },
+      partnerId: {
+        ...existingConfig?.partnerId,
       },
       test: `tests/${name}_liquid_test.yml`,
       ...configDetails,
@@ -81,9 +86,13 @@ class AccountTemplate {
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
-  static #prepareConfigDetails(template) {
+  static #prepareConfigDetails(template, existingConfig = {}) {
     const attributes = this.CONFIG_ITEMS.reduce((acc, attribute) => {
-      acc[attribute] = template[attribute];
+      if (template.hasOwnProperty(attribute)) {
+        acc[attribute] = template[attribute];
+      } else if (existingConfig?.hasOwnProperty(attribute)) {
+        acc[attribute] = existingConfig[attribute];
+      }
       return acc;
     }, {});
     const textParts = templateUtils.filterParts(template);

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -3,7 +3,14 @@ const fsUtils = require("../utils/fsUtils");
 const templateUtils = require("../utils/templateUtils");
 
 class ExportFile {
-  static CONFIG_ITEMS = ["name", "file_name", "externally_managed", "encoding"];
+  static CONFIG_ITEMS = [
+    "name",
+    "file_name",
+    "externally_managed",
+    "encoding",
+    "published",
+    "hide_code",
+  ];
   static TEMPLATE_TYPE = "exportFile";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -28,11 +35,14 @@ class ExportFile {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const configContent = {
       id: {
         ...existingConfig?.id,
         [firmId]: template.id,
+      },
+      partnerId: {
+        ...existingConfig?.partnerId,
       },
       ...configDetails,
     };
@@ -67,9 +77,13 @@ class ExportFile {
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
-  static #prepareConfigDetails(template) {
+  static #prepareConfigDetails(template, existingConfig = {}) {
     const attributes = this.CONFIG_ITEMS.reduce((acc, attribute) => {
-      acc[attribute] = template[attribute];
+      if (template.hasOwnProperty(attribute)) {
+        acc[attribute] = template[attribute];
+      } else if (existingConfig?.hasOwnProperty(attribute)) {
+        acc[attribute] = existingConfig[attribute];
+      }
       return acc;
     }, {});
     const textParts = templateUtils.filterParts(template);

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -18,6 +18,8 @@ class ReconciliationText {
     "allow_duplicate_reconciliations",
     "is_active",
     "externally_managed",
+    "published",
+    "hide_code",
   ];
   static RECONCILIATION_TYPE_OPTIONS = [
     "reconciliation_not_necessary",
@@ -61,11 +63,14 @@ class ReconciliationText {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-    const configDetails = this.#prepareConfigDetails(template);
+    const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const configContent = {
       id: {
         ...existingConfig?.id,
         [firmId]: template.id,
+      },
+      partnerId: {
+        ...existingConfig?.partnerId,
       },
       test: `tests/${handle}_liquid_test.yml`,
       ...configDetails,
@@ -116,9 +121,13 @@ class ReconciliationText {
     return false;
   }
 
-  static #prepareConfigDetails(template) {
+  static #prepareConfigDetails(template, existingConfig = {}) {
     const attributes = this.CONFIG_ITEMS.reduce((acc, attribute) => {
-      acc[attribute] = template[attribute];
+      if (template.hasOwnProperty(attribute)) {
+        acc[attribute] = template[attribute];
+      } else if (existingConfig?.hasOwnProperty(attribute)) {
+        acc[attribute] = existingConfig[attribute];
+      }
       return acc;
     }, {});
     const textParts = templateUtils.filterParts(template);

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -4,7 +4,7 @@ const templateUtils = require("../utils/templateUtils");
 const SF = require("../api/sfApi");
 
 class SharedPart {
-  static CONFIG_ITEMS = ["name", "externally_managed"];
+  static CONFIG_ITEMS = ["name", "externally_managed", "hide_code"];
   static TEMPLATE_TYPE = "sharedPart";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -34,6 +34,9 @@ class SharedPart {
 
     const config = {
       id: { ...existingConfig.id, [firmId]: template.id },
+      partnerId: {
+        ...existingConfig?.partnerId,
+      },
       name: template.name,
       text: `${template.name}.liquid`,
       used_in: usedIn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.24.2",
+      "version": "1.24.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Preparing for the Partners API, we could have different attributes in a firm or in partners. This change is to avoid deleting the existing attributes when they are not provided by the API (in that case, we keep the existing one)
Also, to keep the `partnerId` if it already exists in `config.json`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
