### PR TITLE
remove https from url in getAccessToken

### DIFF
--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -33,7 +33,7 @@ async function getAccessToken(firmId, authCode) {
     const grantType = "authorization_code";
     let requestDetails = {
       method: "POST",
-      url: `https://${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
+      url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
     };
     const response = await axios(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);


### PR DESCRIPTION
## Description

BASE_URL const already includes https:// in `https://live.getsilverfin.com'.
In the config we have to use `https://` in that case as well and ensure no duplicate `https://` is being used when string interpolating.

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
