### PR TITLE
fix: handle additional different datatypes in liquid test errors + ensure versions comparison works for high number of minor versions

### DIFF
--- a/lib/cli/cliUpdates.js
+++ b/lib/cli/cliUpdates.js
@@ -18,13 +18,25 @@ async function getLatestVersion() {
   }
 }
 
+function compareVersions(latestVersion, currentVersion) {
+  const latestVersionParts = latestVersion.split(".").map(Number);
+  const currentVersionParts = currentVersion.split(".").map(Number);
+
+  for (let i = 0; i < latestVersionParts.length; ++i) {
+    // Compare parts of the version numbers and return the result if they are different
+    if (latestVersionParts[i] !== currentVersionParts[i]) {
+      return latestVersionParts[i] > currentVersionParts[i] ? 1 : -1;
+    }
+  }
+}
+
 async function checkVersions() {
   const latestVersion = await getLatestVersion();
   const currentVersion = pkg.version;
   if (!latestVersion || !currentVersion) {
     return;
   }
-  if (latestVersion > currentVersion) {
+  if (compareVersions(latestVersion, currentVersion) > 0) {
     consola.log(`--------------`);
     consola.log(
       "There is a new version available of this CLI (" +

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -165,6 +165,8 @@ function listErrors(items, type) {
 
     if (itemDetails.expected === "nothing") {
       expectedDataType = "blank";
+    } else if (!itemDetails.expected) {
+      expectedDataType = "null";
     }
 
     consola.log(

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -134,14 +134,45 @@ function listErrors(items, type) {
   itemsKeys.forEach((itemName) => {
     let itemDetails = items[itemName];
     consola.log(`At line number ${itemDetails.line_number}`);
+    let gotDataType = typeof itemDetails.got;
+    let expectedDataType = typeof itemDetails.expected;
+    let displayedGot = itemDetails.got;
+    let displayedExpected = itemDetails.expected;
+
+    // If the type is an object, check if it's an array or an object
+    if (gotDataType === "object") {
+      if (Array.isArray(itemDetails.got)) {
+        gotDataType = "array";
+      } else if (!itemDetails.got) {
+        gotDataType = "null";
+      } else {
+        gotDataType = "object";
+
+        // If the received got is an object, split it into lines
+        displayedGot = "\n";
+
+        for (const key in itemDetails.got) {
+          displayedGot += `${key}: ${itemDetails.got[key]}\n`;
+        }
+
+        displayedExpected = JSON.stringify(itemDetails.expected, null, 2);
+      }
+    }
+
+    if (itemDetails.got === "nothing") {
+      gotDataType = "blank";
+    }
+
+    if (itemDetails.expected === "nothing") {
+      expectedDataType = "blank";
+    }
+
     consola.log(
       `For ${type} ${chalk.blue.bold(itemName)} got ${chalk.blue.bold(
-        itemDetails.got
-      )} (${chalk.italic(
-        typeof itemDetails.got
-      )}) but expected ${chalk.blue.bold(itemDetails.expected)} (${chalk.italic(
-        typeof itemDetails.expected
-      )})`
+        displayedGot
+      )} (${chalk.italic(gotDataType)}) but expected ${chalk.blue.bold(
+        displayedExpected
+      )} (${chalk.italic(expectedDataType)})`
     );
   });
   consola.log("");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.5",
+  "version": "1.26.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.26.5",
+      "version": "1.26.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.9",
+  "version": "1.26.10",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.9.0:
+acorn@^8.9.0:
   version "8.10.0"
 
 ajv@^6.10.0, ajv@^6.12.4:
@@ -274,7 +274,7 @@ eslint-scope@^7.2.0:
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   version "3.4.1"
 
-"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.21.0:
+eslint@^8.21.0:
   version "8.45.0"
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"


### PR DESCRIPTION
## Description

Some liquid test errors that returned arrays, null or object were not being displayed correctly in the output.

Fixes https://github.com/silverfin/silverfin-vscode/issues/12

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- ~~README updated (if needed)~~
- [x] Version updated (if needed)
- ~~Documentation updated (if needed)~~
