### PR TITLE
Fix create-shared-part --all

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -527,9 +527,7 @@ program
         settings.envId, 
         options.sharedPart);
     } else if (options.all) {
-      toolkit.newAllSharedParts(
-        settings.type, 
-        options.envId);
+      toolkit.newAllSharedParts(settings.type, settings.envId);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

In the CLI, the create all shared parts commands stills uses options while it should use settings.envId

Fixes #161 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [X] Version updated (if needed)
- [ ] Documentation updated (if needed)
