### PR TITLE
Support Staging environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ export SF_API_CLIENT_ID=...
 export SF_API_SECRET=...
 ```
 
-In case you need to use a different host, you can also set it up as an environmental variable. By default it would be `https://live.getsilverfin.com`.
+### Host
+
+In case you need to use a different host, you can set it up by using the command `silverfin config --set-host [url]`. By default it would be `https://live.getsilverfin.com`.
+
+It is also possible to set it up as an environmental variable, but this has been deprecated and will be removed in future versions.
 
 ```bash
 export SF_HOST=...

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ It is also possible to set it up as an environmental variable, but this has been
 export SF_HOST=...
 ```
 
+### Staging environment
+
+If you need to use the CLI with a staging environment, you can set it up by using the command `silverfin config --set-host [url]` and setting the proper host.
+
+Staging environments implement Basic Authentitation on top of the existing OAuth2.0 authentication, so to make use of it you will need to set up the following environmental variables:
+
+```bash
+export SF_BASIC_AUTH=...
+```
+
 ## Important considerations and assumptions that we adder to
 
 ## Advanced Settings

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1028,5 +1028,6 @@ if (pkg.repository && pkg.repository.url) {
 (async function () {
   // Check if there is a new version available
   await cliUpdates.checkVersions();
+  cliUtils.logCurrentEnvironments();
   await program.parseAsync();
 })();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -822,10 +822,7 @@ program
     }
     if (options.refreshToken) {
       cliUtils.checkDefaultFirm(options.refreshToken, firmIdDefault);
-      const refreshedTokens = await SF.refreshTokens(
-        "firm",
-        options.refreshToken
-      );
+      const refreshedTokens = await SF.refreshFirmTokens(options.refreshToken);
 
       if (refreshedTokens) {
         consola.success(

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -300,8 +300,8 @@ program
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     const settings = runCommandChecks(
-      ["name", "all"], 
-      options, 
+      ["name", "all"],
+      options,
       firmIdDefault,
       true,
       true // Message required
@@ -760,6 +760,15 @@ program
       "Get a new partner api key using the stored api key"
     )
   )
+  .addOption(
+    new Option(
+      "--set-host [host]",
+      "Set a custom host for the Silverfin API (e.g. https://live.getsilverfin.com)"
+    )
+  )
+  .addOption(
+    new Option("--get-host", "Get the current host for the Silverfin API")
+  )
   .action(async (options) => {
     cliUtils.checkUniqueOption(
       [
@@ -769,6 +778,8 @@ program
         "updateName",
         "refreshToken",
         "refreshPartnerToken",
+        "setHost",
+        "getHost",
       ],
       options
     );
@@ -832,6 +843,14 @@ program
           `Partner API key refreshed for partner ID: ${refreshedTokens.partner_id}`
         );
       }
+    }
+    if (options.setHost) {
+      firmCredentials.setHost(options.setHost);
+      consola.success(`Host set to: ${options.setHost}`);
+    }
+    if (options.getHost) {
+      const host = firmCredentials.getHost();
+      consola.info(`Current host: ${host}`);
     }
   });
 

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -42,12 +42,17 @@ class AxiosFactory {
       process.exit(1);
     }
 
