### PR TITLE
Refactor refresh credentials methods

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -756,13 +756,13 @@ program
   )
   .addOption(
     new Option(
-      "--refresh-partner-token [partner_id]",
+      "--refresh-partner-token <partnerId>",
       "Get a new partner api key using the stored api key"
     )
   )
   .addOption(
     new Option(
-      "--set-host [host]",
+      "--set-host <host>",
       "Set a custom host for the Silverfin API (e.g. https://live.getsilverfin.com)"
     )
   )
@@ -835,9 +835,9 @@ program
         options.refreshPartnerToken
       );
 
-      if (refreshedTokens && refreshedTokens.partner_id) {
+      if (refreshedTokens) {
         consola.success(
-          `Partner API key refreshed for partner ID: ${refreshedTokens.partner_id}`
+          `Partner API key refreshed for partner ID: ${options.refreshPartnerToken}`
         );
       }
     }

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -33,7 +33,39 @@ class AxiosFactory {
     return axiosInstance;
   }
 
+  /**
+   * Create an axios instance for a given environment id (type firm)
+   * It will add the necessary headers to handle the authorization, for example Basic Auth for staging.
+   * It won't have any token refresh mechanism, and it won't check or load the tokens from the credentials file.
+   * It is intended to be used for the authorization process, where tokens could not be available yet.
+   * @param {Number} envId - The environment id to create the instance for
+   * @returns {Object} - The created axios instance
+   */
+  static createAuthInstanceForFirm(envId) {
+    this.BASE_URL = firmCredentials.getHost();
+    return this.#createSimpleAxiosInstanceForFirms(envId);
+  }
+
   // PRIVATE METHODS
+
+  static #createSimpleAxiosInstanceForFirms(envId) {
+    let baseHeaders = {
+      "User-Agent": `silverfin-cli/${pkg.version}`,
+      "X-Firm-ID": envId,
+    };
+
+    let axiosDetails = {
+      baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
+      headers: {
+        ...baseHeaders,
+      },
+    };
+    if (this.#isStaging()) {
+      axiosDetails.headers.Authorization = this.#basicAuthHeader();
+    }
+
+    return axios.create(axiosDetails);
+  }
 
   static #createAxiosInstanceForFirms(envId) {
     const firmTokens = firmCredentials.getTokenPair(envId);
