### PR TITLE
avoid showing that tests have failed when excluded_results is used and all expectations pass

### DIFF
--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -150,10 +150,21 @@ function checkTestErrorsPresent(testName, testsFeedback) {
   let testSections = Object.keys(testsFeedback[testName]);
   // Look for reconciled, results or rollforwards
   // We could have only html for successful tests
+  // If the reconciled is null and the results + rollforwards are empty objects, no errors are present
   for (let section of testSections) {
     if (SECTIONS.includes(section)) {
-      errorsPresent = true;
-      break;
+      const sectionElement = testsFeedback[testName][section];
+
+      if (section === "reconciled" && sectionElement !== null) {
+        errorsPresent = true;
+        break;
+      } else if (
+        (section === "results" || section === "rollforwards") &&
+        Object.keys(sectionElement).length > 0
+      ) {
+        errorsPresent = true;
+        break;
+      }
     }
   }
   return errorsPresent;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

The terminal was showing that "TEST FAILED" if all expectations were passing when excluded_results was used. 

This is because excluded_results adds an extra object in the response that we were not expecting yet in our logic. 

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- ~~README updated (if needed)~~
- [x] Version updated (if needed)
- ~~Documentation updated (if needed)~~
