### PR TITLE
fix: wrong list of used shared parts returned if template id is not present for current firm

### DIFF
--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -337,8 +337,14 @@ function listSharedPartsUsedInTemplate(firmId, type, handle) {
   }
   const templateConfig = readConfig(type, handle);
   const templateId = templateConfig.id[firmId];
-  const allSharedPartsNames = getAllTemplatesOfAType("sharedPart");
   const sharedPartsPresent = [];
+
+  if (!templateId) {
+    return sharedPartsPresent;
+  }
+
+  const allSharedPartsNames = getAllTemplatesOfAType("sharedPart");
+
   for (let sharedPartName of allSharedPartsNames) {
     let sharedPartConfig = readConfig("sharedPart", sharedPartName);
     // Find if it is used in the template
@@ -351,6 +357,7 @@ function listSharedPartsUsedInTemplate(firmId, type, handle) {
       sharedPartsPresent.push(sharedPartConfig.name);
     }
   }
+
   return sharedPartsPresent;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.8",
+  "version": "1.26.9",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

A wrong list of shared parts was being displayed in the extension if the id of the current firm did not exist in the config. 

Fixes https://github.com/silverfin/silverfin-vscode/issues/47

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- ~~README updated (if needed)~~
- [x] Version updated (if needed)
- ~~Documentation updated (if needed)~~
