### PR TITLE
Fix: authorization when there are no stored tokens

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -688,7 +688,7 @@ program
   .command("authorize")
   .description("Authorize the CLI by entering your Silverfin API credentials")
   .action(() => {
-    SF.authorizeApp(firmIdDefault);
+    SF.authorizeFirm(firmIdDefault);
   });
 
 // Authorize PARTNER

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -1,57 +1,20 @@
-const axios = require("axios");
-const open = require("open");
-const prompt = require("prompt-sync")({ sigint: true });
 const apiUtils = require("../utils/apiUtils");
 const { consola } = require("consola");
 const { firmCredentials } = require("../api/firmCredentials");
 const { AxiosFactory } = require("./axiosFactory");
+const { SilverfinAuthorizer } = require("./silverfinAuthorizer");
 
 apiUtils.checkRequiredEnvVariables();
 
-async function authorizeApp(firmId = undefined) {
-  try {
-    consola.info(
-      `NOTE: if you need to exit this process you can press "Ctrl/Cmmd + C"`
-    );
-    const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
-    const scope = encodeURIComponent(
-      "administration:read administration:write financials:read financials:write workflows:read"
-    );
-
-    let firmIdPrompt;
-    if (firmId) {
-      firmIdPrompt = prompt(
-        `Enter the firm ID (leave blank to use ${firmId}): `,
-        { value: firmId }
-      );
-    } else {
-      firmIdPrompt = prompt("Enter the firm ID: ");
-    }
-    const url = `${apiUtils.BASE_URL}/f/${firmIdPrompt}/oauth/authorize?client_id=${process.env.SF_API_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
-
-    await open(url);
-    consola.info(`You need to authorize your APP in the browser`);
-    consola.log("Insert your credentials...");
-    const authCodePrompt = prompt("Enter your API authorization code: ", {
-      echo: "*",
-    });
-    // Get tokens
-    const tokens = await apiUtils.getAccessToken(firmIdPrompt, authCodePrompt);
-    if (tokens) {
-      consola.success("Authentication successful");
-    }
-    // Get firm name
-    await apiUtils.getFirmName(firmIdPrompt);
-  } catch (error) {
-    consola.error(error);
-    process.exit(1);
-  }
+async function authorizeFirm(firmId) {
+  SilverfinAuthorizer.authorizeFirm(firmId);
 }
 
 async function refreshFirmTokens(firmId) {
   try {
     const instance = AxiosFactory.createInstance("firm", firmId);
     const firmTokens = firmCredentials.getTokenPair(firmId);
+    const BASE_URL = firmCredentials.getHost();
     let data = {
       client_id: process.env.SF_API_CLIENT_ID,
       client_secret: process.env.SF_API_SECRET,
@@ -61,7 +24,7 @@ async function refreshFirmTokens(firmId) {
       access_token: firmTokens.accessToken,
     };
     const response = await instance.post(
-      `${apiUtils.BASE_URL}/f/${firmId}/oauth/token`,
+      `${BASE_URL}/f/${firmId}/oauth/token`,
       data
     );
 
@@ -92,9 +55,10 @@ async function refreshPartnerToken(partnerId) {
       process.exit(1);
     }
 
+    const BASE_URL = firmCredentials.getHost();
     const instance = AxiosFactory.createInstance("partner", partnerId);
     const response = await instance.post(
-      `${apiUtils.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
+      `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
     );
 
     firmCredentials.storePartnerApiKey(
@@ -838,7 +802,7 @@ async function getFirmDetails(firmId) {
 }
 
 module.exports = {
-  authorizeApp,
+  authorizeFirm,
   refreshFirmTokens,
   refreshPartnerToken,
   createReconciliationText,

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -13,9 +13,10 @@ async function authorizeApp(firmId = undefined) {
     consola.info(
       `NOTE: if you need to exit this process you can press "Ctrl/Cmmd + C"`
     );
-    const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
-    const scope =
-      "administration%3Aread%20administration%3Awrite%20financials%3Aread%20financials%3Awrite%20workflows%3Aread";
+    const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
+    const scope = encodeURIComponent(
+      "administration:read administration:write financials:read financials:write workflows:read"
+    );
 
     let firmIdPrompt;
     if (firmId) {
@@ -35,12 +36,7 @@ async function authorizeApp(firmId = undefined) {
       echo: "*",
     });
     // Get tokens
-    const instance = AxiosFactory.createInstance("firm", firmId);
-    const tokens = await apiUtils.getAccessToken(
-      instance,
-      firmIdPrompt,
-      authCodePrompt
-    );
+    const tokens = await apiUtils.getAccessToken(firmIdPrompt, authCodePrompt);
     if (tokens) {
       consola.success("Authentication successful");
     }

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -1,0 +1,119 @@
+const { firmCredentials } = require("../api/firmCredentials");
+const prompt = require("prompt-sync")({ sigint: true });
+const axios = require("axios");
+const open = require("open");
+const { consola } = require("consola");
+const BASE_URL = firmCredentials.getHost();
+
+class SilverfinAuthorizer {
+  constructor() {}
+
+  /**
+   * Authorize a firm by providing the firm ID
+   * It will prompt for the firm ID, open the browser for authorization and prompt for the authorization code
+   * It will reach for the access and refresh tokens and store them in the credentials file
+   * It will also store the firm name in the credentials file
+   * @param {Number} firmId
+   */
+  static async authorizeFirm(firmId = undefined) {
+    const firmIdUser = await this.#promptForId(firmId);
+    await this.#openBrowser(firmIdUser);
+    await this.#promptForAuthCode(firmIdUser);
+  }
+
+  // PRIVATE METHODS
+
+  static async #promptForId(firmId = undefined) {
+    consola.info(
+      `NOTE: if you need to exit this process you can press "Ctrl/Cmmd + C"`
+    );
+
+    let firmIdPrompt;
+    if (firmId) {
+      firmIdPrompt = prompt(
+        `Enter the firm ID (leave blank to use ${firmId}): `,
+        { value: firmId }
+      );
+    } else {
+      firmIdPrompt = prompt("Enter the firm ID: ");
+    }
+    return firmIdPrompt;
+  }
+
+  static async #openBrowser(firmId) {
+    consola.info(`You need to authorize your APP in the browser now`);
+
+    const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
+    const scope = encodeURIComponent(
+      "administration:read administration:write financials:read financials:write workflows:read"
+    );
+    const BASE_URL = firmCredentials.getHost();
+    const SF_API_CLIENT_ID = process.env.SF_API_CLIENT_ID;
+    const url = `${BASE_URL}/f/${firmId}/oauth/authorize?client_id=${SF_API_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
+
+    await open(url);
+  }
+
+  static async #promptForAuthCode(firmId) {
+    try {
+      consola.log("Insert your credentials...");
+      const authCode = prompt("Enter your API authorization code: ", {
+        echo: "*",
+      });
+
+      const tokens = await this.#getFirmAccessToken(firmId, authCode);
+      if (tokens) {
+        consola.success("Authentication successful");
+      }
+    } catch (error) {
+      consola.error(error);
+      process.exit(1);
+    }
+  }
+
+  // Get Tokens for the first time with an authorization code
+  static async #getFirmAccessToken(firmId, authCode) {
+    try {
+      const grantType = "authorization_code";
+      const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
+      const SF_API_CLIENT_ID = process.env.SF_API_CLIENT_ID;
+      const SF_API_SECRET = process.env.SF_API_SECRET;
+      let requestDetails = {
+        method: "POST",
+        url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
+      };
+      const response = await axios(requestDetails);
+
+      firmCredentials.storeNewTokenPair(firmId, response.data);
+
+      await this.#getFirmName(firmId);
+
+      return true;
+    } catch (error) {
+      consola.error(
+        `Response Status: ${error.response.status} (${error.response.statusText})`
+      );
+      consola.error(
+        `Error description: ${JSON.stringify(
+          error.response.data.error_description
+        )}`
+      );
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Retrieve firm details and store the firm name in the credentials file
+   * @param {Number} firmId
+   */
+  static async #getFirmName(firmId) {
+    try {
+      const response = await axios.get(`/user/firm`);
+      if (response && response.data) {
+        firmCredentials.storeFirmName(firmId, response.data.name);
+      }
+    } catch (error) {}
+  }
+}
+
+module.exports = { SilverfinAuthorizer };

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -3,7 +3,6 @@ const prompt = require("prompt-sync")({ sigint: true });
 const axios = require("axios");
 const open = require("open");
 const { consola } = require("consola");
-const BASE_URL = firmCredentials.getHost();
 
 class SilverfinAuthorizer {
   constructor() {}
@@ -16,7 +15,11 @@ class SilverfinAuthorizer {
    * @param {Number} firmId
    */
   static async authorizeFirm(firmId = undefined) {
+    this.BASE_URL = firmCredentials.getHost();
+
     const firmIdUser = await this.#promptForId(firmId);
+    !firmIdUser ? this.#missingFirmIdMessage() : null;
+
     await this.#openBrowser(firmIdUser);
     await this.#promptForAuthCode(firmIdUser);
   }
@@ -37,7 +40,7 @@ class SilverfinAuthorizer {
     } else {
       firmIdPrompt = prompt("Enter the firm ID: ");
     }
-    return firmIdPrompt;
+    return firmIdPrompt.trim();
   }
 
   static async #openBrowser(firmId) {
@@ -47,9 +50,8 @@ class SilverfinAuthorizer {
     const scope = encodeURIComponent(
       "administration:read administration:write financials:read financials:write workflows:read"
     );
-    const BASE_URL = firmCredentials.getHost();
     const SF_API_CLIENT_ID = process.env.SF_API_CLIENT_ID;
-    const url = `${BASE_URL}/f/${firmId}/oauth/authorize?client_id=${SF_API_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
+    const url = `${this.BASE_URL}/f/${firmId}/oauth/authorize?client_id=${SF_API_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
 
     await open(url);
   }
@@ -80,7 +82,7 @@ class SilverfinAuthorizer {
       const SF_API_SECRET = process.env.SF_API_SECRET;
       let requestDetails = {
         method: "POST",
-        url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
+        url: `${this.BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
       };
       const response = await axios(requestDetails);
 
@@ -113,6 +115,11 @@ class SilverfinAuthorizer {
         firmCredentials.storeFirmName(firmId, response.data.name);
       }
     } catch (error) {}
+  }
+
+  static #missingFirmIdMessage() {
+    consola.error("Firm ID is missing. Please provide a valid one.");
+    process.exit(1);
   }
 }
 

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -177,12 +177,17 @@ function runCommandChecks(
 
 function logCurrentEnvironments() {
   const currentFirmId = loadDefaultFirmId();
+  const currentHost = firmCredentials.getHost();
+
+  if (!currentFirmId && currentHost === firmCredentials.SF_DEFAULT_HOST) {
+    return;
+  }
+
   const currentFirmName = firmCredentials.getFirmName(currentFirmId);
   const firmDetails = currentFirmId
     ? `Current firm: ${currentFirmId} ${currentFirmName ? "(" + currentFirmName + ")" : ""}.`
     : "";
 
-  const currentHost = firmCredentials.getHost();
   const hostDetails =
     currentHost === firmCredentials.SF_DEFAULT_HOST
       ? ""

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -26,7 +26,7 @@ function checkRequiredEnvVariables() {
 }
 
 // Get Tokens for the first time with an authorization code
-async function getAccessToken(axiosInstance, firmId, authCode) {
+async function getAccessToken(firmId, authCode) {
   try {
     const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
     const grantType = "authorization_code";
@@ -34,7 +34,7 @@ async function getAccessToken(axiosInstance, firmId, authCode) {
       method: "POST",
       url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
     };
-    const response = await axiosInstance(requestDetails);
+    const response = await axios(requestDetails);
     firmCredentials.storeNewTokenPair(firmId, response.data);
     await getFirmName(firmId);
     return true;

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -1,8 +1,5 @@
 const { firmCredentials } = require("../api/firmCredentials");
-const axios = require("axios");
 const { consola } = require("consola");
-
-const BASE_URL = firmCredentials.getHost();
 
 function checkAuthorizePartners(partner_id) {
   const partnerCredentials = firmCredentials.getPartnerCredentials(partner_id);
@@ -20,32 +17,6 @@ function checkRequiredEnvVariables() {
     consola.log(`Call export ${missingVariables[0]}=...`);
     consola.log(
       `If you don't have credentials yet, you need to register your app with Silverfin to get them`
-    );
-    process.exit(1);
-  }
-}
-
-// Get Tokens for the first time with an authorization code
-async function getAccessToken(firmId, authCode) {
-  try {
-    const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
-    const grantType = "authorization_code";
-    let requestDetails = {
-      method: "POST",
-      url: `${BASE_URL}/f/${firmId}/oauth/token?client_id=${process.env.SF_API_CLIENT_ID}&client_secret=${process.env.SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
-    };
-    const response = await axios(requestDetails);
-    firmCredentials.storeNewTokenPair(firmId, response.data);
-    await getFirmName(firmId);
-    return true;
-  } catch (error) {
-    consola.error(
-      `Response Status: ${error.response.status} (${error.response.statusText})`
-    );
-    consola.error(
-      `Error description: ${JSON.stringify(
-        error.response.data.error_description
-      )}`
     );
     process.exit(1);
   }
@@ -108,25 +79,9 @@ async function responseErrorHandler(error) {
   throw error;
 }
 
-/**
- * Retrieve firm details and store the firm name in the credentials file
- * @param {Number} firmId
- */
-async function getFirmName(firmId) {
-  try {
-    const response = await axios.get(`/user/firm`);
-    if (response && response.data) {
-      firmCredentials.storeFirmName(firmId, response.data.name);
-    }
-  } catch (error) {}
-}
-
 module.exports = {
-  BASE_URL,
+  checkAuthorizePartners,
   checkRequiredEnvVariables,
-  getAccessToken,
   responseSuccessHandler,
   responseErrorHandler,
-  getFirmName,
-  checkAuthorizePartners,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/api/silverfinAuthorizer.test.js
+++ b/tests/lib/api/silverfinAuthorizer.test.js
@@ -1,0 +1,192 @@
+const { firmCredentials } = require("../../../lib/api/firmCredentials");
+const axios = require("axios");
+const open = require("open");
+const { consola } = require("consola");
+
+const mockPrompt = jest.fn();
+jest.mock("prompt-sync", () => {
+  return () => mockPrompt;
+});
+
+const { SilverfinAuthorizer } = require("../../../lib/api/silverfinAuthorizer"); // it has to be after mock prompt
+
+jest.mock("../../../lib/api/firmCredentials", () => ({
+  firmCredentials: {
+    getHost: jest.fn(),
+    getTokenPair: jest.fn(),
+    storeNewTokenPair: jest.fn(),
+    getPartnerCredentials: jest.fn(),
+    storePartnerApiKey: jest.fn(),
+  },
+}));
+
+jest.mock("axios");
+jest.mock("open");
+jest.mock("consola");
+
+describe("SilverfinAuthorizer", () => {
+  let exitSpy;
+  const mockStoredFirmId = "5000";
+  const mockFirmId = "123";
+  const mockAuthCode = "auth_code_123";
+  const mockTokenResponse = {
+    data: {
+      access_token: "mock_access_token",
+      refresh_token: "mock_refresh_token",
+      expires_in: 7200,
+    },
+  };
+  const mockFirmResponse = {
+    data: {
+      name: "Test Firm",
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    firmCredentials.getHost.mockReturnValue("https://api.test.com");
+    process.env.SF_API_CLIENT_ID = "test_client_id";
+    process.env.SF_API_SECRET = "test_secret";
+
+    // Mock prompt responses
+    mockPrompt
+      .mockReturnValueOnce(mockFirmId) // First prompt for firm ID
+      .mockReturnValueOnce(mockAuthCode); // Second prompt for auth code
+
+    // Mock axios responses
+    axios.mockResolvedValueOnce(mockTokenResponse); // For token request
+    axios.get.mockResolvedValueOnce(mockFirmResponse); // For firm name request
+
+    // Mock process.exit
+    exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Process.exit called with code ${code}`);
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  describe("authorizeFirm", () => {
+    it("should successfully store new tokens when they dont exist", async () => {
+      await SilverfinAuthorizer.authorizeFirm(mockStoredFirmId);
+
+      expect(mockPrompt).toHaveBeenNthCalledWith(
+        1,
+        "Enter the firm ID (leave blank to use 5000): ",
+        { value: "5000" }
+      );
+      expect(mockPrompt).toHaveBeenNthCalledWith(
+        2,
+        "Enter your API authorization code: ",
+        { echo: "*" }
+      );
+
+      expect(open).toHaveBeenCalledWith(
+        expect.stringContaining("api.test.com/f/123/oauth/authorize")
+      );
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          url: expect.stringContaining("api.test.com/f/123/oauth/token"),
+        })
+      );
+      expect(axios.get).toHaveBeenCalledWith("/user/firm");
+
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+        mockFirmId,
+        mockTokenResponse.data
+      );
+
+      expect(consola.error).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should succesfully store new tokens when they exist", async () => {
+    await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("api.test.com/f/123/oauth/authorize")
+    );
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: expect.stringContaining("api.test.com/f/123/oauth/token"),
+      })
+    );
+    expect(axios.get).toHaveBeenCalledWith("/user/firm");
+
+    expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+      mockFirmId,
+      mockTokenResponse.data
+    );
+
+    expect(consola.error).not.toHaveBeenCalled();
+  });
+
+  it("should handle missing firm id", async () => {
+    mockPrompt.mockReset();
+    mockPrompt.mockReturnValueOnce(""); // First prompt for firm ID
+
+    await expect(async () => {
+      await SilverfinAuthorizer.authorizeFirm();
+    }).rejects.toThrow("Process.exit called with code 1");
+
+    expect(mockPrompt).toHaveBeenNthCalledWith(1, "Enter the firm ID: ");
+
+    expect(open).not.toHaveBeenCalled();
+
+    expect(axios).not.toHaveBeenCalled();
+
+    expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Firm ID is missing. Please provide a valid one."
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle response errors", async () => {
+    axios.mockReset();
+    axios.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        statusText: "Bad Request",
+        data: {
+          error_description:
+            "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+        },
+      },
+    });
+
+    await expect(async () => {
+      await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+    }).rejects.toThrow("Process.exit called with code 1");
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Response Status: 400 (Bad Request)"
+    );
+    expect(consola.error).toHaveBeenCalledWith(
+      'Error description: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."'
+    );
+
+    expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+  });
+
+  it("should not raise errors when getting the firm name fails", async () => {
+    axios.get.mockReset();
+    axios.get.mockRejectedValueOnce(new Error("Failed to get firm name"));
+
+    await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+
+    expect(consola.error).not.toHaveBeenCalled();
+
+    expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+      mockFirmId,
+      mockTokenResponse.data
+    );
+  });
+});


### PR DESCRIPTION
## Description

All AxiosInstances will check that there stored access and refresh tokens for the firm, if not it will raise an error to authorize. For that reason, when we are actually authorizating, we don't have to use those instance. If not, the first time you authorize a firm an error will be raised before you can actually authorize it.

## How to test it

- Choose a demo firm and log in into Silverfin in the browser
- Make sure you don't have any old credentials for it (remove it from the config file if needed)
- Run a new `silverfin authorize`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
