### PR TITLE
Fix add-shared-part --all command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

This command was 'broken' when Partners API was implemented. 
Force flag was still accepted as argument but never used Await clause and delay were removed
Here we recover the implementation that we have before Partners API, adding the corresponding options to select between firm and partner ids when corresponding
Based on commit 6c4cd17

Fixes 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
