### PR TITLE
Remove current firm information

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1025,6 +1025,6 @@ if (pkg.repository && pkg.repository.url) {
 (async function () {
   // Check if there is a new version available
   await cliUpdates.checkVersions();
-  cliUtils.logCurrentEnvironments();
+  cliUtils.logCurrentHost();
   await program.parseAsync();
 })();

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -175,25 +175,14 @@ function runCommandChecks(
   return settings;
 }
 
-function logCurrentEnvironments() {
-  const currentFirmId = loadDefaultFirmId();
+function logCurrentHost() {
   const currentHost = firmCredentials.getHost();
-
-  if (!currentFirmId && currentHost === firmCredentials.SF_DEFAULT_HOST) {
+  if (currentHost === firmCredentials.SF_DEFAULT_HOST) {
     return;
   }
+  const hostDetails = `Current host: ${currentHost}.`;
 
-  const currentFirmName = firmCredentials.getFirmName(currentFirmId);
-  const firmDetails = currentFirmId
-    ? `Current firm: ${currentFirmId} ${currentFirmName ? "(" + currentFirmName + ")" : ""}.`
-    : "";
-
-  const hostDetails =
-    currentHost === firmCredentials.SF_DEFAULT_HOST
-      ? ""
-      : `Current host: ${currentHost}.`;
-
-  consola.info(`${firmDetails} ${hostDetails}`);
+  consola.info(hostDetails);
 }
 
 module.exports = {
@@ -206,5 +195,5 @@ module.exports = {
   checkRequiredFirmOrPartner,
   getCommandSettings,
   runCommandChecks,
-  logCurrentEnvironments,
+  logCurrentHost,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

With the introduction of stagings we added a message on every command indicating the stored firm id and host.
We are removing now the information about the firm since it turned out to be more confusing than useful for users.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
