### PR TITLE
ReconciliationText#read - only write config when  it was changed

### DIFF
--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -92,8 +92,10 @@ class ReconciliationText {
   static read(handle) {
     if (!templateUtils.checkValidName(handle, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, handle, true);
+
     // Config.json
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
+    let originalConfig = { ...templateConfig };
     templateConfig = this.#checkHandleAndNameInConfig(templateConfig, handle);
     let template = this.#filterConfigItems(templateConfig);
     template = this.#checkReconciliationType(template);
@@ -104,7 +106,8 @@ class ReconciliationText {
     template.text = this.#readMainLiquid(handle, templateConfig);
     template.text_parts = this.#readPartsLiquid(handle, templateConfig);
 
-    fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, templateConfig);
+    this.#updateConfigIfChanged(originalConfig, templateConfig, handle);
+
     return template;
   }
 
@@ -151,6 +154,12 @@ class ReconciliationText {
       }
       return acc;
     }, {});
+  }
+
+  static #updateConfigIfChanged(originalConfig, currentConfig, handle) {
+    if (JSON.stringify(originalConfig) !== JSON.stringify(currentConfig)) {
+      fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, currentConfig);
+    }
   }
 
   static #checkReconciliationType(template) {

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -143,6 +143,7 @@ async function createLiquidFile(relativePath, fileName, textContent) {
 }
 
 function writeConfig(templateType, handle, config) {
+  consola.debug(`Writing config for ${handle} (${templateType})`);
   const configPath = path.join(
     process.cwd(),
     `${FOLDERS[templateType]}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

When we use `ReconciliationText.read` we perform some checks on the config.json and write it back.
Add an extra check to write only if config has change, to avoid unnecessary write operations in the file system

For reference: https://silverfin.slack.com/archives/C07F1CEQP0S/p1730322904162779

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [X] Bug fix
- [] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
