### PR TITLE
Sort liquid tests before running and printing the outcomes

### DIFF
--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -251,7 +251,7 @@ function processTestRunResponse(testRun, previewOnly) {
           )
         );
 
-        const tests = Object.keys(testRun.tests);
+        const tests = Object.keys(testRun.tests).sort();
         tests.forEach((testName) => {
           let testErrorsPresent = checkTestErrorsPresent(
             testName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Liquid tests were not sorted before they were outputted:
![image](https://github.com/user-attachments/assets/cd3233da-1e22-4f02-9f4e-9c7f4b6ca8ca)

Adding the .sort() will make sure that they are always ordered. 

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
