### PR TITLE
Fix: keep partnersId reference in shared parts config

### DIFF
--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -29,7 +29,7 @@ class SharedPart {
     let usedIn = await this.#processUsedIn(
       firmId,
       template.used_in,
-      existingConfig
+      existingConfig,
     );
 
     const config = {
@@ -83,7 +83,8 @@ class SharedPart {
       template.handle = handle;
       // Check if there's already an existing used_in configuration for other firms
       const templateExistingInConfig = usedIn.findIndex(
-        (existingUsedTemplate) => existingUsedTemplate.handle == template.handle
+        (existingUsedTemplate) =>
+          existingUsedTemplate.handle == template.handle,
       );
       // Missing
       if (templateExistingInConfig !== -1) {
@@ -91,10 +92,12 @@ class SharedPart {
           ...usedIn[templateExistingInConfig].id,
           [firmId]: template.id,
         };
+        template.partnerId = { ...usedIn[templateExistingInConfig].partnerId };
         usedIn[templateExistingInConfig] = template;
         // Update Existing
       } else {
         template.id = { [firmId]: template.id };
+        template.partnerId = {};
         usedIn.push(template);
       }
     }
@@ -110,7 +113,7 @@ class SharedPart {
         case "reconciliationText":
           let reconciliationText = await SF.readReconciliationTextById(
             firmId,
-            template.id
+            template.id,
           );
           if (reconciliationText) {
             handle = reconciliationText.handle;
@@ -136,7 +139,7 @@ class SharedPart {
       fsUtils.createLiquidFile(
         relativePath,
         name,
-        "{% comment %} MAIN PART {% endcomment %}"
+        "{% comment %} MAIN PART {% endcomment %}",
       );
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.24.4",
+  "version": "1.24.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.24.4",
+      "version": "1.24.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.24.4",
+  "version": "1.24.5",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Fix to avoid removing the `partnersId` from `usedIn` in shared part's config

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
