### PR TITLE
Ensure templateConfig & textPartsReducer is an existing variable everywhere + align number of arguments for create functions with other functions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -132,9 +132,9 @@ program
     cliUtils.checkUniqueOption(["handle", "all"], options);
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.handle) {
-      toolkit.newReconciliation(options.firm, options.handle);
+      toolkit.newReconciliation("firm", options.firm, options.handle);
     } else if (options.all) {
-      toolkit.newAllReconciliations(options.firm);
+      toolkit.newAllReconciliations("firm", options.firm);
     }
   });
 
@@ -232,9 +232,9 @@ program
     cliUtils.checkUniqueOption(["name", "all"], options);
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.name) {
-      toolkit.newExportFile(options.firm, options.name);
+      toolkit.newExportFile("firm", options.firm, options.name);
     } else if (options.all) {
-      toolkit.newAllExportFiles(options.firm, options.name);
+      toolkit.newAllExportFiles("firm", options.firm, options.name);
     }
   });
 
@@ -335,9 +335,9 @@ program
     cliUtils.checkUniqueOption(["name", "all"], options);
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.name) {
-      toolkit.newAccountTemplate(options.firm, options.name);
+      toolkit.newAccountTemplate("firm", options.firm, options.name);
     } else if (options.all) {
-      toolkit.newAllAccountTemplates(options.firm, options.name);
+      toolkit.newAllAccountTemplates("firm", options.firm, options.name);
     }
   });
 
