### PR TITLE
Update getAccessToken to use BASE_URL host

### DIFF
--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -33,7 +33,7 @@ async function getAccessToken(firmId, authCode) {
     const grantType = "authorization_code";
     let requestDetails = {
       method: "POST",
-      url: `https://api.getsilverfin.com/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
+      url: `https://${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
     };
     const response = await axios(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.26.12",
+  "version": "1.26.13",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

The AccessToken request fails for the MYOB stack since the base URL is set to api.getsilverfin.com.
In order to solve this, we need to modify it to use the configured `BASE_URL` instead.
This should also solve potential future issues with SSO subdomains, since both /oauth/authentication and /oauth/token should be run on live.getsilverfin or the SSO subdomain.

If no `process.env.SF_HOST ` is set the constant will use live.getsilverfin.com instead. So this should ensure backwards compatibility which means that this change doesn't cause any breaking changes.

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