+    let baseHeaders = {
+      "User-Agent": `silverfin-cli/${pkg.version}`,
+      "X-Firm-ID": envId,
+    };
+
     let axiosDetails;
     if (this.#isStaging()) {
       axiosDetails = {
         baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
         headers: {
-          "User-Agent": `silverfin-cli/${pkg.version}`,
+          ...baseHeaders,
           Authorization: this.#basicAuthHeader(),
         },
         params: {
@@ -58,7 +63,7 @@ class AxiosFactory {
       axiosDetails = {
         baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
         headers: {
-          "User-Agent": `silverfin-cli/${pkg.version}`,
+          ...baseHeaders,
           Authorization: `Bearer ${firmTokens.accessToken}`,
         },
       };
@@ -85,7 +90,8 @@ class AxiosFactory {
 
             try {
               // Get a refreshed set of tokens
-              const firmId = originalConfig.baseURL.split("/").pop();
+              const firmId = originalConfig.headers["X-Firm-ID"];
+
               await this.#refreshFirmTokens(axiosInstance, firmId);
 
               const firmTokens = firmCredentials.getTokenPair(firmId);
@@ -237,7 +243,7 @@ class AxiosFactory {
       let data = {
         client_id: process.env.SF_API_CLIENT_ID,
         client_secret: process.env.SF_API_SECRET,
-        redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+        redirect_uri: encodeURIComponent("urn:ietf:wg:oauth:2.0:oob"),
         grant_type: "refresh_token",
         refresh_token: firmTokens.refreshToken,
         access_token: firmTokens.accessToken,

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -1,0 +1,274 @@
+const { firmCredentials } = require("./firmCredentials");
+const axios = require("axios");
+const { consola } = require("consola");
+const pkg = require("../../package.json");
+
+class AxiosFactory {
+  constructor() {}
+
+  /**
+   * Create an axios instance for a given type and environment id.
+   * It will add the necessary headers and interceptors to handle the authorization, and refresh the tokens if needed.
+   * The created instance will be used to make requests to the Silverfin API.
+   * @param {String} type - The type of instance to create (firm or partner)
+   * @param {Number} envId - The environment id to create the instance for
+   * @returns {Object} - The created axios instance
+   */
+  static createInstance(type, envId) {
+    this.BASE_URL = firmCredentials.getHost();
+    let axiosInstance;
+
+    switch (type) {
+      case "firm":
+        axiosInstance = this.#createAxiosInstanceForFirms(envId);
+        break;
+      case "partner":
+        axiosInstance = this.#createAxiosInstanceForPartners(envId);
+        break;
+      default:
+        consola.error(`Invalid type environment: ${type}`);
+        process.exit(1);
+    }
+
+    return axiosInstance;
+  }
+
+  // PRIVATE METHODS
+
+  static #createAxiosInstanceForFirms(envId) {
+    const firmTokens = firmCredentials.getTokenPair(envId);
+    if (!firmTokens) {
+      consola.error(`Missing authorization for firm id: ${envId}`);
+      process.exit(1);
+    }
+
+    let axiosDetails;
+    if (this.#isStaging()) {
+      axiosDetails = {
+        baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
+        headers: {
+          "User-Agent": `silverfin-cli/${pkg.version}`,
+          Authorization: this.#basicAuthHeader(),
+        },
+        params: {
+          access_token: firmTokens.accessToken,
+        },
+      };
+    } else {
+      axiosDetails = {
+        baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
+        headers: {
+          "User-Agent": `silverfin-cli/${pkg.version}`,
+          Authorization: `Bearer ${firmTokens.accessToken}`,
+        },
+      };
+    }
+
+    let axiosInstance = axios.create(axiosDetails);
+    axiosInstance = this.#addFirmTokenRefresher(axiosInstance);
+
+    return axiosInstance;
+  }
+
+  // Add a response interceptor to refresh the access token if it's expired
+  static #addFirmTokenRefresher(axiosInstance) {
+    axiosInstance.interceptors.response.use(
+      (response) => {
+        return response;
+      },
+      async (error) => {
+        const originalConfig = error.config;
+        if (error.response) {
+          if (error.response.status === 401 && !originalConfig._retry) {
+            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+            originalConfig._retry = true;
+
+            try {
+              // Get a refreshed set of tokens
+              const firmId = originalConfig.baseURL.split("/").pop();
+              await this.#refreshFirmTokens(axiosInstance, firmId);
+
+              const firmTokens = firmCredentials.getTokenPair(firmId);
+
+              // Set the new access token for current and future requests
+              if (this.#isStaging()) {
+                axiosInstance.defaults.params = {
+                  ...axiosInstance.defaults.params,
+                  access_token: firmTokens.accessToken,
+                };
+                originalConfig.params = {
+                  ...originalConfig.params,
+                  access_token: firmTokens.accessToken,
+                };
+              } else {
+                axiosInstance.defaults.headers.common["Authorization"] =
+                  `Bearer ${firmTokens.accessToken}`;
+                originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+              }
+
+              return axiosInstance(originalConfig);
+            } catch (_error) {
+              consola.error(
+                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
+              );
+
+              if (_error.response && _error.response.data) {
+                return Promise.reject(_error.response.data);
+              }
+
+              return Promise.reject(_error);
+            }
+          }
+        }
+
+        return Promise.reject(error);
+      }
+    );
+
+    return axiosInstance;
+  }
+
+  static #createAxiosInstanceForPartners(envId) {
+    const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
+    if (!partnerToken) {
+      consola.error(`Missing authorization for partner id: ${envId}`);
+      process.exit(1);
+    }
+
+    let axiosDetails = {
+      baseURL: `${this.BASE_URL}/api/partner/v1`,
+      headers: {
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+      },
+      params: {
+        partner_id: envId,
+        api_key: partnerToken,
+      },
+    };
+
+    if (this.#isStaging()) {
+      axiosDetails.headers.Authorization = this.#basicAuthHeader();
+    }
+
+    let axiosInstance = axios.create(axiosDetails);
+    axiosInstance = this.#addPartnerTokenRefresher(axiosInstance);
+
+    return axiosInstance;
+  }
+
+  // Add a response interceptor to refresh the partner token if it's expired
+  static #addPartnerTokenRefresher(axiosInstance) {
+    axiosInstance.interceptors.response.use(
+      (response) => {
+        return response;
+      },
+      async (error) => {
+        const originalConfig = error.config;
+        if (error.response) {
+          if (error.response.status === 401 && !originalConfig._retry) {
+            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+            originalConfig._retry = true;
+
+            try {
+              // Get a refresh API key
+              const originalPartnerId = originalConfig.params.partner_id;
+              const originalPartnerApiKey = originalConfig.params.api_key;
+
+              const response = await axiosInstance.post(
+                `${this.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
+              );
+
+              firmCredentials.storePartnerApiKey(
+                originalPartnerId,
+                response.data.api_key
+              );
+
+              consola.debug("Refreshed partner api key");
+
+              // Set the new access token for current and future requests
+              axiosInstance.defaults.params.api_key = response.data.api_key;
+              originalConfig.params.api_key = response.data.api_key;
+
+              return axiosInstance(originalConfig);
+            } catch (_error) {
+              consola.error(
+                `Error 401: Failed to refresh the partner API key automatically, try to manually authorize the partner again with the authorize-partner command`
+              );
+
+              if (_error.response && _error.response.data) {
+                return Promise.reject(_error.response.data);
+              }
+
+              return Promise.reject(_error);
+            }
+          }
+        }
+
+        return Promise.reject(error);
+      }
+    );
+
+    return axiosInstance;
+  }
+
+  /**
+   * Check if current host is staging or not
+   * @returns {Boolean}
+   */
+  static #isStaging() {
+    return /staging\.getsilverfin/.test(this.BASE_URL);
+  }
+
+  static #basicAuthHeader() {
+    if (!process.env.SF_BASIC_AUTH) {
+      consola.error(`Missing environment variable: SF_BASIC_AUTH`);
+      process.exit(1);
+    }
+    return `Basic ${process.env.SF_BASIC_AUTH}`;
+  }
+
+  /**
+   * Get a new set of tokens for a given firm id
+   */
+  static async #refreshFirmTokens(axiosInstance, firmId) {
+    try {
+      consola.debug(`Refreshing tokens for firm ${firmId}`);
+      const firmTokens = firmCredentials.getTokenPair(firmId);
+      let data = {
+        client_id: process.env.SF_API_CLIENT_ID,
+        client_secret: process.env.SF_API_SECRET,
+        redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+        grant_type: "refresh_token",
+        refresh_token: firmTokens.refreshToken,
+        access_token: firmTokens.accessToken,
+      };
+      const response = await axiosInstance.post(
+        `${this.BASE_URL}/f/${firmId}/oauth/token`,
+        data
+      );
+
+      firmCredentials.storeNewTokenPair(firmId, response.data);
+      consola.debug(`Refreshed tokens for firm ${firmId}`);
+
+      return true;
+    } catch (error) {
+      // NOTE: Should we handle the error differently? No response
+      if (!error?.response) {
+        throw error;
+      }
+
+      const description =
+        error?.response?.data?.error_description || error?.request?.data;
+
+      consola.error(
+        `Response Status: ${error.response.status} (${error.response.statusText})`,
+        description ? `\nError description: ${description}` : "",
+        "\n",
+        `Error refreshing the tokens. Try running the authentication process again`
+      );
+      process.exit(1);
+    }
+  }
+}
+
+module.exports = { AxiosFactory };

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -15,11 +15,12 @@ const { consola } = require("consola");
 class FirmCredentials {
   #SF_FOLDER_PATH = path.resolve(homedir, ".silverfin/");
   #SF_CREDENTIALS_PATH = path.resolve(this.#SF_FOLDER_PATH, "config.json");
+  #SF_DEFAULT_HOST = "https://live.getsilverfin.com";
   constructor() {
     this.#createSilverfinDir();
     this.#createCredentialsFile();
     this.loadCredentials();
-    this.#checkDefaultFirmsObject();
+    this.#checkDefaultValues();
   }
 
   /** Read credentials from file. It will replace already loaded credendtials */
@@ -198,6 +199,26 @@ class FirmCredentials {
     return [];
   }
 
+  /**
+   * Store the host for the Silverfin environment
+   * @param {string} host - Host URL
+   */
+  setHost(host) {
+    this.data.host = host;
+    this.saveCredentials();
+  }
+
+  /**
+   * Get the host for the Silverfin environment
+   * The host can be set as an environmental variable `SF_HOST`, can be set using the `setHost` method
+   * or it will default to `https://live.getsilverfin.com`
+   * @returns {string} Host URL
+   */
+  getHost() {
+    const env_host = process.env.SF_HOST;
+    return env_host ? env_host : this.data.host;
+  }
+
   // PRIVATE METHODS
 
   /** Create `.silverfin` folder in home directory if it doesn't exist yet
@@ -214,17 +235,23 @@ class FirmCredentials {
    */
   #createCredentialsFile() {
     if (!fs.existsSync(this.#SF_CREDENTIALS_PATH)) {
-      this.data = { defaultFirmIDs: {} };
+      this.data = {
+        defaultFirmIDs: {},
+        host: this.#SF_DEFAULT_HOST,
+      };
       this.saveCredentials();
     }
   }
 
-  /** Create `DefaultFirmIDs` if missing (for legacy compatibility of existing files)
+  /** Create `DefaultFirmIDs` and `host` if missing (for legacy compatibility of existing files)
    * @private
    */
-  #checkDefaultFirmsObject() {
+  #checkDefaultValues() {
     if (!this.data.hasOwnProperty("defaultFirmIDs")) {
       this.data.defaultFirmIDs = {};
+    }
+    if (!this.data.hasOwnProperty("host")) {
+      this.data.host = this.#SF_DEFAULT_HOST;
     }
   }
 }

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -15,7 +15,7 @@ const { consola } = require("consola");
 class FirmCredentials {
   #SF_FOLDER_PATH = path.resolve(homedir, ".silverfin/");
   #SF_CREDENTIALS_PATH = path.resolve(this.#SF_FOLDER_PATH, "config.json");
-  #SF_DEFAULT_HOST = "https://live.getsilverfin.com";
+  SF_DEFAULT_HOST = "https://live.getsilverfin.com";
   constructor() {
     this.#createSilverfinDir();
     this.#createCredentialsFile();
@@ -237,7 +237,7 @@ class FirmCredentials {
     if (!fs.existsSync(this.#SF_CREDENTIALS_PATH)) {
       this.data = {
         defaultFirmIDs: {},
-        host: this.#SF_DEFAULT_HOST,
+        host: this.SF_DEFAULT_HOST,
       };
       this.saveCredentials();
     }
@@ -251,7 +251,7 @@ class FirmCredentials {
       this.data.defaultFirmIDs = {};
     }
     if (!this.data.hasOwnProperty("host")) {
-      this.data.host = this.#SF_DEFAULT_HOST;
+      this.data.host = this.SF_DEFAULT_HOST;
     }
   }
 }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -4,6 +4,7 @@ const prompt = require("prompt-sync")({ sigint: true });
 const apiUtils = require("../utils/apiUtils");
 const { consola } = require("consola");
 const { firmCredentials } = require("../api/firmCredentials");
+const { AxiosFactory } = require("./axiosFactory");
 
 apiUtils.checkRequiredEnvVariables();
 
@@ -34,7 +35,12 @@ async function authorizeApp(firmId = undefined) {
       echo: "*",
     });
     // Get tokens
-    const tokens = await apiUtils.getAccessToken(firmIdPrompt, authCodePrompt);
+    const instance = AxiosFactory.createInstance("firm", firmId);
+    const tokens = await apiUtils.getAccessToken(
+      instance,
+      firmIdPrompt,
+      authCodePrompt
+    );
     if (tokens) {
       consola.success("Authentication successful");
     }
@@ -46,34 +52,66 @@ async function authorizeApp(firmId = undefined) {
   }
 }
 
-async function refreshTokens(type, firmId) {
-  const instance = apiUtils.setAxiosDefaults(type, firmId);
-  await apiUtils.refreshTokens(instance, firmId);
+async function refreshFirmTokens(firmId) {
+  try {
+    const instance = AxiosFactory.createInstance("firm", firmId);
+    const firmTokens = firmCredentials.getTokenPair(firmId);
+    let data = {
+      client_id: process.env.SF_API_CLIENT_ID,
+      client_secret: process.env.SF_API_SECRET,
+      redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+      grant_type: "refresh_token",
+      refresh_token: firmTokens.refreshToken,
+      access_token: firmTokens.accessToken,
+    };
+    const response = await instance.post(
+      `${apiUtils.BASE_URL}/f/${firmId}/oauth/token`,
+      data
+    );
 
-  return true;
+    firmCredentials.storeNewTokenPair(firmId, response.data);
+    consola.info(`Refreshed tokens for firm ${firmId}`);
+  } catch (error) {
+    const description =
+      error?.response?.data?.error_description || error?.request?.data;
+
+    consola.error(
+      `Response Status: ${error.response.status} (${error.response.statusText})`,
+      description ? `\nError description: ${description}` : "",
+      "\n",
+      `Error refreshing the tokens. Try running the authentication process again`
+    );
+    process.exit(1);
+  }
 }
 
-async function refreshPartnerToken(partner_id) {
+async function refreshPartnerToken(partnerId) {
   try {
-    const partnerCredentials = apiUtils.checkAuthorizePartners(partner_id);
+    const partnerCredentials = apiUtils.checkAuthorizePartners(partnerId);
 
-    if (partnerCredentials) {
-      const response = await axios.post(
-        `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
+    if (!partnerCredentials) {
+      consola.error(
+        `Partner ${partnerId} is not authorized. Please authorize the partner first`
       );
-
-      firmCredentials.storePartnerApiKey(
-        partner_id,
-        response.data.api_key,
-        partnerCredentials?.name
-      );
-
-      return {
-        partner_id,
-        partnerName: partnerCredentials?.name,
-        token: response.data.api_key,
-      };
+      process.exit(1);
     }
+
+    const instance = AxiosFactory.createInstance("partner", partnerId);
+    const response = await instance.post(
+      `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
+    );
+
+    firmCredentials.storePartnerApiKey(
+      partnerId,
+      response.data.api_key,
+      partnerCredentials?.name
+    );
+
+    return {
+      partner_id: partnerId,
+      partnerName: partnerCredentials?.name,
+      token: response.data.api_key,
+    };
   } catch (error) {
     consola.error(
       `Response Status: ${error.response.status} (${error.response.statusText})`
@@ -85,7 +123,7 @@ async function refreshPartnerToken(partner_id) {
 }
 
 async function createReconciliationText(type, envId, attributes) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(`reconciliations`, attributes);
     apiUtils.responseSuccessHandler(response);
@@ -97,7 +135,7 @@ async function createReconciliationText(type, envId, attributes) {
 }
 
 async function readReconciliationTexts(type, envId, page = 1) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`reconciliations`, {
       params: { page: page, per_page: 200 },
@@ -111,7 +149,7 @@ async function readReconciliationTexts(type, envId, page = 1) {
 }
 
 async function readReconciliationTextById(type, envId, id) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
 
   try {
     const response = await instance.get(`reconciliations/${id}`);
@@ -166,7 +204,7 @@ async function updateReconciliationText(
   reconciliationId,
   attributes
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `reconciliations/${reconciliationId}`,
@@ -187,7 +225,7 @@ async function readReconciliationTextDetails(
   periodId,
   reconciliationId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}`
@@ -208,7 +246,7 @@ async function getReconciliationCustom(
   reconciliationId,
   page = 1
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`,
@@ -229,7 +267,7 @@ async function getReconciliationResults(
   periodId,
   reconciliationId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/results`
@@ -243,7 +281,7 @@ async function getReconciliationResults(
 }
 
 async function readSharedParts(type, envId, page = 1) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`shared_parts`, {
       params: { page: page, per_page: 200 },
@@ -257,7 +295,7 @@ async function readSharedParts(type, envId, page = 1) {
 }
 
 async function readSharedPartById(type, envId, sharedPartId) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
@@ -286,7 +324,7 @@ async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
 }
 
 async function updateSharedPart(type, envId, sharedPartId, attributes) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `shared_parts/${sharedPartId}`,
@@ -301,7 +339,7 @@ async function updateSharedPart(type, envId, sharedPartId, attributes) {
 }
 
 async function createSharedPart(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.post(`shared_parts`, attributes);
     apiUtils.responseSuccessHandler(response);
@@ -318,7 +356,7 @@ async function addSharedPartToReconciliation(
   sharedPartId,
   reconciliationId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
@@ -337,7 +375,7 @@ async function removeSharedPartFromReconciliation(
   sharedPartId,
   reconciliationId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.delete(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
@@ -351,7 +389,7 @@ async function removeSharedPartFromReconciliation(
 }
 
 async function createExportFile(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.post(`export_files`, attributes);
     apiUtils.responseSuccessHandler(response);
@@ -363,7 +401,7 @@ async function createExportFile(firmId, attributes) {
 }
 
 async function updateExportFile(type, envId, exportFileId, attributes) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `export_files/${exportFileId}`,
@@ -378,7 +416,7 @@ async function updateExportFile(type, envId, exportFileId, attributes) {
 }
 
 async function readExportFiles(type, envId, page = 1) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`export_files`, {
       params: { page: page, per_page: 200 },
@@ -392,7 +430,7 @@ async function readExportFiles(type, envId, page = 1) {
 }
 
 async function readExportFileById(type, envId, exportFileId) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`export_files/${exportFileId}`);
     apiUtils.responseSuccessHandler(response);
@@ -425,7 +463,7 @@ async function addSharedPartToExportFile(
   sharedPartId,
   exportFileId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `export_files/${exportFileId}/shared_parts/${sharedPartId}`
@@ -444,7 +482,7 @@ async function removeSharedPartFromExportFile(
   sharedPartId,
   exportFileId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.delete(
       `export_files/${exportFileId}/shared_parts/${sharedPartId}`
@@ -458,7 +496,7 @@ async function removeSharedPartFromExportFile(
 }
 
 async function createAccountTemplate(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.post(`account_templates`, attributes);
     apiUtils.responseSuccessHandler(response);
@@ -475,7 +513,7 @@ async function updateAccountTemplate(
   accountTemplateId,
   attributes
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `account_templates/${accountTemplateId}`,
@@ -490,7 +528,7 @@ async function updateAccountTemplate(
 }
 
 async function readAccountTemplates(type, envId, page = 1) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`account_templates`, {
       params: { page: page, per_page: 200 },
@@ -504,7 +542,7 @@ async function readAccountTemplates(type, envId, page = 1) {
 }
 
 async function readAccountTemplateById(type, envId, accountTemplateId) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(
       `account_templates/${accountTemplateId}`
@@ -549,7 +587,7 @@ async function addSharedPartToAccountTemplate(
   sharedPartId,
   accountTemplateId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.post(
       `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
@@ -568,7 +606,7 @@ async function removeSharedPartFromAccountTemplate(
   sharedPartId,
   accountTemplateId
 ) {
-  const instance = apiUtils.setAxiosDefaults(type, envId);
+  const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.delete(
       `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
@@ -582,7 +620,7 @@ async function removeSharedPartFromAccountTemplate(
 }
 
 async function createTestRun(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.post("reconciliations/test", attributes);
     return response;
@@ -593,7 +631,7 @@ async function createTestRun(firmId, attributes) {
 }
 
 async function createPreviewRun(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.post("reconciliations/render", attributes);
     return response;
@@ -604,7 +642,7 @@ async function createPreviewRun(firmId, attributes) {
 }
 
 async function readTestRun(firmId, testId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`reconciliations/test_runs/${testId}`);
     return response;
@@ -615,7 +653,7 @@ async function readTestRun(firmId, testId) {
 }
 
 async function getPeriods(firmId, companyId, page = 1) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`/companies/${companyId}/periods`, {
       params: { page: page, per_page: 200 },
@@ -633,7 +671,7 @@ function findPeriod(periodId, periodsArray) {
 }
 
 async function getCompanyDrop(firmId, companyId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`/companies/${companyId}`);
     apiUtils.responseSuccessHandler(response);
@@ -645,7 +683,7 @@ async function getCompanyDrop(firmId, companyId) {
 }
 
 async function getCompanyCustom(firmId, companyId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`/companies/${companyId}/custom`);
     apiUtils.responseSuccessHandler(response);
@@ -657,7 +695,7 @@ async function getCompanyCustom(firmId, companyId) {
 }
 
 async function getWorkflows(firmId, companyId, periodId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/workflows`
@@ -677,7 +715,7 @@ async function getWorkflowInformation(
   workflowId,
   page = 1
 ) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(
       `/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`,
@@ -760,7 +798,7 @@ async function findReconciliationInWorkflows(
 }
 
 async function getAccountDetails(firmId, companyId, periodId, accountId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(
       `companies/${companyId}/periods/${periodId}/accounts/${accountId}`
@@ -776,7 +814,7 @@ async function getAccountDetails(firmId, companyId, periodId, accountId) {
 // Liquid Linter
 // attributes should be JSON
 async function verifyLiquid(firmId, attributes) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const config = { headers: { "Content-Type": "application/json" } };
     const response = await instance.post(
@@ -792,7 +830,7 @@ async function verifyLiquid(firmId, attributes) {
 }
 
 async function getFirmDetails(firmId) {
-  const instance = apiUtils.setAxiosDefaults("firm", firmId);
+  const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`/user/firm`);
     apiUtils.responseSuccessHandler(response);
@@ -805,7 +843,7 @@ async function getFirmDetails(firmId) {
 
 module.exports = {
   authorizeApp,
-  refreshTokens,
+  refreshFirmTokens,
   refreshPartnerToken,
   createReconciliationText,
   readReconciliationTexts,

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -148,8 +148,7 @@ function runCommandChecks(
         `The option "--partner" is not supported when using "--export-file"`
       );
       process.exit(1);
-    }
-    else if (messageRequired && !options.message) {
+    } else if (messageRequired && !options.message) {
       consola.error(
         `Message required when updating a partner template. Please use "--message"`
       );
@@ -176,6 +175,22 @@ function runCommandChecks(
   return settings;
 }
 
+function logCurrentEnvironments() {
+  const currentFirmId = loadDefaultFirmId();
+  const currentFirmName = firmCredentials.getFirmName(currentFirmId);
+  const firmDetails = currentFirmId
+    ? `Current firm: ${currentFirmId} ${currentFirmName ? "(" + currentFirmName + ")" : ""}.`
+    : "";
+
+  const currentHost = firmCredentials.getHost();
+  const hostDetails =
+    currentHost === firmCredentials.SF_DEFAULT_HOST
+      ? ""
+      : `Current host: ${currentHost}.`;
+
+  consola.info(`${firmDetails} ${hostDetails}`);
+}
+
 module.exports = {
   loadDefaultFirmId,
   checkDefaultFirm,
@@ -186,4 +201,5 @@ module.exports = {
   checkRequiredFirmOrPartner,
   getCommandSettings,
   runCommandChecks,
+  logCurrentEnvironments,
 };

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -35,6 +35,11 @@ async function getAccessToken(firmId, authCode) {
       method: "POST",
       url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
     };
+    if (isStaging()) {
+      requestDetails.headers = {
+        Authorization: basicAuthHeader(),
+      };
+    }
     const response = await axios(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);
     await getFirmName(firmId);
@@ -55,7 +60,7 @@ async function getAccessToken(firmId, authCode) {
 // Get a new pair of tokens
 async function refreshTokens(instance, firmId) {
   try {
-    consola.debug(`refreshing tokens for firm ${firmId}`);
+    consola.debug(`Refreshing tokens for firm ${firmId}`);
     const firmTokens = firmCredentials.getTokenPair(firmId);
     let data = {
       client_id: process.env.SF_API_CLIENT_ID,
@@ -111,14 +116,29 @@ function createAxiosInstanceForFirms(envId) {
     process.exit(1);
   }
 
-  let axiosInstance = axios.create({
-    baseURL: `${BASE_URL}/api/v4/f/${envId}`,
-    headers: {
-      "User-Agent": `silverfin-cli/${pkg.version}`,
-      Authorization: `Bearer ${firmTokens.accessToken}`,
-    },
-  });
+  let axiosDetails;
+  if (isStaging()) {
+    axiosDetails = {
+      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
+      headers: {
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+        Authorization: basicAuthHeader(),
+      },
+      params: {
+        access_token: firmTokens.accessToken,
+      },
+    };
+  } else {
+    axiosDetails = {
+      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
+      headers: {
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+        Authorization: `Bearer ${firmTokens.accessToken}`,
+      },
+    };
+  }
 
+  let axiosInstance = axios.create(axiosDetails);
   axiosInstance = addFirmTokenRefresher(axiosInstance);
 
   return axiosInstance;
@@ -142,14 +162,24 @@ function addFirmTokenRefresher(axiosInstance) {
             const firmId = originalConfig.baseURL.split("/").pop();
             await refreshTokens(axiosInstance, firmId);
 
-            // Set the Authorization header with the new access token
             const firmTokens = firmCredentials.getTokenPair(firmId);
-            consola.debug(`refreshed tokens for firm ${firmId}`);
+            consola.debug(`Refreshed tokens for firm ${firmId}`);
 
-            axiosInstance.defaults.headers.common["Authorization"] =
-              `Bearer ${firmTokens.accessToken}`;
-
-            originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+            // Set the Authorization header with the new access token
+            if (isStaging()) {
+              axiosInstance.defaults.params = {
+                ...axiosInstance.defaults.params,
+                access_token: firmTokens.accessToken,
+              };
+              originalConfig.params = {
+                ...originalConfig.params,
+                access_token: firmTokens.accessToken,
+              };
+            } else {
+              axiosInstance.defaults.headers.common["Authorization"] =
+                `Bearer ${firmTokens.accessToken}`;
+              originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+            }
 
             return axiosInstance(originalConfig);
           } catch (_error) {
@@ -174,12 +204,16 @@ function addFirmTokenRefresher(axiosInstance) {
 }
 
 function createAxiosInstanceForPartners(envId) {
-  let axiosInstance = axios.create({
+  let axiosDetails = {
     baseURL: `${BASE_URL}/api/partner/v1`,
     headers: {
       "User-Agent": `silverfin-cli/${pkg.version}`,
     },
-  });
+  };
+  if (isStaging()) {
+    axiosDetails.headers.Authorization = basicAuthHeader();
+  }
+  let axiosInstance = axios.create(axiosDetails);
 
   // Add a request interceptor to add the partner api key and id to every request
   axiosInstance.interceptors.request.use((config) => {
@@ -321,6 +355,22 @@ async function getFirmName(firmId) {
       firmCredentials.storeFirmName(firmId, response.data.name);
     }
   } catch (error) {}
+}
+
+/**
+ * Check if current host is staging or not
+ * @returns {Boolean}
+ */
+function isStaging() {
+  return /staging\.getsilverfin/.test(BASE_URL);
+}
+
+function basicAuthHeader() {
+  if (!process.env.SF_BASIC_AUTH) {
+    consola.error(`Missing environment variable: SF_BASIC_AUTH`);
+    process.exit(1);
+  }
+  return `Basic ${process.env.SF_BASIC_AUTH}`;
 }
 
 module.exports = {

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -96,135 +96,158 @@ function setAxiosDefaults(type, envId) {
   let axiosInstance;
 
   if (type == "firm") {
-    const firmTokens = firmCredentials.getTokenPair(envId);
-    if (!firmTokens) {
-      consola.error(`Missing authorization for firm id: ${envId}`);
-      process.exit(1);
-    }
-
-    axiosInstance = axios.create({
-      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
-      headers: {
-        "User-Agent": `silverfin-cli/${pkg.version}`,
-        Authorization: `Bearer ${firmTokens.accessToken}`,
-      },
-    });
-
-    // Add a response interceptor to refresh the access token if it's expired
-    axiosInstance.interceptors.response.use(
-      (res) => {
-        return res;
-      },
-      async (error) => {
-        const originalConfig = error.config;
-        if (error.response) {
-          if (error.response.status === 401 && !originalConfig._retry) {
-            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-            originalConfig._retry = true;
-
-            try {
-              // Get a refreshed set of tokens
-              const firmId = originalConfig.baseURL.split("/").pop();
-              await refreshTokens(axiosInstance, firmId);
-
-              // Set the Authorization header with the new access token
-              const firmTokens = firmCredentials.getTokenPair(firmId);
-              consola.debug(`refreshed tokens for firm ${firmId}`);
-
-              axiosInstance.defaults.headers.common[
-                "Authorization"
-              ] = `Bearer ${firmTokens.accessToken}`;
-
-              originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
-
-              return axiosInstance(originalConfig);
-            } catch (_error) {
-              consola.error(
-                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
-              );
-
-              if (_error.response && _error.response.data) {
-                return Promise.reject(_error.response.data);
-              }
-
-              return Promise.reject(_error);
-            }
-          }
-        }
-
-        return Promise.reject(error);
-      }
-    );
+    axiosInstance = createAxiosInstanceForFirms(envId);
   } else if (type == "partner") {
-    axiosInstance = axios.create({
-      baseURL: `${BASE_URL}/api/partner/v1`,
-      headers: {
-        "User-Agent": `silverfin-cli/${pkg.version}`,
-      },
-    });
+    axiosInstance = createAxiosInstanceForPartners(envId);
+  }
 
-    // Add a request interceptor to add the partner api key and id to every request
-    axiosInstance.interceptors.request.use((config) => {
-      // Fetch the stored partner api key
-      const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
+  return axiosInstance;
+}
 
-      // Set the partner api key and id as a query param to every request
-      config.params = {
-        ...config.params,
-        partner_id: envId,
-        api_key: partnerToken,
-      };
+function createAxiosInstanceForFirms(envId) {
+  const firmTokens = firmCredentials.getTokenPair(envId);
+  if (!firmTokens) {
+    consola.error(`Missing authorization for firm id: ${envId}`);
+    process.exit(1);
+  }
 
-      return config;
-    });
+  let axiosInstance = axios.create({
+    baseURL: `${BASE_URL}/api/v4/f/${envId}`,
+    headers: {
+      "User-Agent": `silverfin-cli/${pkg.version}`,
+      Authorization: `Bearer ${firmTokens.accessToken}`,
+    },
+  });
 
-    // Add a response interceptor to refresh the partner api key if it's expired
-    axiosInstance.interceptors.response.use(
-      (res) => {
-        return res;
-      },
-      async (error) => {
-        const originalConfig = error.config;
-        if (error.response) {
-          if (error.response.status === 401 && !originalConfig._retry) {
-            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-            originalConfig._retry = true;
+  axiosInstance = addFirmTokenRefresher(axiosInstance);
 
-            try {
-              // Get a refresh API key
-              const originalPartnerId = originalConfig.params.partner_id;
-              const originalPartnerApiKey = originalConfig.params.api_key;
+  return axiosInstance;
+}
 
-              const response = await axios.post(
-                `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
-              );
+// Add a response interceptor to refresh the access token if it's expired
+function addFirmTokenRefresher(axiosInstance) {
+  axiosInstance.interceptors.response.use(
+    (res) => {
+      return res;
+    },
+    async (error) => {
+      const originalConfig = error.config;
+      if (error.response) {
+        if (error.response.status === 401 && !originalConfig._retry) {
+          // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+          originalConfig._retry = true;
 
-              firmCredentials.storePartnerApiKey(
-                originalPartnerId,
-                response.data.api_key
-              );
+          try {
+            // Get a refreshed set of tokens
+            const firmId = originalConfig.baseURL.split("/").pop();
+            await refreshTokens(axiosInstance, firmId);
 
-              consola.debug("refreshed partner api key");
+            // Set the Authorization header with the new access token
+            const firmTokens = firmCredentials.getTokenPair(firmId);
+            consola.debug(`refreshed tokens for firm ${firmId}`);
 
-              return axiosInstance(originalConfig);
-            } catch (_error) {
-              consola.error(
-                `Error 401: Failed to refresh the partner api key automatically, try to manually authorize the partner again with the authorize-partner command`
-              );
+            axiosInstance.defaults.headers.common["Authorization"] =
+              `Bearer ${firmTokens.accessToken}`;
 
-              if (_error.response && _error.response.data) {
-                return Promise.reject(_error.response.data);
-              }
+            originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
 
-              return Promise.reject(_error);
+            return axiosInstance(originalConfig);
+          } catch (_error) {
+            consola.error(
+              `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
+            );
+
+            if (_error.response && _error.response.data) {
+              return Promise.reject(_error.response.data);
             }
+
+            return Promise.reject(_error);
           }
         }
-
-        return Promise.reject(error);
       }
-    );
-  }
+
+      return Promise.reject(error);
+    }
+  );
+
+  return axiosInstance;
+}
+
+function createAxiosInstanceForPartners(envId) {
+  let axiosInstance = axios.create({
+    baseURL: `${BASE_URL}/api/partner/v1`,
+    headers: {
+      "User-Agent": `silverfin-cli/${pkg.version}`,
+    },
+  });
+
+  // Add a request interceptor to add the partner api key and id to every request
+  axiosInstance.interceptors.request.use((config) => {
+    // Fetch the stored partner api key
+    const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
+
+    // Set the partner api key and id as a query param to every request
+    config.params = {
+      ...config.params,
+      partner_id: envId,
+      api_key: partnerToken,
+    };
+
+    return config;
+  });
+
+  axiosInstance = addPartnerTokenRefresher(axiosInstance);
+
+  return axiosInstance;
+}
+
+// Add a response interceptor to refresh the partner token if it's expired
+function addPartnerTokenRefresher(axiosInstance) {
+  axiosInstance.interceptors.response.use(
+    (res) => {
+      return res;
+    },
+    async (error) => {
+      const originalConfig = error.config;
+      if (error.response) {
+        if (error.response.status === 401 && !originalConfig._retry) {
+          // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+          originalConfig._retry = true;
+
+          try {
+            // Get a refresh API key
+            const originalPartnerId = originalConfig.params.partner_id;
+            const originalPartnerApiKey = originalConfig.params.api_key;
+
+            const response = await axios.post(
+              `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
+            );
+
+            firmCredentials.storePartnerApiKey(
+              originalPartnerId,
+              response.data.api_key
+            );
+
+            consola.debug("Refreshed partner api key");
+
+            return axiosInstance(originalConfig);
+          } catch (_error) {
+            consola.error(
+              `Error 401: Failed to refresh the partner api key automatically, try to manually authorize the partner again with the authorize-partner command`
+            );
+
+            if (_error.response && _error.response.data) {
+              return Promise.reject(_error.response.data);
+            }
+
+            return Promise.reject(_error);
+          }
+        }
+      }
+
+      return Promise.reject(error);
+    }
+  );
 
   return axiosInstance;
 }

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -3,7 +3,7 @@ const pkg = require("../../package.json");
 const axios = require("axios");
 const { consola } = require("consola");
 
-const BASE_URL = process.env.SF_HOST || "https://live.getsilverfin.com";
+const BASE_URL = firmCredentials.getHost();
 
 function checkAuthorizePartners(partner_id) {
   const partnerCredentials = firmCredentials.getPartnerCredentials(partner_id);

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -1,5 +1,4 @@
 const { firmCredentials } = require("../api/firmCredentials");
-const pkg = require("../../package.json");
 const axios = require("axios");
 const { consola } = require("consola");
 
@@ -26,8 +25,8 @@ function checkRequiredEnvVariables() {
   }
 }
 
-// Get Tokens for the first time
-async function getAccessToken(firmId, authCode) {
+// Get Tokens for the first time with an authorization code
+async function getAccessToken(axiosInstance, firmId, authCode) {
   try {
     const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
     const grantType = "authorization_code";
@@ -35,12 +34,7 @@ async function getAccessToken(firmId, authCode) {
       method: "POST",
       url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
     };
-    if (isStaging()) {
-      requestDetails.headers = {
-        Authorization: basicAuthHeader(),
-      };
-    }
-    const response = await axios(requestDetails);
+    const response = await axiosInstance(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);
     await getFirmName(firmId);
     return true;
@@ -55,235 +49,6 @@ async function getAccessToken(firmId, authCode) {
     );
     process.exit(1);
   }
-}
-
-// Get a new pair of tokens
-async function refreshTokens(instance, firmId) {
-  try {
-    consola.debug(`Refreshing tokens for firm ${firmId}`);
-    const firmTokens = firmCredentials.getTokenPair(firmId);
-    let data = {
-      client_id: process.env.SF_API_CLIENT_ID,
-      client_secret: process.env.SF_API_SECRET,
-      redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
-      grant_type: "refresh_token",
-      refresh_token: firmTokens.refreshToken,
-      access_token: firmTokens.accessToken,
-    };
-    const response = await instance.post(
-      `${BASE_URL}/f/${firmId}/oauth/token`,
-      data
-    );
-    firmCredentials.storeNewTokenPair(firmId, response.data);
-    // firm name
-    const firmName = firmCredentials.getFirmName(firmId);
-
-    if (!firmName) {
-      await getFirmName(firmId);
-    }
-
-    return true;
-  } catch (error) {
-    const description =
-      error?.response?.data?.error_description || error?.request?.data;
-
-    consola.error(
-      `Response Status: ${error.response.status} (${error.response.statusText})`,
-      description ? `\nError description: ${description}` : "",
-      "\n",
-      `Error refreshing the tokens. Try running the authentication process again`
-    );
-    process.exit(1);
-  }
-}
-
-function setAxiosDefaults(type, envId) {
-  let axiosInstance;
-
-  if (type == "firm") {
-    axiosInstance = createAxiosInstanceForFirms(envId);
-  } else if (type == "partner") {
-    axiosInstance = createAxiosInstanceForPartners(envId);
-  }
-
-  return axiosInstance;
-}
-
-function createAxiosInstanceForFirms(envId) {
-  const firmTokens = firmCredentials.getTokenPair(envId);
-  if (!firmTokens) {
-    consola.error(`Missing authorization for firm id: ${envId}`);
-    process.exit(1);
-  }
-
-  let axiosDetails;
-  if (isStaging()) {
-    axiosDetails = {
-      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
-      headers: {
-        "User-Agent": `silverfin-cli/${pkg.version}`,
-        Authorization: basicAuthHeader(),
-      },
-      params: {
-        access_token: firmTokens.accessToken,
-      },
-    };
-  } else {
-    axiosDetails = {
-      baseURL: `${BASE_URL}/api/v4/f/${envId}`,
-      headers: {
-        "User-Agent": `silverfin-cli/${pkg.version}`,
-        Authorization: `Bearer ${firmTokens.accessToken}`,
-      },
-    };
-  }
-
-  let axiosInstance = axios.create(axiosDetails);
-  axiosInstance = addFirmTokenRefresher(axiosInstance);
-
-  return axiosInstance;
-}
-
-// Add a response interceptor to refresh the access token if it's expired
-function addFirmTokenRefresher(axiosInstance) {
-  axiosInstance.interceptors.response.use(
-    (res) => {
-      return res;
-    },
-    async (error) => {
-      const originalConfig = error.config;
-      if (error.response) {
-        if (error.response.status === 401 && !originalConfig._retry) {
-          // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-          originalConfig._retry = true;
-
-          try {
-            // Get a refreshed set of tokens
-            const firmId = originalConfig.baseURL.split("/").pop();
-            await refreshTokens(axiosInstance, firmId);
-
-            const firmTokens = firmCredentials.getTokenPair(firmId);
-            consola.debug(`Refreshed tokens for firm ${firmId}`);
-
-            // Set the Authorization header with the new access token
-            if (isStaging()) {
-              axiosInstance.defaults.params = {
-                ...axiosInstance.defaults.params,
-                access_token: firmTokens.accessToken,
-              };
-              originalConfig.params = {
-                ...originalConfig.params,
-                access_token: firmTokens.accessToken,
-              };
-            } else {
-              axiosInstance.defaults.headers.common["Authorization"] =
-                `Bearer ${firmTokens.accessToken}`;
-              originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
-            }
-
-            return axiosInstance(originalConfig);
-          } catch (_error) {
-            consola.error(
-              `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
-            );
-
-            if (_error.response && _error.response.data) {
-              return Promise.reject(_error.response.data);
-            }
-
-            return Promise.reject(_error);
-          }
-        }
-      }
-
-      return Promise.reject(error);
-    }
-  );
-
-  return axiosInstance;
-}
-
-function createAxiosInstanceForPartners(envId) {
-  let axiosDetails = {
-    baseURL: `${BASE_URL}/api/partner/v1`,
-    headers: {
-      "User-Agent": `silverfin-cli/${pkg.version}`,
-    },
-  };
-  if (isStaging()) {
-    axiosDetails.headers.Authorization = basicAuthHeader();
-  }
-  let axiosInstance = axios.create(axiosDetails);
-
-  // Add a request interceptor to add the partner api key and id to every request
-  axiosInstance.interceptors.request.use((config) => {
-    // Fetch the stored partner api key
-    const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
-
-    // Set the partner api key and id as a query param to every request
-    config.params = {
-      ...config.params,
-      partner_id: envId,
-      api_key: partnerToken,
-    };
-
-    return config;
-  });
-
-  axiosInstance = addPartnerTokenRefresher(axiosInstance);
-
-  return axiosInstance;
-}
-
-// Add a response interceptor to refresh the partner token if it's expired
-function addPartnerTokenRefresher(axiosInstance) {
-  axiosInstance.interceptors.response.use(
-    (res) => {
-      return res;
-    },
-    async (error) => {
-      const originalConfig = error.config;
-      if (error.response) {
-        if (error.response.status === 401 && !originalConfig._retry) {
-          // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-          originalConfig._retry = true;
-
-          try {
-            // Get a refresh API key
-            const originalPartnerId = originalConfig.params.partner_id;
-            const originalPartnerApiKey = originalConfig.params.api_key;
-
-            const response = await axios.post(
-              `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
-            );
-
-            firmCredentials.storePartnerApiKey(
-              originalPartnerId,
-              response.data.api_key
-            );
-
-            consola.debug("Refreshed partner api key");
-
-            return axiosInstance(originalConfig);
-          } catch (_error) {
-            consola.error(
-              `Error 401: Failed to refresh the partner api key automatically, try to manually authorize the partner again with the authorize-partner command`
-            );
-
-            if (_error.response && _error.response.data) {
-              return Promise.reject(_error.response.data);
-            }
-
-            return Promise.reject(_error);
-          }
-        }
-      }
-
-      return Promise.reject(error);
-    }
-  );
-
-  return axiosInstance;
 }
 
 function responseSuccessHandler(response) {
@@ -348,7 +113,6 @@ async function responseErrorHandler(error) {
  * @param {Number} firmId
  */
 async function getFirmName(firmId) {
-  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/user/firm`);
     if (response && response.data) {
@@ -357,30 +121,12 @@ async function getFirmName(firmId) {
   } catch (error) {}
 }
 
-/**
- * Check if current host is staging or not
- * @returns {Boolean}
- */
-function isStaging() {
-  return /staging\.getsilverfin/.test(BASE_URL);
-}
-
-function basicAuthHeader() {
-  if (!process.env.SF_BASIC_AUTH) {
-    consola.error(`Missing environment variable: SF_BASIC_AUTH`);
-    process.exit(1);
-  }
-  return `Basic ${process.env.SF_BASIC_AUTH}`;
-}
-
 module.exports = {
   BASE_URL,
   checkRequiredEnvVariables,
   getAccessToken,
-  setAxiosDefaults,
   responseSuccessHandler,
   responseErrorHandler,
-  refreshTokens,
   getFirmName,
   checkAuthorizePartners,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.3",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.27.3",
+      "version": "1.28.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -24,6 +24,7 @@
         "silverfin": "bin/cli.js"
       },
       "devDependencies": {
+        "axios-mock-adapter": "^2.1.0",
         "eslint": "^8.21.0",
         "jest": "^29.7.0"
       }
@@ -1462,6 +1463,19 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2689,6 +2703,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "yaml": "^2.2.1"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "^8.21.0",
     "jest": "^29.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.4",
+  "version": "1.28.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -1,0 +1,473 @@
+const { consola } = require("consola");
+const axios = require("axios");
+const { firmCredentials } = require("../../../lib/api/firmCredentials");
+const { AxiosFactory } = require("../../../lib/api/axiosFactory");
+const AxiosMockAdapter = require("axios-mock-adapter");
+
+jest.mock("consola");
+jest.mock("../../../lib/api/firmCredentials", () => ({
+  firmCredentials: {
+    getHost: jest.fn(),
+    getTokenPair: jest.fn(),
+    storeNewTokenPair: jest.fn(),
+    getPartnerCredentials: jest.fn(),
+    storePartnerApiKey: jest.fn(),
+  },
+}));
+jest.spyOn(axios, "create");
+axios.get = jest.fn();
+axios.post = jest.fn();
+
+describe("AxiosFactory", () => {
+  let axiosMockAdapter;
+  let exitSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    process.env.SF_BASIC_AUTH = "test_basic_auth";
+    process.env.SF_API_CLIENT_ID = "test_client_id";
+    process.env.SF_API_SECRET = "test_client_secret";
+    exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Process.exit called with code ${code}`);
+    });
+
+    axiosMockAdapter = new AxiosMockAdapter(axios);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+
+    axiosMockAdapter.restore();
+  });
+
+  describe("Create instance", () => {
+    it("should throw an error for invalid type", () => {
+      const mockHost = "https://test-api.com";
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      const mockTokenPair = {
+        accessToken: "stored-access",
+        refreshToken: "stored-refresh",
+      };
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      expect(() => {
+        AxiosFactory.createInstance("invalid", 123);
+      }).toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("Firm instance", () => {
+    const firmId = 50000;
+    const mockHost = "https://test-api.com";
+    const mockTokenPair = {
+      accessToken: "stored-access",
+      refreshToken: "stored-refresh",
+    };
+
+    it("should create a firm instance", () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const instance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(instance).toBeDefined();
+      expect(instance.defaults.baseURL).toBe(
+        `https://test-api.com/api/v4/f/50000`
+      );
+      expect(instance.defaults.headers.Authorization).toBe(
+        "Bearer stored-access"
+      );
+    });
+
+    it("should thrown an error for missing tokens", () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(null);
+
+      expect(() => {
+        AxiosFactory.createInstance("firm", firmId);
+      }).toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should refresh tokens on 401 unauthorized error", async () => {
+      const newTokenPair = {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+      };
+      const newTokenPairResponse = {
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+      };
+
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValueOnce(mockTokenPair); // original request
+      firmCredentials.getTokenPair.mockReturnValueOnce(mockTokenPair); // refresh tokens
+      firmCredentials.getTokenPair.mockReturnValueOnce(newTokenPair); // retry request
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply((config) => {
+        const token = config.headers.Authorization.split(" ")[1];
+
+        if (token === "stored-access") {
+          return [401, "Unauthorized"];
+        } else if (token === "new-access") {
+          return [200, "Success"];
+        } else {
+          throw new Error("Unexpected token");
+        }
+      });
+
+      axiosMockAdapter
+        .onPost(`${mockHost}/f/${firmId}/oauth/token`)
+        .reply(200, newTokenPairResponse);
+      jest.spyOn(axiosInstance, "post");
+
+      const response = await axiosInstance.get("/test-endpoint");
+
+      expect(axiosInstance.post).toHaveBeenCalledTimes(1); // Once to refresh
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+        String(firmId),
+        newTokenPairResponse
+      );
+      expect(response.data).toBe("Success");
+    });
+
+    it("should attempt to refresh tokens only once", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+      axiosMockAdapter
+        .onPost(`${mockHost}/f/${firmId}/oauth/token`)
+        .reply(200, {});
+      jest.spyOn(axiosInstance, "post");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledTimes(1);
+        expect(axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(error.response.status).toBe(401);
+      }
+    });
+
+    it("should show an error message if token refresh fails", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+      axiosMockAdapter
+        .onPost(`${mockHost}/f/${firmId}/oauth/token`)
+        .reply(400, "Bad request");
+      jest.spyOn(axiosInstance, "post");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+        expect(axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(consola.error).toHaveBeenCalledWith(
+          "Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command"
+        );
+      }
+    });
+
+    it("should not attept to refresh tokens on non-401 unauthorized error", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      jest.spyOn(axiosInstance, "get");
+      axiosInstance.post = jest.fn();
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(404, "Not found");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(axiosInstance.get).toHaveBeenCalled();
+        expect(axiosInstance.post).not.toHaveBeenCalled();
+        expect(error.response.status).toBe(404);
+      }
+    });
+
+    it("should raise the error again if there is no response", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").networkError();
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(error.message).toBe("Network Error");
+      }
+    });
+  });
+
+  describe("Partner instance", () => {
+    const mockHost = "https://test-api.com";
+    const partnerId = 100;
+    const mockPartnerTokens = {
+      token: "stored-api-key",
+    };
+
+    it("should create a partner instance", () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axiosInstance.defaults.baseURL).toBe(
+        `https://test-api.com/api/partner/v1`
+      );
+      expect(axiosInstance.defaults.headers.Authorization).toBeUndefined();
+    });
+
+    it("should add partner_id and api_key to requests params", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      axiosMockAdapter.onGet("/test-endpoint").reply((config) => {
+        expect(config.params).toHaveProperty("api_key", "stored-api-key");
+        expect(config.params).toHaveProperty("partner_id", partnerId);
+
+        return [200, "Success"];
+      });
+      jest.spyOn(axiosInstance, "get");
+
+      const response = await axiosInstance.get("/test-endpoint");
+
+      expect(response.data).toBe("Success");
+    });
+
+    it("should refresh API key on 401 Unauthorized error", async () => {
+      const newApiKey = "new-api-key";
+
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValueOnce(
+        mockPartnerTokens
+      ); // original request
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply((config) => {
+        const token = config.params.api_key;
+
+        if (token === "stored-api-key") {
+          return [401, "Unauthorized"];
+        } else if (token === "new-api-key") {
+          return [200, "Success"];
+        } else {
+          throw new Error("Unexpected token");
+        }
+      });
+
+      axiosMockAdapter
+        .onPost(
+          `${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`
+        )
+        .reply(200, { api_key: newApiKey });
+      jest.spyOn(axiosInstance, "post");
+
+      const response = await axiosInstance.get("/test-endpoint");
+
+      expect(axiosInstance.post).toHaveBeenCalledTimes(1); // Once to refresh
+      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(
+        partnerId,
+        newApiKey
+      );
+      expect(response.data).toBe("Success");
+    });
+
+    it("should attempt to refresh API key only once", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+      axiosMockAdapter
+        .onPost(
+          `${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`
+        )
+        .reply(200, {});
+      jest.spyOn(axiosInstance, "post");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledTimes(1);
+        expect(axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(error.response.status).toBe(401);
+      }
+    });
+
+    it("should show an error message if API key refresh fails", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+      axiosMockAdapter
+        .onPost(
+          `${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`
+        )
+        .reply(400, "Bad request");
+      jest.spyOn(axiosInstance, "post");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(firmCredentials.storePartnerApiKey).not.toHaveBeenCalled();
+        expect(axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(consola.error).toHaveBeenCalledWith(
+          "Error 401: Failed to refresh the partner API key automatically, try to manually authorize the partner again with the authorize-partner command"
+        );
+      }
+    });
+
+    it("should not attempt to refresh API key on non-401 Unauthorized error", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      jest.spyOn(axiosInstance, "get");
+      axiosInstance.post = jest.fn();
+
+      expect(axiosInstance).toBeDefined();
+      expect(axios.create).toHaveBeenCalled();
+
+      axiosMockAdapter.onGet("/test-endpoint").reply(404, "Not found");
+
+      try {
+        await axiosInstance.get("/test-endpoint");
+        fail("Expected an error to be thrown");
+      } catch (error) {
+        expect(axiosInstance.get).toHaveBeenCalled();
+        expect(axiosInstance.post).not.toHaveBeenCalled();
+        expect(error.response.status).toBe(404);
+      }
+    });
+  });
+
+  describe("Staging environment", () => {
+    const mockHost = "https://test-api.staging.getsilverfin.com";
+
+    it("should raise an error if environment variable is not set", () => {
+      const mockTokenPair = {
+        accessToken: "stored-access",
+        refreshToken: "stored-refresh",
+      };
+      delete process.env.SF_BASIC_AUTH;
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      expect(() => {
+        AxiosFactory.createInstance("firm", 123);
+      }).toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should use basic auth for firm instance in staging", () => {
+      const firmId = 50000;
+      const mockTokenPair = {
+        accessToken: "stored-access",
+        refreshToken: "stored-refresh",
+      };
+
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axiosInstance.defaults.baseURL).toBe(
+        `https://test-api.staging.getsilverfin.com/api/v4/f/50000`
+      );
+
+      expect(axiosInstance.defaults.headers.Authorization).toBe(
+        "Basic test_basic_auth"
+      );
+      expect(axiosInstance.defaults.params).toEqual({
+        access_token: "stored-access",
+      });
+    });
+
+    it("should use basic auth for partner instance in staging", () => {
+      const partnerId = 100;
+      const mockPartnerTokens = {
+        token: "stored-api-key",
+      };
+
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerTokens);
+
+      const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
+
+      expect(axiosInstance).toBeDefined();
+      expect(axiosInstance.defaults.baseURL).toBe(
+        `https://test-api.staging.getsilverfin.com/api/partner/v1`
+      );
+
+      expect(axiosInstance.defaults.headers.Authorization).toBe(
+        "Basic test_basic_auth"
+      );
+      expect(axiosInstance.defaults.params).toEqual({
+        partner_id: partnerId,
+        api_key: mockPartnerTokens.token,
+      });
+    });
+  });
+});

--- a/tests/lib/api/firmCredentials.test.js
+++ b/tests/lib/api/firmCredentials.test.js
@@ -1,0 +1,70 @@
+const fs = require("fs");
+const path = require("path");
+
+jest.mock("fs");
+
+const { firmCredentials } = require("../../../lib/api/firmCredentials");
+
+describe("FirmCredentials", () => {
+  let mockConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig = {
+      defaultFirmIDs: {},
+      host: "https://live.getsilverfin.com",
+    };
+
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify(mockConfig));
+    jest.resetModules();
+
+    firmCredentials.loadCredentials();
+  });
+
+  describe("setHost and getHost", () => {
+    it("should set and get the host correctly", () => {
+      const testHost = "https://test.getsilverfin.com";
+
+      let writtenData;
+      fs.writeFileSync.mockImplementation((_, data) => {
+        writtenData = JSON.parse(data);
+      });
+
+      firmCredentials.setHost(testHost);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        JSON.stringify({ defaultFirmIDs: {}, host: testHost }, null, 2),
+        "utf8",
+        expect.any(Function)
+      );
+
+      expect(writtenData.host).toBe(testHost);
+      expect(firmCredentials.getHost()).toBe(testHost);
+    });
+
+    it("should return environment variable host if set", () => {
+      const envHost = "https://env.getsilverfin.com";
+      process.env.SF_HOST = envHost;
+      fs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          host: "https://stored-host.getsilverfin.com",
+        })
+      );
+      firmCredentials.setHost("https://new-host.getsilverfin.com");
+
+      expect(firmCredentials.getHost()).toBe(envHost);
+
+      delete process.env.SF_HOST;
+    });
+
+    it("should return default host if not set", () => {
+      delete process.env.SF_HOST;
+      fs.readFileSync.mockReturnValue(JSON.stringify({}));
+      jest.resetModules();
+
+      expect(firmCredentials.getHost()).toBe("https://live.getsilverfin.com");
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,7 +779,15 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.6.2:
+axios-mock-adapter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz"
+  integrity sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
+axios@^1.6.2, "axios@>= 0.17.0":
   version "1.7.7"
   resolved "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz"
   integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
@@ -1367,11 +1375,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1518,6 +1521,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-core-module@^2.13.0:
   version "2.15.1"


### PR DESCRIPTION
## Description

Fixes #131 

For Silverfin Staging, Basic authentication needs to be added in the request header, with the proper credentials.

## Updates 

- New commands to set and get HOST
- Maintain also HOST as ENV variable for compatibility
- Support Staging Environments
- Log stored firms and host before each command
- Extract into dedicated class and add tests

## How to test

You need to create a new ENV variable named `SF_BASIC_AUTH`  (you can reach out to me in case you don't have it yet)

Different commands that should be tested.
NOTE: when you switch hosts (for example, from live to staging) a new `silverfin authorize` would need to be run first.
TIP: always use `--verbose` flag in all commands

```bash
silverfin authorize
silverfin config --get-host
silverfin config --set-host # switch between live and staging
silverfin import-reconciliation # from live/staging and firm/partners
silverfin config --refresh-token
silverfin config --refresh-partner-token
```

For example, some steps that can be followed:

```bash
silverfin --set-host <staging-url>
silverfin authorize
silverfin import-reconciliation # from firm
silverfin import-reconciliation # from partners
silverfin config --get-host
silverfin config --refresh-token
silverfin config --refresh-partner-token
silverfin --set-host <production-url>
silverfin authorize
silverfin import-reconciliation # from firm
silverfin import-reconciliation # from partners
silverfin config --refresh-token
silverfin config --refresh-partner-token
```

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
