### PR TITLE
Avoid creating config when running tests for non-existing templates + add additional user feedback on errors

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -413,11 +413,7 @@ program
         options.message
       );
     } else if (options.all) {
-      toolkit.publishAllSharedParts(
-        "firm",
-        settings.envId,
-        options.message
-      );
+      toolkit.publishAllSharedParts("firm", settings.envId, options.message);
     }
   });
 
@@ -643,6 +639,7 @@ program
         );
         process.exit(1);
       }
+
       liquidTestRunner.runTestsWithOutput(
         options.firm,
         options.handle,

--- a/index.js
+++ b/index.js
@@ -655,8 +655,11 @@ async function fetchExistingSharedParts(type, envId) {
   for (let name of templates) {
     const configPresent = fsUtils.configExists("sharedPart", name);
 
-    if (!configPresent)
-      consola.warn(`Config file for shared part "${name}" not found`);
+    if (!configPresent) {
+      consola.error(`Config file for shared part "${name}" not found`);
+
+      return;
+    }
 
     const templateConfig = fsUtils.readConfig("sharedPart", name);
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ async function fetchAllReconciliations(type, envId, page = 1) {
 async function fetchExistingReconciliations(type, envId) {
   const templates = fsUtils.getAllTemplatesOfAType("reconciliationText");
 
-  if (templates.length == 0) {
+  if (!templates || templates.length == 0) {
     consola.warn("No reconciliation templates with a valid config found");
     return;
   }

--- a/index.js
+++ b/index.js
@@ -229,12 +229,7 @@ async function newReconciliation(type, firmId, handle) {
 
     // Store new id
     if (response && response.status == 201) {
-      ReconciliationText.updateTemplateId(
-        "firm",
-        firmId,
-        handle,
-        response.data.id
-      );
+      ReconciliationText.updateTemplateId(firmId, handle, response.data.id);
       consola.success(`Reconciliation "${handle}" created`);
     }
   } catch (error) {

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -124,8 +124,9 @@ async function readReconciliationTextById(type, envId, id) {
 }
 
 /**
- * Find reconciliation by handle. We only look for templates that are not from Partners (because tecnically they don't belong to the current firm). If we find a template from Partners we will skip it and continue looking for the next one.
- * @param {Number} firmId
+ * Find reconciliation by handle. We only look for templates that are not from Partners (because technically they don't belong to the current firm). If we find a template from Partners we will skip it and continue looking for the next one.
+ * @param {String} type | Firm or Partner
+ * @param {Number} envId | Firm ID or Partner ID
  * @param {String} handle
  * @param {Number} page
  * @returns {Object} Reconciliation Text object

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -31,8 +31,24 @@ function findTestRows(testContent) {
 
 function buildTestParams(firmId, handle, testName = "", renderMode) {
   const relativePath = `./reconciliation_texts/${handle}`;
+
+  const configPresent = fsUtils.configExists("reconciliationText", handle);
+
+  if (!configPresent) {
+    consola.error(`Config file for "${handle}" not found`);
+
+    return;
+  }
+
   const config = fsUtils.readConfig("reconciliationText", handle);
   const testPath = `${relativePath}/${config.test}`;
+
+  if (!fs.existsSync(testPath)) {
+    consola.error(`Test file for "${handle}" not found`);
+
+    return;
+  }
+
   const testContent = fs.readFileSync(testPath, "utf-8").trim();
 
   // Empty YAML check

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const fsUtils = require("../utils/fsUtils");
 const templateUtils = require("../utils/templateUtils");
+const { consola } = require("consola");
 
 class AccountTemplate {
   static CONFIG_ITEMS = [
@@ -24,9 +25,19 @@ class AccountTemplate {
    * @param {object} template The object to be processed and saved
    */
   static save(type, envId, template) {
-    if (!template.name_nl) return false; // NL must be enabled in "Advanced Settings" in Silverfin
+    if (!template?.name_nl) {
+      consola.warn(
+        `Template name_nl is missing "${
+          template?.name_en ||
+          template?.name_fr ||
+          template?.name_da ||
+          template?.name_de
+        }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because this is the only required field for a template name.`
+      );
+      return false;
+    } // NL must be enabled in "Advanced Settings" in Silverfin
     if (templateUtils.missingLiquidCode(template)) return false;
-    if (!templateUtils.checkValidName(template.name_nl, this.TEMPLATE_TYPE))
+    if (!templateUtils.checkValidName(template?.name_nl, this.TEMPLATE_TYPE))
       return false;
 
     const name = template.name_nl;

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -32,7 +32,7 @@ class AccountTemplate {
           template?.name_fr ||
           template?.name_da ||
           template?.name_de
-        }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because this is the only required field for a template name.`
+        }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because the NL name is the only required field for a template name.`
       );
       return false;
     } // NL must be enabled in "Advanced Settings" in Silverfin

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -109,19 +109,9 @@ class ReconciliationText {
   }
 
   /** Update template's id for the corresponding firm in template's config file */
-  static updateTemplateId(type, envId, handle, templateId) {
+  static updateTemplateId(firmId, handle, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-
-    if (type === "firm") {
-      if (!templateConfig.id) templateConfig.id = {};
-
-      templateConfig.id[envId] = templateId;
-    } else if (type === "partner") {
-      if (!templateConfig.partner_id) templateConfig.partner_id = {};
-
-      templateConfig.partner_id[envId] = templateId;
-    }
-
+    templateConfig.id[firmId] = templateId;
     fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, templateConfig);
   }
 

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -63,22 +63,8 @@ class ReconciliationText {
     }
     fsUtils.createLiquidTestFiles(this.TEMPLATE_TYPE, handle, testContent);
 
-    // Config Json File
-    const configPresent = fsUtils.configExists(this.TEMPLATE_TYPE, handle);
-
-    if(!configPresent) {
-      fsUtils.createConfigIfMissing("reconciliationText", handle);
-    }
-
-    this.updateTemplateId(
-      type,
-      envId,
-      handle,
-      template.id
-    );
-
+    // Fetch existing config file
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-
     const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
@@ -127,11 +113,11 @@ class ReconciliationText {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
 
     if (type === "firm") {
-      if(!templateConfig.id) templateConfig.id = {};
+      if (!templateConfig.id) templateConfig.id = {};
 
       templateConfig.id[envId] = templateId;
     } else if (type === "partner") {
-      if(!templateConfig.partner_id) templateConfig.partner_id = {};
+      if (!templateConfig.partner_id) templateConfig.partner_id = {};
 
       templateConfig.partner_id[envId] = templateId;
     }

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -65,7 +65,21 @@ class ReconciliationText {
     fsUtils.createLiquidTestFiles(this.TEMPLATE_TYPE, handle, testContent);
 
     // Config Json File
+    const configPresent = fsUtils.configExists(this.TEMPLATE_TYPE, handle);
+
+    if(!configPresent) {
+      fsUtils.createConfigIfMissing("reconciliationText", handle);
+    }
+
+    this.updateTemplateId(
+      type,
+      envId,
+      handle,
+      template.id
+    );
+
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
+
     const configDetails = this.#prepareConfigDetails(template, existingConfig);
     const addNewId = (currentType, typeCheck, envId, template) =>
       currentType == typeCheck ? { [envId]: template.id } : {};
@@ -110,9 +124,19 @@ class ReconciliationText {
   }
 
   /** Update template's id for the corresponding firm in template's config file */
-  static updateTemplateId(firmId, handle, templateId) {
+  static updateTemplateId(type, envId, handle, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-    templateConfig.id[firmId] = templateId;
+
+    if (type === "firm") {
+      if(!templateConfig.id) templateConfig.id = {};
+
+      templateConfig.id[envId] = templateId;
+    } else if (type === "partner") {
+      if(!templateConfig.partner_id) templateConfig.partner_id = {};
+
+      templateConfig.partner_id[envId] = templateId;
+    }
+
     fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, templateConfig);
   }
 

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -160,19 +160,21 @@ function configExists(templateType, handle) {
     `${handle}`,
     "config.json"
   );
+
   return fs.existsSync(configPath);
 }
 
 function readConfig(templateType, handle) {
   try {
-    createConfigIfMissing(templateType, handle);
     const configPath = path.join(
       process.cwd(),
       `${FOLDERS[templateType]}`,
       `${handle}`,
       "config.json"
     );
+
     const configData = fs.readFileSync(configPath).toString();
+    
     return JSON.parse(configData);
   } catch (error) {
     consola.error(error);

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -166,6 +166,7 @@ function configExists(templateType, handle) {
 
 function readConfig(templateType, handle) {
   try {
+    createConfigIfMissing(templateType, handle);
     const configPath = path.join(
       process.cwd(),
       `${FOLDERS[templateType]}`,
@@ -174,7 +175,7 @@ function readConfig(templateType, handle) {
     );
 
     const configData = fs.readFileSync(configPath).toString();
-    
+
     return JSON.parse(configData);
   } catch (error) {
     consola.error(error);

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -178,6 +178,10 @@ function readConfig(templateType, handle) {
 
     return JSON.parse(configData);
   } catch (error) {
+    consola.error(
+      `An error occurred when trying to read the config for "${handle}"`
+    );
+
     consola.error(error);
     process.exit(1);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.7",
+  "version": "1.26.8",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/resources/liquidTests/README.md
+++ b/resources/liquidTests/README.md
@@ -3,15 +3,3 @@
 ## [Template name]
 
 > Use this Readme file to add extra information about the Liquid Tests that can be performed
-
-### Empty state
-
-> Describe the empty state or initial state (a test were the template is usually empty)
-
-### Unit test 1: [Title]
-
-- Test 1
-- Test 2
-- ...
-
-> Add some information about what the 'Unit 1' is about and each of the test that take part of it.


### PR DESCRIPTION
## Description

At the moment, we were creating configs too early for non-existing templates on for typos when running tests. 

Additionally, in quite a few places we were silently throwing errors or not providing that great of a user feedback. 

This aims to solve this issue so we only create configs when we're supposed to and improve certain error messages. 

Fixes 
#127 
#115

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- [x] README updated (if needed)
- [x] Version updated (if needed)
- [x] Documentation updated (if needed)
