### PR TITLE
Cover case so hard error isn't thrown if mapping list ranges are not in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,11 +499,10 @@ async function publishAccountTemplateByName(
     template.version_comment = message;
 
     // Filter out the mapping_list_ranges that do not have this "type" and "envId"
-    template.mapping_list_ranges = template.mapping_list_ranges.filter(
-      (range) => {
+    template.mapping_list_ranges =
+      template.mapping_list_ranges?.filter((range) => {
         return range.type === type && range.env_id === envId;
-      }
-    );
+      }) || [];
 
     if (type == "partner") {
       template.version_significant_change = false;

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -139,14 +139,15 @@ class AccountTemplate {
     let updatedMappingRanges = [...existingMappingRanges];
 
     // Remove the mapping list ranges from this partner / firm env_id which are no longer part of the response
-    updatedMappingRanges = updatedMappingRanges.filter(
-      (range) =>
-        latestMappingListIds.includes(
-          type == "partner"
-            ? range.partner_account_mapping_list_id
-            : range.account_mapping_list_id
-        ) || range.env_id !== envId
-    );
+    updatedMappingRanges =
+      updatedMappingRanges?.filter(
+        (range) =>
+          latestMappingListIds.includes(
+            type == "partner"
+              ? range.partner_account_mapping_list_id
+              : range.account_mapping_list_id
+          ) || range.env_id !== envId
+      ) || [];
 
     for (let latestMappingListRange of template.mapping_list_ranges) {
       // Find the existing mapping list range, if any

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

If mapping list ranges were not in the config, a hard error was thrown:
![image](https://github.com/silverfin/silverfin-cli/assets/99254741/7a044394-12d2-4a42-99b1-825d6b3959d3)


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
