### PR TITLE
Avoid errors to terminate process

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,10 +82,12 @@ async function publishReconciliationByHandle(
     const configPresent = fsUtils.configExists("reconciliationText", handle);
     if (!configPresent) {
       errorUtils.missingReconciliationId(handle);
+      return false;
     }
     const templateConfig = fsUtils.readConfig("reconciliationText", handle);
     if (!templateConfig || !templateConfig.id[firmId]) {
       errorUtils.missingReconciliationId(handle);
+      return false;
     }
     let templateId = templateConfig.id[firmId];
     consola.debug(`Updating reconciliation ${handle}...`);
@@ -224,10 +226,12 @@ async function publishExportFileByName(
     const configPresent = fsUtils.configExists("exportFile", name);
     if (!configPresent) {
       errorUtils.missingExportFileId(name);
+      return false;
     }
     const templateConfig = fsUtils.readConfig("exportFile", name);
     if (!templateConfig || !templateConfig.id[firmId]) {
       errorUtils.missingExportFileId(name);
+      return false;
     }
     let templateId = templateConfig.id[firmId];
     consola.debug(`Updating export file ${name}...`);
@@ -364,10 +368,12 @@ async function publishAccountTemplateByName(
     const configPresent = fsUtils.configExists("accountTemplate", name);
     if (!configPresent) {
       errorUtils.missingAccountTemplateId(name);
+      return false;
     }
     const templateConfig = fsUtils.readConfig("accountTemplate", name);
     if (!templateConfig || !templateConfig.id[firmId]) {
       errorUtils.missingAccountTemplateId(name);
+      return false;
     }
     let templateId = templateConfig.id[firmId];
     consola.debug(`Updating account template ${name}...`);
@@ -515,10 +521,12 @@ async function publishSharedPartByName(
     const configPresent = fsUtils.configExists("sharedPart", name);
     if (!configPresent) {
       errorUtils.missingSharedPartId(name);
+      return false;
     }
     const templateConfig = fsUtils.readConfig("sharedPart", name);
     if (!templateConfig || !templateConfig.id[firmId]) {
       errorUtils.missingSharedPartId(name);
+      return false;
     }
     consola.debug(`Updating shared part ${name}...`);
     const template = await SharedPart.read(name);

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -37,7 +37,7 @@ function missingReconciliationId(handle) {
       `silverfin get-reconciliation-id --handle ${handle}`
     )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
   );
-  process.exit(1);
+  return false;
 }
 
 function missingSharedPartId(name) {
@@ -47,17 +47,17 @@ function missingSharedPartId(name) {
       `silverfin get-shared-part-id --shared-part ${name}`
     )} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`
   );
-  process.exit(1);
+  return false;
 }
 
 function missingExportFileId(name) {
   consola.error(`Export file ${name}: ID is missing. Aborted`);
-  process.exit(1);
+  return false;
 }
 
 function missingAccountTemplateId(name) {
   consola.error(`Account template ${name}: ID is missing. Aborted`);
-  process.exit(1);
+  return false;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.25.6",
+  "version": "1.25.7",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Right now, most error handling functions raise and error and terminate the process with `process.exit(1)`. 
Changes this behavior to display the error but continue, only returning false. Allowing to the caller to handle the exception as needed.
This could be used in the Extension for example, or in commands like `update-reconciliation --all` where any error would stop the execution. 

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