@@ -82,51 +114,49 @@ class AxiosFactory {
         return response;
       },
       async (error) => {
-        const originalConfig = error.config;
         if (error.response) {
-          if (error.response.status === 401 && !originalConfig._retry) {
-            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-            originalConfig._retry = true;
+          if (error.response.status === 401) {
+            const originalConfig = error.config;
+            if (!originalConfig._retry) {
+              try {
+                // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+                originalConfig._retry = true;
 
-            try {
-              // Get a refreshed set of tokens
-              const firmId = originalConfig.headers["X-Firm-ID"];
+                // Get a refreshed set of tokens
+                const firmId = originalConfig.headers["X-Firm-ID"];
 
-              await this.#refreshFirmTokens(axiosInstance, firmId);
+                await this.#refreshFirmTokens(firmId);
 
-              const firmTokens = firmCredentials.getTokenPair(firmId);
+                const firmTokens = firmCredentials.getTokenPair(firmId);
 
-              // Set the new access token for current and future requests
-              if (this.#isStaging()) {
-                axiosInstance.defaults.params = {
-                  ...axiosInstance.defaults.params,
-                  access_token: firmTokens.accessToken,
-                };
-                originalConfig.params = {
-                  ...originalConfig.params,
-                  access_token: firmTokens.accessToken,
-                };
-              } else {
-                axiosInstance.defaults.headers.common["Authorization"] =
-                  `Bearer ${firmTokens.accessToken}`;
-                originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+                // Set the new access token for current and future requests
+                if (this.#isStaging()) {
+                  axiosInstance.defaults.params = {
+                    ...axiosInstance.defaults.params,
+                    access_token: firmTokens.accessToken,
+                  };
+                  originalConfig.params = {
+                    ...originalConfig.params,
+                    access_token: firmTokens.accessToken,
+                  };
+                } else {
+                  axiosInstance.defaults.headers.common["Authorization"] =
+                    `Bearer ${firmTokens.accessToken}`;
+                  originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
+                }
+
+                return axiosInstance(originalConfig);
+              } catch (_error) {
+                return Promise.reject(_error);
               }
-
-              return axiosInstance(originalConfig);
-            } catch (_error) {
-              consola.error(
-                `Error 401: Failed to refresh the firm access token automatically, try to manually authorize the firm again with the authorize command`
-              );
-
-              if (_error.response && _error.response.data) {
-                return Promise.reject(_error.response.data);
-              }
-
-              return Promise.reject(_error);
             }
+
+            // Refresh failed
+            this.#handleFailedRefresh(error);
           }
         }
 
+        // Return any error that is not related to the token
         return Promise.reject(error);
       }
     );
@@ -134,13 +164,7 @@ class AxiosFactory {
     return axiosInstance;
   }
 
-  static #createAxiosInstanceForPartners(envId) {
-    const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
-    if (!partnerToken) {
-      consola.error(`Missing authorization for partner id: ${envId}`);
-      process.exit(1);
-    }
-
+  static #prepareAxiosDetailsForPartners(envId, partnerToken) {
     let axiosDetails = {
       baseURL: `${this.BASE_URL}/api/partner/v1`,
       headers: {
@@ -156,6 +180,20 @@ class AxiosFactory {
       axiosDetails.headers.Authorization = this.#basicAuthHeader();
     }
 
+    return axiosDetails;
+  }
+
+  static #createAxiosInstanceForPartners(envId) {
+    const partnerToken = firmCredentials.getPartnerCredentials(envId)?.token;
+    if (!partnerToken) {
+      consola.error(`Missing authorization for partner id: ${envId}`);
+      process.exit(1);
+    }
+
+    let axiosDetails = this.#prepareAxiosDetailsForPartners(
+      envId,
+      partnerToken
+    );
     let axiosInstance = axios.create(axiosDetails);
     axiosInstance = this.#addPartnerTokenRefresher(axiosInstance);
 
@@ -171,45 +209,34 @@ class AxiosFactory {
       async (error) => {
         const originalConfig = error.config;
         if (error.response) {
-          if (error.response.status === 401 && !originalConfig._retry) {
-            // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
-            originalConfig._retry = true;
+          if (error.response.status === 401) {
+            if (!originalConfig._retry) {
+              try {
+                // Set _retry to true after trying the first refresh request on 401 status to avoid an infinite loop
+                originalConfig._retry = true;
+                const partnerId = originalConfig.params.partner_id;
 
-            try {
-              // Get a refresh API key
-              const originalPartnerId = originalConfig.params.partner_id;
-              const originalPartnerApiKey = originalConfig.params.api_key;
+                await this.#refreshPartnerApiKey(partnerId);
 
-              const response = await axiosInstance.post(
-                `${this.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${originalPartnerApiKey}`
-              );
+                const newPartnerToken =
+                  firmCredentials.getPartnerCredentials(partnerId).token;
 
-              firmCredentials.storePartnerApiKey(
-                originalPartnerId,
-                response.data.api_key
-              );
+                // Set the new access token for current and future requests
+                axiosInstance.defaults.params.api_key = newPartnerToken;
+                originalConfig.params.api_key = newPartnerToken;
 
-              consola.debug("Refreshed partner api key");
-
-              // Set the new access token for current and future requests
-              axiosInstance.defaults.params.api_key = response.data.api_key;
-              originalConfig.params.api_key = response.data.api_key;
-
-              return axiosInstance(originalConfig);
-            } catch (_error) {
-              consola.error(
-                `Error 401: Failed to refresh the partner API key automatically, try to manually authorize the partner again with the authorize-partner command`
-              );
-
-              if (_error.response && _error.response.data) {
-                return Promise.reject(_error.response.data);
+                return axiosInstance(originalConfig);
+              } catch (_error) {
+                return Promise.reject(_error);
               }
-
-              return Promise.reject(_error);
             }
+
+            // Refresh failed
+            this.#handleFailedRefresh(error);
           }
         }
 
+        // Return any error that is not related to the token
         return Promise.reject(error);
       }
     );
@@ -236,7 +263,7 @@ class AxiosFactory {
   /**
    * Get a new set of tokens for a given firm id
    */
-  static async #refreshFirmTokens(axiosInstance, firmId) {
+  static async #refreshFirmTokens(firmId) {
     try {
       consola.debug(`Refreshing tokens for firm ${firmId}`);
       const firmTokens = firmCredentials.getTokenPair(firmId);
@@ -248,6 +275,10 @@ class AxiosFactory {
         refresh_token: firmTokens.refreshToken,
         access_token: firmTokens.accessToken,
       };
+
+      // We create an instance without interceptors to avoid an infinite loop
+      const axiosInstance = this.#createSimpleAxiosInstanceForFirms(firmId);
+
       const response = await axiosInstance.post(
         `${this.BASE_URL}/f/${firmId}/oauth/token`,
         data
@@ -258,22 +289,50 @@ class AxiosFactory {
 
       return true;
     } catch (error) {
-      // NOTE: Should we handle the error differently? No response
-      if (!error?.response) {
-        throw error;
-      }
-
-      const description =
-        error?.response?.data?.error_description || error?.request?.data;
-
-      consola.error(
-        `Response Status: ${error.response.status} (${error.response.statusText})`,
-        description ? `\nError description: ${description}` : "",
-        "\n",
-        `Error refreshing the tokens. Try running the authentication process again`
-      );
-      process.exit(1);
+      this.#handleFailedRefresh(error);
     }
+  }
+
+  /**
+   * Get a new API key for a given partner id
+   */
+  static async #refreshPartnerApiKey(partnerId) {
+    try {
+      consola.debug(`Refreshing API key for partner ${partnerId}`);
+
+      const partnerToken =
+        firmCredentials.getPartnerCredentials(partnerId).token;
+
+      // Create a new instance with not interceptors to avoid an infinite loop
+      const newAxiosDetails = this.#prepareAxiosDetailsForPartners(
+        partnerId,
+        partnerToken
+      );
+      const newAxiosInstance = axios.create(newAxiosDetails);
+      const response = await newAxiosInstance.post(
+        `${this.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerToken}`
+      );
+
+      firmCredentials.storePartnerApiKey(partnerId, response.data.api_key);
+
+      consola.debug(`Refreshed API key for partner ${partnerId}`);
+
+      return true;
+    } catch (error) {
+      this.#handleFailedRefresh(error);
+    }
+  }
+
+  static #handleFailedRefresh(error) {
+    if (error.response) {
+      consola.error(
+        `Response Status: ${error.response.status} (${error.response.statusText})`
+      );
+    }
+    consola.error(
+      `Error refreshing credentials. Try running the authentication process again`
+    );
+    process.exit(1);
   }
 }
 

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -204,7 +204,7 @@ class FirmCredentials {
    * @param {string} host - Host URL
    */
   setHost(host) {
-    this.data.host = host;
+    this.data.host = host.toString().trim();
     this.saveCredentials();
   }
 

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -1,6 +1,5 @@
 const apiUtils = require("../utils/apiUtils");
 const { consola } = require("consola");
-const { firmCredentials } = require("../api/firmCredentials");
 const { AxiosFactory } = require("./axiosFactory");
 const { SilverfinAuthorizer } = require("./silverfinAuthorizer");
 
@@ -11,75 +10,11 @@ async function authorizeFirm(firmId) {
 }
 
 async function refreshFirmTokens(firmId) {
-  try {
-    const instance = AxiosFactory.createInstance("firm", firmId);
-    const firmTokens = firmCredentials.getTokenPair(firmId);
-    const BASE_URL = firmCredentials.getHost();
-    let data = {
-      client_id: process.env.SF_API_CLIENT_ID,
-      client_secret: process.env.SF_API_SECRET,
-      redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
-      grant_type: "refresh_token",
-      refresh_token: firmTokens.refreshToken,
-      access_token: firmTokens.accessToken,
-    };
-    const response = await instance.post(
-      `${BASE_URL}/f/${firmId}/oauth/token`,
-      data
-    );
-
-    firmCredentials.storeNewTokenPair(firmId, response.data);
-    consola.info(`Refreshed tokens for firm ${firmId}`);
-  } catch (error) {
-    const description =
-      error?.response?.data?.error_description || error?.request?.data;
-
-    consola.error(
-      `Response Status: ${error.response.status} (${error.response.statusText})`,
-      description ? `\nError description: ${description}` : "",
-      "\n",
-      `Error refreshing the tokens. Try running the authentication process again`
-    );
-    process.exit(1);
-  }
+  return SilverfinAuthorizer.refreshFirm(firmId);
 }
 
 async function refreshPartnerToken(partnerId) {
-  try {
-    const partnerCredentials = apiUtils.checkAuthorizePartners(partnerId);
-
-    if (!partnerCredentials) {
-      consola.error(
-        `Partner ${partnerId} is not authorized. Please authorize the partner first`
-      );
-      process.exit(1);
-    }
-
-    const BASE_URL = firmCredentials.getHost();
-    const instance = AxiosFactory.createInstance("partner", partnerId);
-    const response = await instance.post(
-      `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
-    );
-
-    firmCredentials.storePartnerApiKey(
-      partnerId,
-      response.data.api_key,
-      partnerCredentials?.name
-    );
-
-    return {
-      partner_id: partnerId,
-      partnerName: partnerCredentials?.name,
-      token: response.data.api_key,
-    };
-  } catch (error) {
-    consola.error(
-      `Response Status: ${error.response.status} (${error.response.statusText})`
-    );
-    consola.error("An error occurred trying to refresh the partner API key");
-    consola.error(error);
-    process.exit(1);
-  }
+  return SilverfinAuthorizer.refreshPartner(partnerId);
 }
 
 async function createReconciliationText(type, envId, attributes) {

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -1,6 +1,6 @@
 const { firmCredentials } = require("../api/firmCredentials");
 const prompt = require("prompt-sync")({ sigint: true });
-const axios = require("axios");
+const { AxiosFactory } = require("./axiosFactory");
 const open = require("open");
 const { consola } = require("consola");
 
@@ -21,7 +21,105 @@ class SilverfinAuthorizer {
     !firmIdUser ? this.#missingFirmIdMessage() : null;
 
     await this.#openBrowser(firmIdUser);
-    await this.#promptForAuthCode(firmIdUser);
+    const authCode = await this.#promptForAuthCode();
+
+    const tokens = await this.#getFirmAccessToken(firmIdUser, authCode);
+
+    if (tokens) {
+      consola.success("Authentication successful");
+    }
+
+    await this.#getFirmName(firmId);
+  }
+
+  /**
+   * Refresh the tokens for a firm
+   * It will store the new tokens in the credentials file
+   * @param {Number} firmId
+   * @returns {Boolean} It will return true if the tokens were refreshed successfully
+   */
+  static async refreshFirm(firmId) {
+    try {
+      const firmTokens = firmCredentials.getTokenPair(firmId);
+      if (!firmTokens) {
+        consola.error(
+          `Firm ${firmId} is not authorized. Please authorize the firm first`
+        );
+        process.exit(1);
+      }
+
+      const BASE_URL = firmCredentials.getHost();
+      let data = {
+        client_id: process.env.SF_API_CLIENT_ID,
+        client_secret: process.env.SF_API_SECRET,
+        redirect_uri: encodeURIComponent("urn:ietf:wg:oauth:2.0:oob"),
+        grant_type: "refresh_token",
+        refresh_token: firmTokens.refreshToken,
+        access_token: firmTokens.accessToken,
+      };
+      const instance = AxiosFactory.createInstance("firm", firmId);
+      const response = await instance.post(
+        `${BASE_URL}/f/${firmId}/oauth/token`,
+        data
+      );
+
+      firmCredentials.storeNewTokenPair(firmId, response.data);
+
+      return true;
+    } catch (error) {
+      if (error.response) {
+        const description =
+          error?.response?.data?.error_description || error?.request?.data;
+
+        consola.error(
+          `Response Status: ${error.response.status} (${error.response.statusText})`,
+          description ? `\nError description: ${description}` : "",
+          "\nError refreshing the tokens. Try running the authentication process again"
+        );
+      }
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Refresh the Partner API Keys
+   * It will store the new token in the credentials file
+   * @param {Number} partnerId
+   * @returns {Boolean} It will return true if the API Key was refreshed successfully
+   */
+  static async refreshPartner(partnerId) {
+    try {
+      const partnerCredentials =
+        firmCredentials.getPartnerCredentials(partnerId);
+
+      if (!partnerCredentials) {
+        consola.error(
+          `Partner ${partnerId} is not authorized. Please authorize the partner first`
+        );
+        process.exit(1);
+      }
+
+      const BASE_URL = firmCredentials.getHost();
+      const instance = AxiosFactory.createInstance("partner", partnerId);
+      const response = await instance.post(
+        `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
+      );
+
+      firmCredentials.storePartnerApiKey(
+        partnerId,
+        response.data.api_key,
+        partnerCredentials?.name
+      );
+
+      return true;
+    } catch (error) {
+      if (error.response) {
+        consola.error(
+          `Response Status: ${error.response.status} (${error.response.statusText}). An error occurred trying to refresh the partner API key`
+        );
+      }
+      process.exit(1);
+    }
   }
 
   // PRIVATE METHODS
@@ -56,17 +154,13 @@ class SilverfinAuthorizer {
     await open(url);
   }
 
-  static async #promptForAuthCode(firmId) {
+  static async #promptForAuthCode() {
     try {
       consola.log("Insert your credentials...");
       const authCode = prompt("Enter your API authorization code: ", {
         echo: "*",
       });
-
-      const tokens = await this.#getFirmAccessToken(firmId, authCode);
-      if (tokens) {
-        consola.success("Authentication successful");
-      }
+      return authCode.trim();
     } catch (error) {
       consola.error(error);
       process.exit(1);
@@ -80,15 +174,12 @@ class SilverfinAuthorizer {
       const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
       const SF_API_CLIENT_ID = process.env.SF_API_CLIENT_ID;
       const SF_API_SECRET = process.env.SF_API_SECRET;
-      let requestDetails = {
-        method: "POST",
-        url: `${this.BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`,
-      };
-      const response = await axios(requestDetails);
+      const url = `${this.BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`;
+
+      const instance = AxiosFactory.createAuthInstanceForFirm(firmId);
+      const response = await instance.post(url);
 
       firmCredentials.storeNewTokenPair(firmId, response.data);
-
-      await this.#getFirmName(firmId);
 
       return true;
     } catch (error) {
@@ -110,7 +201,8 @@ class SilverfinAuthorizer {
    */
   static async #getFirmName(firmId) {
     try {
-      const response = await axios.get(`/user/firm`);
+      const instance = AxiosFactory.createInstance("firm", firmId);
+      const response = await instance.get(`/user/firm`);
       if (response && response.data) {
         firmCredentials.storeFirmName(firmId, response.data.name);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.28.0",
+  "version": "1.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.28.0",
+      "version": "1.29.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.28.1",
+  "version": "1.29.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/api/silverfinAuthorizer.test.js
+++ b/tests/lib/api/silverfinAuthorizer.test.js
@@ -1,5 +1,5 @@
 const { firmCredentials } = require("../../../lib/api/firmCredentials");
-const axios = require("axios");
+const { AxiosFactory } = require("../../../lib/api/axiosFactory");
 const open = require("open");
 const { consola } = require("consola");
 
@@ -20,9 +20,17 @@ jest.mock("../../../lib/api/firmCredentials", () => ({
   },
 }));
 
-jest.mock("axios");
+jest.mock("../../../lib/api/axiosFactory", () => ({
+  AxiosFactory: {
+    createInstance: jest.fn(),
+    createAuthInstanceForFirm: jest.fn(),
+  },
+}));
+
 jest.mock("open");
 jest.mock("consola");
+
+let mockAxiosInstance;
 
 describe("SilverfinAuthorizer", () => {
   let exitSpy;
@@ -41,6 +49,12 @@ describe("SilverfinAuthorizer", () => {
       name: "Test Firm",
     },
   };
+  const mockPartnerId = "500";
+  const mockPartnerStoredToken = {
+    id: 500,
+    name: "Partner-Name",
+    token: "stored-token",
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -55,8 +69,14 @@ describe("SilverfinAuthorizer", () => {
       .mockReturnValueOnce(mockAuthCode); // Second prompt for auth code
 
     // Mock axios responses
-    axios.mockResolvedValueOnce(mockTokenResponse); // For token request
-    axios.get.mockResolvedValueOnce(mockFirmResponse); // For firm name request
+    mockAxiosInstance = {
+      post: jest.fn(),
+      get: jest.fn(),
+    };
+    mockAxiosInstance.post.mockResolvedValue(mockTokenResponse);
+    mockAxiosInstance.get.mockResolvedValue(mockFirmResponse);
+    AxiosFactory.createInstance.mockReturnValue(mockAxiosInstance);
+    AxiosFactory.createAuthInstanceForFirm.mockReturnValue(mockAxiosInstance);
 
     // Mock process.exit
     exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
@@ -87,13 +107,15 @@ describe("SilverfinAuthorizer", () => {
         expect.stringContaining("api.test.com/f/123/oauth/authorize")
       );
 
-      expect(axios).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "POST",
-          url: expect.stringContaining("api.test.com/f/123/oauth/token"),
-        })
+      expect(AxiosFactory.createAuthInstanceForFirm).toHaveBeenCalledWith(
+        mockFirmId
       );
-      expect(axios.get).toHaveBeenCalledWith("/user/firm");
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        expect.stringContaining("api.test.com/f/123/oauth/token")
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user/firm");
 
       expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
         mockFirmId,
@@ -102,91 +124,239 @@ describe("SilverfinAuthorizer", () => {
 
       expect(consola.error).not.toHaveBeenCalled();
     });
-  });
 
-  it("should succesfully store new tokens when they exist", async () => {
-    await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+    it("should succesfully store new tokens when they exist", async () => {
+      await SilverfinAuthorizer.authorizeFirm(mockFirmId);
 
-    expect(open).toHaveBeenCalledWith(
-      expect.stringContaining("api.test.com/f/123/oauth/authorize")
-    );
+      expect(open).toHaveBeenCalledWith(
+        expect.stringContaining("api.test.com/f/123/oauth/authorize")
+      );
 
-    expect(axios).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "POST",
-        url: expect.stringContaining("api.test.com/f/123/oauth/token"),
-      })
-    );
-    expect(axios.get).toHaveBeenCalledWith("/user/firm");
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        expect.stringContaining("api.test.com/f/123/oauth/token")
+      );
 
-    expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-      mockFirmId,
-      mockTokenResponse.data
-    );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user/firm");
 
-    expect(consola.error).not.toHaveBeenCalled();
-  });
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+        mockFirmId,
+        mockTokenResponse.data
+      );
 
-  it("should handle missing firm id", async () => {
-    mockPrompt.mockReset();
-    mockPrompt.mockReturnValueOnce(""); // First prompt for firm ID
-
-    await expect(async () => {
-      await SilverfinAuthorizer.authorizeFirm();
-    }).rejects.toThrow("Process.exit called with code 1");
-
-    expect(mockPrompt).toHaveBeenNthCalledWith(1, "Enter the firm ID: ");
-
-    expect(open).not.toHaveBeenCalled();
-
-    expect(axios).not.toHaveBeenCalled();
-
-    expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
-
-    expect(consola.error).toHaveBeenCalledWith(
-      "Firm ID is missing. Please provide a valid one."
-    );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it("should handle response errors", async () => {
-    axios.mockReset();
-    axios.mockRejectedValueOnce({
-      response: {
-        status: 400,
-        statusText: "Bad Request",
-        data: {
-          error_description:
-            "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
-        },
-      },
+      expect(consola.error).not.toHaveBeenCalled();
     });
 
-    await expect(async () => {
+    it("should raise an error when firm id is missing", async () => {
+      mockPrompt.mockReset();
+      mockPrompt.mockReturnValueOnce(""); // First prompt for firm ID
+
+      await expect(async () => {
+        await SilverfinAuthorizer.authorizeFirm();
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(mockPrompt).toHaveBeenNthCalledWith(1, "Enter the firm ID: ");
+
+      expect(open).not.toHaveBeenCalled();
+
+      expect(AxiosFactory.createAuthInstanceForFirm).not.toHaveBeenCalled();
+      expect(AxiosFactory.createInstance).not.toHaveBeenCalled();
+
+      expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Firm ID is missing. Please provide a valid one."
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle response errors", async () => {
+      mockAxiosInstance.post.mockReset();
+      mockAxiosInstance.post.mockRejectedValueOnce({
+        response: {
+          status: 400,
+          statusText: "Bad Request",
+          data: {
+            error_description:
+              "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+          },
+        },
+      });
+
+      await expect(async () => {
+        await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Response Status: 400 (Bad Request)"
+      );
+      expect(consola.error).toHaveBeenCalledWith(
+        'Error description: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."'
+      );
+
+      expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+    });
+
+    it("should not raise errors when getting the firm name fails", async () => {
+      mockAxiosInstance.get.mockReset();
+      mockAxiosInstance.get.mockRejectedValueOnce(
+        new Error("Failed to get firm name")
+      );
+
       await SilverfinAuthorizer.authorizeFirm(mockFirmId);
-    }).rejects.toThrow("Process.exit called with code 1");
 
-    expect(consola.error).toHaveBeenCalledWith(
-      "Response Status: 400 (Bad Request)"
-    );
-    expect(consola.error).toHaveBeenCalledWith(
-      'Error description: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."'
-    );
+      expect(consola.error).not.toHaveBeenCalled();
 
-    expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+        mockFirmId,
+        mockTokenResponse.data
+      );
+    });
   });
 
-  it("should not raise errors when getting the firm name fails", async () => {
-    axios.get.mockReset();
-    axios.get.mockRejectedValueOnce(new Error("Failed to get firm name"));
+  describe("refreshFirm", () => {
+    it("should store provided tokens", async () => {
+      const mockTokenPair = {
+        accessToken: "stored-access",
+        refreshToken: "stored-refresh",
+      };
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
 
-    await SilverfinAuthorizer.authorizeFirm(mockFirmId);
+      await SilverfinAuthorizer.refreshFirm(mockFirmId);
 
-    expect(consola.error).not.toHaveBeenCalled();
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        "https://api.test.com/f/123/oauth/token",
+        {
+          client_id: "test_client_id",
+          client_secret: "test_secret",
+          redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+          grant_type: "refresh_token",
+          refresh_token: "stored-refresh",
+          access_token: "stored-access",
+        }
+      );
 
-    expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-      mockFirmId,
-      mockTokenResponse.data
-    );
+      expect(consola.error).not.toHaveBeenCalled();
+
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
+        mockFirmId,
+        mockTokenResponse.data
+      );
+    });
+
+    it("should raise an error when there are no previous tokens", async () => {
+      firmCredentials.getTokenPair.mockReturnValue(null);
+
+      await expect(async () => {
+        await SilverfinAuthorizer.refreshFirm(mockFirmId);
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Firm 123 is not authorized. Please authorize the firm first"
+      );
+
+      expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+    });
+
+    it("should handle response errors", async () => {
+      const mockTokenPair = {
+        accessToken: "stored-access",
+        refreshToken: "stored-refresh",
+      };
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+      mockAxiosInstance.post.mockReset();
+      mockAxiosInstance.post.mockRejectedValueOnce({
+        response: {
+          status: 401,
+          statusText: "Unauthorized",
+          data: {
+            error_description: "Invalid refresh token",
+          },
+        },
+      });
+
+      await expect(async () => {
+        await SilverfinAuthorizer.refreshFirm(mockFirmId);
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Response Status: 401 (Unauthorized)",
+        "\nError description: Invalid refresh token",
+        "\nError refreshing the tokens. Try running the authentication process again"
+      );
+
+      expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("refreshPartner", () => {
+    it("should store the new API key", async () => {
+      firmCredentials.getPartnerCredentials.mockReturnValue(
+        mockPartnerStoredToken
+      );
+      const mockTokenResponse = {
+        data: {
+          api_key: "new-api-key",
+        },
+      };
+      mockAxiosInstance.post.mockReset();
+      mockAxiosInstance.post.mockResolvedValueOnce(mockTokenResponse);
+
+      await SilverfinAuthorizer.refreshPartner(mockPartnerId);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        "https://api.test.com/api/partner/v1/refresh_api_key?api_key=stored-token"
+      );
+
+      expect(consola.error).not.toHaveBeenCalled();
+
+      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(
+        mockPartnerId,
+        mockTokenResponse.data.api_key,
+        mockPartnerStoredToken.name
+      );
+    });
+
+    it("should raise an error when there are no previous tokens", async () => {
+      firmCredentials.getPartnerCredentials.mockReturnValue(null);
+
+      await expect(async () => {
+        await SilverfinAuthorizer.refreshPartner("partner_123");
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Partner partner_123 is not authorized. Please authorize the partner first"
+      );
+
+      expect(firmCredentials.storePartnerApiKey).not.toHaveBeenCalled();
+    });
+
+    it("should handle response errors", async () => {
+      firmCredentials.getPartnerCredentials.mockReturnValue(
+        mockPartnerStoredToken
+      );
+      mockAxiosInstance.post.mockReset();
+      mockAxiosInstance.post.mockRejectedValueOnce({
+        response: {
+          status: 401,
+          statusText: "Unauthorized",
+        },
+      });
+
+      await expect(async () => {
+        await SilverfinAuthorizer.refreshPartner(mockPartnerId);
+      }).rejects.toThrow("Process.exit called with code 1");
+
+      expect(consola.error).toHaveBeenCalledWith(
+        "Response Status: 401 (Unauthorized). An error occurred trying to refresh the partner API key"
+      );
+
+      expect(firmCredentials.storePartnerApiKey).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Description

Refactoring with the goal of improving the code quality, by grouping related functionality, in this case refresh credentials methods within the previously created `SilverfinAuthorizer` class, and adding test coverage for the mentioned functionality.

The `SilverfinAuthorizer` class should handle all Authorizations, which includes renewing (refreshing) expired credentials manually.
Also, all axios instances should be generated by `AxiosFactory`, which will handle to add headers if needed (basic auth for stagings, for example) and request interceptors to refresh token on the fly if they have expired.

Considering that all axios instances will be generated by AxiosFactory, there is a new method to create instances dedicated to the authorization process, which does not validate the existence of previous tokens and it does not add any interceptors

## Test

Make sure that the following commands works both in Production and Staging

```
silverfin authorize
silverfin authorize-partner
silverfin config --refresh-token
silverfin config --refresh-partner-token
```

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
