### PR TITLE
Not permitted to update new template

### DIFF
--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -27,6 +27,9 @@ class ReconciliationText {
     "can_be_reconciled_without_data",
     "only_reconciled_with_data",
   ];
+  static EXTERNALLY_MANAGED_ITEMS = [
+    "downloadable_as_docx"
+  ];
   static TEMPLATE_TYPE = "reconciliationText";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -149,6 +152,12 @@ class ReconciliationText {
 
   static #filterConfigItems(templateConfig) {
     return this.CONFIG_ITEMS.reduce((acc, attribute) => {
+      // Skip externally managed items if externally_managed is false
+      if (this.EXTERNALLY_MANAGED_ITEMS.includes(attribute) &&
+        templateConfig.externally_managed === false) {
+        return acc;
+      }
+
       if (templateConfig.hasOwnProperty(attribute)) {
         acc[attribute] = templateConfig[attribute];
       }

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -151,10 +151,14 @@ class ReconciliationText {
   }
 
   static #filterConfigItems(templateConfig) {
-    return this.CONFIG_ITEMS.reduce((acc, attribute) => {
+
+    const skippedItems = [];
+
+    const filteredConfig = this.CONFIG_ITEMS.reduce((acc, attribute) => {
       // Skip externally managed items if externally_managed is false
       if (this.EXTERNALLY_MANAGED_ITEMS.includes(attribute) &&
         templateConfig.externally_managed === false) {
+        skippedItems.push(attribute);
         return acc;
       }
 
@@ -163,6 +167,13 @@ class ReconciliationText {
       }
       return acc;
     }, {});
+
+    if (skippedItems.length > 0) {
+      consola.warn(
+        `The following attributes were skipped because they can only be updated when the template is externally managed: ${skippedItems.join(", ")}.`
+      );
+    }
+    return filteredConfig;
   }
 
   static #updateConfigIfChanged(originalConfig, currentConfig, handle) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.27.2",
+      "version": "1.27.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/templates/reconciliationTexts.test.js
+++ b/tests/lib/templates/reconciliationTexts.test.js
@@ -452,5 +452,35 @@ describe("ReconciliationText", () => {
 
       expect(result.text_parts).toEqual([{ name: "empty_part", content: "" }]);
     });
+
+    it("should exclude downloadable_as_docx and show warning when externally_managed is false", () => {
+      const invalidCombinationConfig = {
+        ...configContent,
+        externally_managed: false,
+        downloadable_as_docx: true
+      };
+      fs.writeFileSync(configPath, JSON.stringify(invalidCombinationConfig));
+
+      const result = ReconciliationText.read(handle);
+
+      expect(result.downloadable_as_docx).toBeUndefined();
+      expect(require("consola").warn).toHaveBeenCalledWith(
+        "The following attributes were skipped because they can only be updated when the template is externally managed: downloadable_as_docx."
+      );
+    });
+
+    it("should include downloadable_as_docx when externally_managed is true", () => {
+      const validCombinationConfig = {
+        ...configContent,
+        externally_managed: true,
+        downloadable_as_docx: true
+      };
+      fs.writeFileSync(configPath, JSON.stringify(validCombinationConfig));
+
+      const result = ReconciliationText.read(handle);
+
+      expect(result.downloadable_as_docx).toBe(true);
+    });
+
   });
 });


### PR DESCRIPTION
## Description

Fix was made in line with what you proposed here: https://gitlab.silverfin.com/development/silverfin/-/issues/23082.

We will basically loop through all config items (with the reduce function), if the config item is present in the list of externally managed items (which is a new array) AND the config item externally_managed is put to false -> then the downloadable_as_docx will not be added to the final list of config items. 

This was verified within the be_market repo already, and seemed to work fine. downloadable_as_docx can be true/false, it won't be updated on the platform as long as externally_managed is put to false. 

Updating the template via the Silverfin extension doesn't work at the moment, but I assume this is because we still refer to the main version of the silverfin-cli code (thus excluding this check). Could you confirm this, and is there any way in which we can check this anyway? 

Fixes #121 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