@@ -442,9 +442,9 @@ program
     cliUtils.checkUniqueOption(["sharedPart", "all"], options);
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.sharedPart) {
-      toolkit.newSharedPart(options.firm, options.sharedPart);
+      toolkit.newSharedPart("firm", options.firm, options.sharedPart);
     } else if (options.all) {
-      toolkit.newAllSharedParts(options.firm);
+      toolkit.newAllSharedParts("firm", options.firm);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ async function fetchReconciliationByHandle(type, envId, handle) {
     let existingTemplate;
 
     if (configPresent) {
-      templateConfig = fsUtils.readConfig("reconciliationText", handle);
+      const templateConfig = fsUtils.readConfig("reconciliationText", handle);
 
       id =
         type == "firm"
@@ -104,7 +104,7 @@ async function fetchExistingReconciliations(type, envId) {
 
     if (!configPresent) return;
 
-    templateConfig = fsUtils.readConfig("reconciliationText", handle);
+    const templateConfig = fsUtils.readConfig("reconciliationText", handle);
 
     let templateId =
       type == "firm"
@@ -280,7 +280,7 @@ async function fetchExistingExportFiles(firmId) {
   const templates = fsUtils.getAllTemplatesOfAType("exportFile");
   if (!templates) return;
   templates.forEach(async (name) => {
-    templateConfig = fsUtils.readConfig("exportFile", name);
+    const templateConfig = fsUtils.readConfig("exportFile", name);
     if (!templateConfig || !templateConfig.id[firmId]) return;
     await fetchExportFileById(firmId, templateConfig.id[firmId]);
   });
@@ -449,7 +449,7 @@ async function fetchExistingAccountTemplates(type, envId) {
   const templates = fsUtils.getAllTemplatesOfAType("accountTemplate");
   if (!templates) return;
   templates.forEach(async (name) => {
-    templateConfig = fsUtils.readConfig("accountTemplate", name);
+    const templateConfig = fsUtils.readConfig("accountTemplate", name);
     let templateId =
       type == "firm"
         ? templateConfig?.id?.[envId]
@@ -643,7 +643,7 @@ async function fetchExistingSharedParts(type, envId) {
 
     if (!configPresent) return;
 
-    templateConfig = fsUtils.readConfig("sharedPart", name);
+    const templateConfig = fsUtils.readConfig("sharedPart", name);
 
     let templateId =
       type == "firm"

--- a/index.js
+++ b/index.js
@@ -189,10 +189,10 @@ async function publishAllReconciliations(
   }
 }
 
-async function newReconciliation(firmId, handle) {
+async function newReconciliation(type, firmId, handle) {
   try {
     const existingTemplate = await SF.findReconciliationTextByHandle(
-      "firm",
+      type,
       firmId,
       handle
     );
@@ -221,10 +221,10 @@ async function newReconciliation(firmId, handle) {
   }
 }
 
-async function newAllReconciliations(firmId) {
+async function newAllReconciliations(type, firmId) {
   const templates = fsUtils.getAllTemplatesOfAType("reconciliationText");
   for (let handle of templates) {
-    await newReconciliation(firmId, handle);
+    await newReconciliation(type, firmId, handle);
   }
 }
 
@@ -355,15 +355,15 @@ async function publishAllExportFiles(
   }
 }
 
-async function newExportFile(firmId, name) {
+async function newExportFile(type, firmId, name) {
   try {
     const existingTemplate = await SF.findExportFileByName(
-      "firm",
+      type,
       firmId,
       name
     );
     if (existingTemplate) {
-      consola.info(
+      consola.warn(
         `Export file "${name}" already exists. Skipping its creation`
       );
       return;
@@ -383,10 +383,10 @@ async function newExportFile(firmId, name) {
   }
 }
 
-async function newAllExportFiles(firmId) {
+async function newAllExportFiles(type, firmId) {
   const templates = fsUtils.getAllTemplatesOfAType("exportFile");
   for (let name of templates) {
-    await newExportFile(firmId, name);
+    await newExportFile(type, firmId, name);
   }
 }
 
@@ -539,10 +539,10 @@ async function publishAllAccountTemplates(
   }
 }
 
-async function newAccountTemplate(firmId, name) {
+async function newAccountTemplate(type, firmId, name) {
   try {
     const existingTemplate = await SF.findAccountTemplateByName(
-      "firm",
+      type,
       firmId,
       name
     );
@@ -576,10 +576,10 @@ async function newAccountTemplate(firmId, name) {
   }
 }
 
-async function newAllAccountTemplates(firmId) {
+async function newAllAccountTemplates(type, firmId) {
   const templates = fsUtils.getAllTemplatesOfAType("accountTemplate");
   for (let name of templates) {
-    await newAccountTemplate(firmId, name);
+    await newAccountTemplate(type, firmId, name);
   }
 }
 
@@ -726,10 +726,10 @@ async function publishAllSharedParts(
   }
 }
 
-async function newSharedPart(firmId, name) {
+async function newSharedPart(type, firmId, name) {
   try {
     const existingSharedPart = await SF.findSharedPartByName(
-      "firm",
+      type,
       firmId,
       name
     );
@@ -754,10 +754,10 @@ async function newSharedPart(firmId, name) {
   }
 }
 
-async function newAllSharedParts(firmId) {
+async function newAllSharedParts(type, firmId) {
   const templates = fsUtils.getAllTemplatesOfAType("sharedPart");
   for (let name of templates) {
-    await newSharedPart(firmId, name);
+    await newSharedPart(type, firmId, name);
   }
 }
 

--- a/lib/utils/templateUtils.js
+++ b/lib/utils/templateUtils.js
@@ -52,7 +52,7 @@ function checkValidName(name, templateType) {
 
 /** Process response provided by the Silverfin API and return an object with the text parts */
 function filterParts(template) {
-  textPartsReducer = (acc, part) => {
+  const textPartsReducer = (acc, part) => {
     acc[part.name] = part.content;
     return acc;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Some variables were never defined as let or const within the function scope, but this was only throwing errors when using them within the extension.

Additionally, for the bulk command updates using the VS Code extension it's easier if all functions expect the same number of arguments, now there was still a difference here because the "create" commands don't support partner updates and it wasn't needed. Aligned this so we align the code more here instead of adding additional complexity in the logic of the extension. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Documentation updated (if needed)
