### PR TITLE
fix: process exiting if a shared part is missing an ID on --existing import instead of moving to the next shared part

### DIFF
--- a/lib/cli/cliUpdates.js
+++ b/lib/cli/cliUpdates.js
@@ -25,7 +25,7 @@ function compareVersions(latestVersion, currentVersion) {
   for (let i = 0; i < latestVersionParts.length; ++i) {
     // Compare parts of the version numbers and return the result if they are different
     if (latestVersionParts[i] !== currentVersionParts[i]) {
-      return latestVersionParts[i] > currentVersionParts[i] ? 1 : -1;
+      return latestVersionParts[i] > currentVersionParts[i] ? true : false;
     }
   }
 }
@@ -36,7 +36,7 @@ async function checkVersions() {
   if (!latestVersion || !currentVersion) {
     return;
   }
-  if (compareVersions(latestVersion, currentVersion) > 0) {
+  if (compareVersions(latestVersion, currentVersion)) {
     consola.log(`--------------`);
     consola.log(
       "There is a new version available of this CLI (" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.10",
+  "version": "1.26.11",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

1. The process was immediately exiting when a shared part was missing an ID on an `--existing` import instead of going to the next template
![image](https://github.com/silverfin/silverfin-cli/assets/99254741/7d935170-021f-4f2b-a600-7b2bcebf765b)

2. Refactored the code for the CLI updates a bit

## Type of change

- [x] Bug fix
- ~~New feature~~
- ~~Breaking change~~

## Checklist

- ~~README updated (if needed)~~
- [x] Version updated (if needed)
- ~~Documentation updated (if needed)~~
