### PR TITLE
Improve --help guidance for account templates and export files

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -138,7 +138,7 @@ program
   .description("Import export file templates")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>", "Import a specific export file by name")
+  .option('-n, --name "<name>"', "Import a specific export file by name | Make sure to always enclose the name in double quotes")
   .option("-i, --id <id>", "Import a specific export file by id")
   .option("-a, --all", "Import all existing export files")
   .option("-e, --existing","Import all export files (already stored in the repository)")
@@ -175,7 +175,7 @@ program
   .description("Update an existing export file template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>", "Specify the export file to be used (mandatory)")
+  .option('-n, --name "<name>"', "Specify the export file to be used (mandatory) | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Update all export files")
   .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
@@ -210,7 +210,7 @@ program
   .description("Create a new export file template")
   .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>","Specify the name of the export file to be created")
+  .option('-n, --name "<name>"', "Specify the name of the export file to be created | Make sure to always enclose the name in double quotes")
   .option("-a, --all","Try to create all export files stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -241,7 +241,7 @@ program
   .description("Import account templates")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>", "Import a specific account template by name")
+  .option('-n, --name "<name>"', "Import a specific account template by name | Make sure to always enclose the name in double quotes")
   .option("-i, --id <id>", "Import a specific account template by id")
   .option("-a, --all", "Import all existing account templates")
   .option("-e, --existing","Import all account templates (already stored in the repository)")
@@ -278,7 +278,7 @@ program
   .description("Update an existing account template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>","Specify the account template to be used (mandatory)")
+  .option('-n, --name "<name>"', "Specify the account template to be used (mandatory) | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Update all account templates")
   .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
@@ -313,7 +313,7 @@ program
   .description("Create a new account template")
   .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
   .option("-p, --partner <partner-id>","Specify the partner to be used")
-  .option("-n, --name <name>","Specify the name of the account template to be created")
+  .option('-n, --name "<name>"', "Specify the name of the account template to be created | Make sure to always enclose the name in double quotes")
   .option("-a, --all","Try to create all account templates stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -798,7 +798,7 @@ program
   .description("Fetch the ID of an export file from Silverfin")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>", "Fetch the export file ID by name")
+  .option('-n, --name "<name>"', "Fetch the export file ID by name | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Fetch the ID for every export file")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
@@ -829,7 +829,7 @@ program
   .description("Fetch the ID of an account template from Silverfin")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-n, --name <name>", "Fetch the account template ID by name")
+  .option('-n, --name "<name>"', "Fetch the account template ID by name | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Fetch the ID for every account template")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,30 +34,18 @@ program
   .description("Import reconciliation templates")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-h, --handle <handle>","Import a specific firm reconciliation by handle")
+  .option("-h, --handle <handle>", "Import a specific firm reconciliation by handle")
   .option("-i, --id <id>", "Import a specific reconciliation by id")
   .option("-a, --all", "Import all reconciliations")
-  .option("-e, --existing","Import all reconciliations (already stored in the repository)")
+  .option("-e, --existing", "Import all reconciliations (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action(async (options) => {
-    const settings = runCommandChecks(
-      ["handle", "id", "all", "existing"],
-      options,
-      firmIdDefault
-    );
+    const settings = runCommandChecks(["handle", "id", "all", "existing"], options, firmIdDefault);
 
     if (options.handle) {
-      toolkit.fetchReconciliationByHandle(
-        settings.type,
-        settings.envId,
-        options.handle
-      );
+      toolkit.fetchReconciliationByHandle(settings.type, settings.envId, options.handle);
     } else if (options.id) {
-      toolkit.fetchReconciliationById(
-        settings.type,
-        settings.envId,
-        options.id
-      );
+      toolkit.fetchReconciliationById(settings.type, settings.envId, options.id);
     } else if (options.all) {
       toolkit.fetchAllReconciliations(settings.type, settings.envId);
     } else if (options.existing) {
@@ -71,9 +59,9 @@ program
   .description("Update an existing reconciliation template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-h, --handle <handle>","Specify the reconcilation to be used (mandatory)")
+  .option("-h, --handle <handle>", "Specify the reconcilation to be used (mandatory)")
   .option("-a, --all", "Update all reconciliations")
-  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
+  .option("-m, --message <message>", "Add a message to Silverfin's changelog (optional)", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -85,18 +73,9 @@ program
     );
 
     if (options.handle) {
-      toolkit.publishReconciliationByHandle(
-        settings.type,
-        settings.envId,
-        options.handle,
-        options.message
-      );
+      toolkit.publishReconciliationByHandle(settings.type, settings.envId, options.handle, options.message);
     } else if (options.all) {
-      toolkit.publishAllReconciliations(
-        settings.type,
-        settings.envId,
-        options.message
-      );
+      toolkit.publishAllReconciliations(settings.type, settings.envId, options.message);
     }
   });
 
@@ -104,10 +83,10 @@ program
 program
   .command("create-reconciliation")
   .description("Create a new reconciliation text")
-  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
-  .option("-p, --partner <partner-id>","Specify the partner to be used")
-  .option("-h, --handle <handle>","Specify the handle of the reconciliation text to be created")
-  .option("-a, --all","Try to create all the reconciliation texts stored in the repository")
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
+  .option("-h, --handle <handle>", "Specify the handle of the reconciliation text to be created")
+  .option("-a, --all", "Try to create all the reconciliation texts stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -116,19 +95,12 @@ program
       firmIdDefault,
       false, // Message required
       true // Confirmation check skipped
-    )
+    );
 
     if (options.handle) {
-      toolkit.newReconciliation(
-        settings.type, 
-        settings.envId,
-        options.handle
-      );
+      toolkit.newReconciliation(settings.type, settings.envId, options.handle);
     } else if (options.all) {
-      toolkit.newAllReconciliations(
-        settings.type,
-        settings.envId,
-      );
+      toolkit.newAllReconciliations(settings.type, settings.envId);
     }
   });
 
@@ -141,27 +113,15 @@ program
   .option('-n, --name "<name>"', "Import a specific export file by name | Make sure to always enclose the name in double quotes")
   .option("-i, --id <id>", "Import a specific export file by id")
   .option("-a, --all", "Import all existing export files")
-  .option("-e, --existing","Import all export files (already stored in the repository)")
+  .option("-e, --existing", "Import all export files (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["name", "id", "all", "existing"],
-      options,
-      firmIdDefault,
-    );
+    const settings = runCommandChecks(["name", "id", "all", "existing"], options, firmIdDefault);
 
     if (options.name) {
-      toolkit.fetchExportFileByName(
-        settings.type,
-        settings.envId,
-        options.name
-      );
+      toolkit.fetchExportFileByName(settings.type, settings.envId, options.name);
     } else if (options.id) {
-      toolkit.fetchExportFileById(
-        settings.type, 
-        settings.envId, 
-        options.id
-      );
+      toolkit.fetchExportFileById(settings.type, settings.envId, options.id);
     } else if (options.all) {
       toolkit.fetchAllExportFiles(settings.type, settings.envId);
     } else if (options.existing) {
@@ -177,7 +137,7 @@ program
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option('-n, --name "<name>"', "Specify the export file to be used (mandatory) | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Update all export files")
-  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
+  .option("-m, --message <message>", "Add a message to Silverfin's changelog (optional)", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -189,18 +149,9 @@ program
     );
 
     if (options.name) {
-      toolkit.publishExportFileByName(
-        settings.type,
-        settings.envId,
-        options.name,
-        options.message
-      );
+      toolkit.publishExportFileByName(settings.type, settings.envId, options.name, options.message);
     } else if (options.all) {
-      toolkit.publishAllExportFiles(
-        settings.type,
-        settings.envId,
-        options.message
-      );
+      toolkit.publishAllExportFiles(settings.type, settings.envId, options.message);
     }
   });
 
@@ -208,10 +159,10 @@ program
 program
   .command("create-export-file")
   .description("Create a new export file template")
-  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option('-n, --name "<name>"', "Specify the name of the export file to be created | Make sure to always enclose the name in double quotes")
-  .option("-a, --all","Try to create all export files stored in the repository")
+  .option("-a, --all", "Try to create all export files stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -222,16 +173,9 @@ program
       true // Confirmation check skipped
     );
     if (options.name) {
-      toolkit.newExportFile(
-        settings.type,
-        settings.envId,
-        options.name
-      );
+      toolkit.newExportFile(settings.type, settings.envId, options.name);
     } else if (options.all) {
-      toolkit.newAllExportFiles(
-        settings.type,
-        settings.envId
-      );
+      toolkit.newAllExportFiles(settings.type, settings.envId);
     }
   });
 
@@ -244,27 +188,15 @@ program
   .option('-n, --name "<name>"', "Import a specific account template by name | Make sure to always enclose the name in double quotes")
   .option("-i, --id <id>", "Import a specific account template by id")
   .option("-a, --all", "Import all existing account templates")
-  .option("-e, --existing","Import all account templates (already stored in the repository)")
+  .option("-e, --existing", "Import all account templates (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["name", "id", "all", "existing"],
-      options,
-      firmIdDefault
-    );
+    const settings = runCommandChecks(["name", "id", "all", "existing"], options, firmIdDefault);
 
     if (options.name) {
-      toolkit.fetchAccountTemplateByName(
-        settings.type,
-        settings.envId,
-        options.name
-      );
+      toolkit.fetchAccountTemplateByName(settings.type, settings.envId, options.name);
     } else if (options.id) {
-      toolkit.fetchAccountTemplateById(
-        settings.type,
-        settings.envId,
-        options.id
-      );
+      toolkit.fetchAccountTemplateById(settings.type, settings.envId, options.id);
     } else if (options.all) {
       toolkit.fetchAllAccountTemplates(settings.type, settings.envId);
     } else if (options.existing) {
@@ -280,7 +212,7 @@ program
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option('-n, --name "<name>"', "Specify the account template to be used (mandatory) | Make sure to always enclose the name in double quotes")
   .option("-a, --all", "Update all account templates")
-  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
+  .option("-m, --message <message>", "Add a message to Silverfin's changelog (optional)", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -292,18 +224,9 @@ program
     );
 
     if (options.name) {
-      toolkit.publishAccountTemplateByName(
-        settings.type,
-        settings.envId,
-        options.name,
-        options.message
-      );
+      toolkit.publishAccountTemplateByName(settings.type, settings.envId, options.name, options.message);
     } else if (options.all) {
-      toolkit.publishAllAccountTemplates(
-        settings.type,
-        settings.envId,
-        options.message
-      );
+      toolkit.publishAllAccountTemplates(settings.type, settings.envId, options.message);
     }
   });
 
@@ -311,10 +234,10 @@ program
 program
   .command("create-account-template")
   .description("Create a new account template")
-  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
-  .option("-p, --partner <partner-id>","Specify the partner to be used")
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option('-n, --name "<name>"', "Specify the name of the account template to be created | Make sure to always enclose the name in double quotes")
-  .option("-a, --all","Try to create all account templates stored in the repository")
+  .option("-a, --all", "Try to create all account templates stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -323,19 +246,12 @@ program
       firmIdDefault,
       false, // Message required
       true // Confirmation check skipped
-    )
+    );
 
     if (options.name) {
-      toolkit.newAccountTemplate(
-        settings.type, 
-        settings.envId, 
-        options.name
-      );
+      toolkit.newAccountTemplate(settings.type, settings.envId, options.name);
     } else if (options.all) {
-      toolkit.newAllAccountTemplates(
-        settings.type, 
-        settings.envId, 
-      );
+      toolkit.newAllAccountTemplates(settings.type, settings.envId);
     }
   });
 
@@ -348,27 +264,15 @@ program
   .option("-s, --shared-part <name>", "Import a specific shared part")
   .option("-i, --id <id>", "Import a specific shared part by id")
   .option("-a, --all", "Import all shared parts")
-  .option("-e, --existing","Import all shared parts (already stored in the repository)")
+  .option("-e, --existing", "Import all shared parts (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action(async (options) => {
-    const settings = runCommandChecks(
-      ["sharedPart", "id", "all", "existing"],
-      options,
-      firmIdDefault
-    );
+    const settings = runCommandChecks(["sharedPart", "id", "all", "existing"], options, firmIdDefault);
 
     if (options.sharedPart) {
-      await toolkit.fetchSharedPartByName(
-        settings.type,
-        settings.envId,
-        options.sharedPart
-      );
+      await toolkit.fetchSharedPartByName(settings.type, settings.envId, options.sharedPart);
     } else if (options.id) {
-      await toolkit.fetchSharedPartById(
-        settings.type,
-        settings.envId,
-        options.id
-      );
+      await toolkit.fetchSharedPartById(settings.type, settings.envId, options.id);
     } else if (options.all) {
       await toolkit.fetchAllSharedParts(settings.type, settings.envId);
     } else if (options.existing) {
@@ -382,9 +286,9 @@ program
   .description("Update an existing shared part")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-s, --shared-part <name>","Specify the shared part to be used (mandatory)")
+  .option("-s, --shared-part <name>", "Specify the shared part to be used (mandatory)")
   .option("-a, --all", "Update all shared parts")
-  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
+  .option("-m, --message <message>", "Add a message to Silverfin's changelog (optional)", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -396,18 +300,9 @@ program
     );
 
     if (options.sharedPart) {
-      toolkit.publishSharedPartByName(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.message
-      );
+      toolkit.publishSharedPartByName(settings.type, settings.envId, options.sharedPart, options.message);
     } else if (options.all) {
-      toolkit.publishAllSharedParts(
-        settings.type, 
-        settings.envId, 
-        options.message
-      );
+      toolkit.publishAllSharedParts(settings.type, settings.envId, options.message);
     }
   });
 
@@ -415,10 +310,10 @@ program
 program
   .command("create-shared-part")
   .description("Create a new shared part")
-  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
-  .option("-p, --partner <partner-id>","Specify the partner to be used")
-  .option("-s, --shared-part <name>","Specify the name of the shared part to be created")
-  .option("-a, --all","Try to create all the shared parts stored in the repository")
+  .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
+  .option("-s, --shared-part <name>", "Specify the name of the shared part to be created")
+  .option("-a, --all", "Try to create all the shared parts stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -427,13 +322,10 @@ program
       firmIdDefault,
       false, // Message required
       true // Confirmation check skipped
-    )
+    );
 
     if (options.sharedPart) {
-      toolkit.newSharedPart(
-        settings.type, 
-        settings.envId, 
-        options.sharedPart);
+      toolkit.newSharedPart(settings.type, settings.envId, options.sharedPart);
     } else if (options.all) {
       toolkit.newAllSharedParts(settings.type, settings.envId);
     }
@@ -445,61 +337,29 @@ program
   .description("Add an existing shared part to an existing template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-s, --shared-part <name>",`Specify the shared part to be added (used together with "--handle" or "--export-file")`)
-  .option("-h, --handle <handle>",`Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
-  .option("-e, --export-file <name>",`Specify the export file that needs to be updated (used together with "--shared-part")`)
-  .option("-at, --account-template <name>",`Specify the account template that needs to be updated (used together with "--shared-part")`)
-  .option("-a, --all","Add all shared parts to all templates (based on the config file of shared parts and the handles assigned there to each template)")
-  .option("-f, --force",`Force adding shared parts to all templates, even if they already have it. It can only be used together with "--all" (optional)`,false)
+  .option("-s, --shared-part <name>", `Specify the shared part to be added (used together with "--handle" or "--export-file")`)
+  .option("-h, --handle <handle>", `Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
+  .option("-e, --export-file <name>", `Specify the export file that needs to be updated (used together with "--shared-part")`)
+  .option("-at, --account-template <name>", `Specify the account template that needs to be updated (used together with "--shared-part")`)
+  .option("-a, --all", "Add all shared parts to all templates (based on the config file of shared parts and the handles assigned there to each template)")
+  .option("-f, --force", `Force adding shared parts to all templates, even if they already have it. It can only be used together with "--all" (optional)`, false)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["sharedPart", "all"],
-      options,
-      firmIdDefault,
-    );
+    const settings = runCommandChecks(["sharedPart", "all"], options, firmIdDefault);
 
     if (options.sharedPart) {
-      cliUtils.checkUniqueOption(
-        ["handle", "exportFile", "accountTemplate"],
-        options
-      );
+      cliUtils.checkUniqueOption(["handle", "exportFile", "accountTemplate"], options);
     } else {
-      cliUtils.checkUniqueOption(
-        ["handle", "exportFile", "accountTemplate", "all"],
-        options
-      );
+      cliUtils.checkUniqueOption(["handle", "exportFile", "accountTemplate", "all"], options);
     }
     if (options.handle) {
-      toolkit.addSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.handle,
-        "reconciliationText"
-      );
+      toolkit.addSharedPart(settings.type, settings.envId, options.sharedPart, options.handle, "reconciliationText");
     } else if (options.exportFile) {
-      toolkit.addSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.exportFile,
-        "exportFile"
-      );
+      toolkit.addSharedPart(settings.type, settings.envId, options.sharedPart, options.exportFile, "exportFile");
     } else if (options.accountTemplate) {
-      toolkit.addSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.accountTemplate,
-        "accountTemplate"
-      );
+      toolkit.addSharedPart(settings.type, settings.envId, options.sharedPart, options.accountTemplate, "accountTemplate");
     } else if (options.all) {
-      toolkit.addAllSharedParts(
-        settings.type,
-        settings.envId,
-        options.force
-      );
+      toolkit.addAllSharedParts(settings.type, settings.envId, options.force);
     }
   });
 
@@ -509,101 +369,55 @@ program
   .description("Remove an existing shared part from an existing template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .requiredOption("-s, --shared-part <name>",`Specify the shared part to be removed (mandatory, used together with "--handle" or "--export-file")`)
-  .option("-h, --handle <handle>",`Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
-  .option("-e, --export-file <name>",`Specify the export file that needs to be updated (used together with "--shared-part")`)
-  .option("-at, --account-template <name>",`Specify the account template that needs to be updated (used together with "--shared-part")`)
+  .requiredOption("-s, --shared-part <name>", `Specify the shared part to be removed (mandatory, used together with "--handle" or "--export-file")`)
+  .option("-h, --handle <handle>", `Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
+  .option("-e, --export-file <name>", `Specify the export file that needs to be updated (used together with "--shared-part")`)
+  .option("-at, --account-template <name>", `Specify the account template that needs to be updated (used together with "--shared-part")`)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["handle", "exportFile", "accountTemplate"],
-      options,
-      firmIdDefault,
-    );
+    const settings = runCommandChecks(["handle", "exportFile", "accountTemplate"], options, firmIdDefault);
 
     if (options.handle) {
-      toolkit.removeSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.handle,
-        "reconciliationText"
-      );
+      toolkit.removeSharedPart(settings.type, settings.envId, options.sharedPart, options.handle, "reconciliationText");
     } else if (options.exportFile) {
-      toolkit.removeSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.exportFile,
-        "exportFile"
-      );
+      toolkit.removeSharedPart(settings.type, settings.envId, options.sharedPart, options.exportFile, "exportFile");
     } else if (options.accountTemplate) {
-      toolkit.removeSharedPart(
-        settings.type,
-        settings.envId,
-        options.sharedPart,
-        options.accountTemplate,
-        "accountTemplate"
-      );
+      toolkit.removeSharedPart(settings.type, settings.envId, options.sharedPart, options.accountTemplate, "accountTemplate");
     }
   });
 
 // Run Liquid Test
 program
   .command("run-test")
-  .description(
-    "Run Liquid Tests for a reconciliation template from a YAML file"
-  )
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .requiredOption(
-    "-h, --handle <handle>",
-    "Specify the reconciliation to be used (mandatory)"
-  )
-  .option("-t, --test <test-name>","Specify the name of the test to be run (optional)","")
-  .option("--html-input","Get a static html of the input-view of the template generated with the Liquid Test data (optional)",false)
-  .option("--html-preview","Get a static html of the export-view of the template generated with the Liquid Test data (optional)",false)
-  .option("--preview-only","Skip the checking of the results of the Liquid Test in case you only want to generate a preview template (optional)",false)
-  .option("--status","Only return the status of the test runs as PASSED/FAILED (optional)",false)
+  .description("Run Liquid Tests for a reconciliation template from a YAML file")
+  .requiredOption("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .requiredOption("-h, --handle <handle>", "Specify the reconciliation to be used (mandatory)")
+  .option("-t, --test <test-name>", "Specify the name of the test to be run (optional)", "")
+  .option("--html-input", "Get a static html of the input-view of the template generated with the Liquid Test data (optional)", false)
+  .option("--html-preview", "Get a static html of the export-view of the template generated with the Liquid Test data (optional)", false)
+  .option("--preview-only", "Skip the checking of the results of the Liquid Test in case you only want to generate a preview template (optional)", false)
+  .option("--status", "Only return the status of the test runs as PASSED/FAILED (optional)", false)
   .action((options) => {
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.status) {
-      liquidTestRunner.runTestsStatusOnly(
-        options.firm,
-        options.handle,
-        options.test
-      );
+      liquidTestRunner.runTestsStatusOnly(options.firm, options.handle, options.test);
     } else {
       if (options.previewOnly && !options.htmlInput && !options.htmlPreview) {
-        consola.info(
-          `When using "--preview-only" you need to specify at least one of the following options: "--html-input", "--html-preview"`
-        );
+        consola.info(`When using "--preview-only" you need to specify at least one of the following options: "--html-input", "--html-preview"`);
         process.exit(1);
       }
 
-      liquidTestRunner.runTestsWithOutput(
-        options.firm,
-        options.handle,
-        options.test,
-        options.previewOnly,
-        options.htmlInput,
-        options.htmlPreview
-      );
+      liquidTestRunner.runTestsWithOutput(options.firm, options.handle, options.test, options.previewOnly, options.htmlInput, options.htmlPreview);
     }
   });
 
 // Create Liquid Test
 program
   .command("create-test")
-  .description(
-    "Create Liquid Test (YAML file) from an existing reconciliation in a company file"
-  )
+  .description("Create Liquid Test (YAML file) from an existing reconciliation in a company file")
   .requiredOption("-u, --url <url>", "Specify the url to be used (mandatory)")
-  .option("--unreconciled","By default, the reconciled status will be set as true. Add this option to set it as false (optional)")
-  .option("-t, --test <test-name>","Establish the name of the test. It should have no white-spaces (e.g. test_name)(optional)")
+  .option("--unreconciled", "By default, the reconciled status will be set as true. Add this option to set it as false (optional)")
+  .option("-t, --test <test-name>", "Establish the name of the test. It should have no white-spaces (e.g. test_name)(optional)")
   .action((options) => {
     reconciledStatus = options.unreconciled ? false : true;
     let testName = options.test ? options.test : "test_name";
@@ -622,15 +436,11 @@ program
 program
   .command("authorize-partner")
   .description("Authorize a Silverfin partner environment by entering the API key and partner information")
-  .requiredOption("-i, --partner-id <partner-id>","Specify the partner environment id to be added")
-  .requiredOption("-k, --api-key <api-key>","Specify the api key of the partner environment to be added")
-  .option("-n, --partner-name <partner-name>","Specify the partner environment name to be added")
+  .requiredOption("-i, --partner-id <partner-id>", "Specify the partner environment id to be added")
+  .requiredOption("-k, --api-key <api-key>", "Specify the api key of the partner environment to be added")
+  .option("-n, --partner-name <partner-name>", "Specify the partner environment name to be added")
   .action((options) => {
-    const stored = firmCredentials.storePartnerApiKey(
-      options.partnerId,
-      options.apiKey,
-      options.partnerName
-    );
+    const stored = firmCredentials.storePartnerApiKey(options.partnerId, options.apiKey, options.partnerName);
 
     if (stored) {
       consola.success("Partner API key succesfully stored");
@@ -650,50 +460,16 @@ program
 program
   .command("config")
   .description("Configuration options")
-  .option("-s, --set-firm <firmId>","Store a firm id to use it as default (setting a firm id will overwrite any existing data)")
+  .option("-s, --set-firm <firmId>", "Store a firm id to use it as default (setting a firm id will overwrite any existing data)")
   .option("-g, --get-firm", "Check if there is any firm id already stored")
   .option("-l, --list-all", "List all the firm IDs stored")
-  .addOption(
-    new Option(
-      "-n, --update-name [firmId]",
-      "Update the name of the firm (fetched from Silverfin)"
-    ).preset(firmIdDefault)
-  )
-  .addOption(
-    new Option(
-      "-r, --refresh-token [firmId]",
-      "Get a new pair of credentials using the stored refresh token"
-    ).preset(firmIdDefault)
-  )
-  .addOption(
-    new Option(
-      "--refresh-partner-token <partnerId>",
-      "Get a new partner api key using the stored api key"
-    )
-  )
-  .addOption(
-    new Option(
-      "--set-host <host>",
-      "Set a custom host for the Silverfin API (e.g. https://live.getsilverfin.com)"
-    )
-  )
-  .addOption(
-    new Option("--get-host", "Get the current host for the Silverfin API")
-  )
+  .addOption(new Option("-n, --update-name [firmId]", "Update the name of the firm (fetched from Silverfin)").preset(firmIdDefault))
+  .addOption(new Option("-r, --refresh-token [firmId]", "Get a new pair of credentials using the stored refresh token").preset(firmIdDefault))
+  .addOption(new Option("--refresh-partner-token <partnerId>", "Get a new partner api key using the stored api key"))
+  .addOption(new Option("--set-host <host>", "Set a custom host for the Silverfin API (e.g. https://live.getsilverfin.com)"))
+  .addOption(new Option("--get-host", "Get the current host for the Silverfin API"))
   .action(async (options) => {
-    cliUtils.checkUniqueOption(
-      [
-        "setFirm",
-        "getFirm",
-        "listAll",
-        "updateName",
-        "refreshToken",
-        "refreshPartnerToken",
-        "setHost",
-        "getHost",
-      ],
-      options
-    );
+    cliUtils.checkUniqueOption(["setFirm", "getFirm", "listAll", "updateName", "refreshToken", "refreshPartnerToken", "setHost", "getHost"], options);
     if (options.setFirm) {
       firmCredentials.setDefaultFirmId(options.setFirm);
       const currentDirectory = path.basename(process.cwd());
@@ -711,20 +487,14 @@ program
       const firms = firmCredentials.listAuthorizedFirms() || [];
       if (firms) {
         consola.info("List of authorized firms");
-        firms.forEach((element) =>
-          consola.log(`- ${element[0]}${element[1] ? ` (${element[1]})` : ""}`)
-        );
+        firms.forEach((element) => consola.log(`- ${element[0]}${element[1] ? ` (${element[1]})` : ""}`));
       }
 
       const partners = firmCredentials.listAuthorizedPartners();
       if (partners.length > 0) {
         consola.log("\n");
         consola.info("List of authorized partners");
-        partners.forEach((element) =>
-          consola.log(
-            `- ${element.id}${element.name ? ` (${element.name})` : ""}`
-          )
-        );
+        partners.forEach((element) => consola.log(`- ${element.id}${element.name ? ` (${element.name})` : ""}`));
       }
     }
     if (options.updateName) {
@@ -736,20 +506,14 @@ program
       const refreshedTokens = await SF.refreshFirmTokens(options.refreshToken);
 
       if (refreshedTokens) {
-        consola.success(
-          `Tokens refreshed for firm ID: ${options.refreshToken}`
-        );
+        consola.success(`Tokens refreshed for firm ID: ${options.refreshToken}`);
       }
     }
     if (options.refreshPartnerToken) {
-      const refreshedTokens = await SF.refreshPartnerToken(
-        options.refreshPartnerToken
-      );
+      const refreshedTokens = await SF.refreshPartnerToken(options.refreshPartnerToken);
 
       if (refreshedTokens) {
-        consola.success(
-          `Partner API key refreshed for partner ID: ${options.refreshPartnerToken}`
-        );
+        consola.success(`Partner API key refreshed for partner ID: ${options.refreshPartnerToken}`);
       }
     }
     if (options.setHost) {
@@ -771,25 +535,12 @@ program
   .option("-a, --all", "Fetch the ID for every reconciliation")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["handle", "all"],
-      options,
-      firmIdDefault
-    );
+    const settings = runCommandChecks(["handle", "all"], options, firmIdDefault);
 
     if (options.handle) {
-      toolkit.getTemplateId(
-        settings.type,
-        settings.envId,
-        "reconciliationText",
-        options.handle
-      );
+      toolkit.getTemplateId(settings.type, settings.envId, "reconciliationText", options.handle);
     } else if (options.all) {
-      toolkit.getAllTemplatesId(
-        settings.type,
-        settings.envId,
-        "reconciliationText"
-      );
+      toolkit.getAllTemplatesId(settings.type, settings.envId, "reconciliationText");
     }
   });
 
@@ -802,25 +553,12 @@ program
   .option("-a, --all", "Fetch the ID for every export file")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["name", "all"],
-      options,
-      firmIdDefault,
-    );
+    const settings = runCommandChecks(["name", "all"], options, firmIdDefault);
 
     if (options.name) {
-      toolkit.getTemplateId(
-        settings.type,
-        settings.envId,
-        "exportFile",
-        options.name
-      );
+      toolkit.getTemplateId(settings.type, settings.envId, "exportFile", options.name);
     } else if (options.all) {
-      toolkit.getAllTemplatesId(
-        settings.type, 
-        settings.envId, 
-        "exportFile"
-      );
+      toolkit.getAllTemplatesId(settings.type, settings.envId, "exportFile");
     }
   });
 
@@ -836,18 +574,9 @@ program
     const settings = runCommandChecks(["name", "all"], options, firmIdDefault);
 
     if (options.name) {
-      toolkit.getTemplateId(
-        settings.type,
-        settings.envId,
-        "accountTemplate",
-        options.name
-      );
+      toolkit.getTemplateId(settings.type, settings.envId, "accountTemplate", options.name);
     } else if (options.all) {
-      toolkit.getAllTemplatesId(
-        settings.type,
-        settings.envId,
-        "accountTemplate"
-      );
+      toolkit.getAllTemplatesId(settings.type, settings.envId, "accountTemplate");
     }
   });
 
@@ -860,19 +589,10 @@ program
   .option("-a, --all", "Fetch the ID for every shared part")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    const settings = runCommandChecks(
-      ["sharedPart", "all"],
-      options,
-      firmIdDefault
-    );
+    const settings = runCommandChecks(["sharedPart", "all"], options, firmIdDefault);
 
     if (options.sharedPart) {
-      toolkit.getTemplateId(
-        settings.type,
-        settings.envId,
-        "sharedPart",
-        options.sharedPart
-      );
+      toolkit.getTemplateId(settings.type, settings.envId, "sharedPart", options.sharedPart);
     } else if (options.all) {
       toolkit.getAllTemplatesId(settings.type, settings.envId, "sharedPart");
     }
@@ -882,11 +602,11 @@ program
 program
   .command("development-mode")
   .description("Development mode - Watch for changes in files")
-  .requiredOption("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
-  .option("-h, --handle <handle>","Watch for changes in liquid and yaml files related to the reconcilation mentioned. Run a new Liquid Test on each save")
-  .option("-u, --update-templates","Watch for changes in any liquid file. Publish the new code of the template into the Platform on each save")
-  .option("-t, --test <test-name>",`Specify the name of the test to be run (optional). It has to be used together with "--handle"`,"")
-  .option("--html",`Get a html file of the template's input-view generated with the Liquid Test information (optional). It has to be used together with "--handle"`,false)
+  .requiredOption("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
+  .option("-h, --handle <handle>", "Watch for changes in liquid and yaml files related to the reconcilation mentioned. Run a new Liquid Test on each save")
+  .option("-u, --update-templates", "Watch for changes in any liquid file. Publish the new code of the template into the Platform on each save")
+  .option("-t, --test <test-name>", `Specify the name of the test to be run (optional). It has to be used together with "--handle"`, "")
+  .option("--html", `Get a html file of the template's input-view generated with the Liquid Test information (optional). It has to be used together with "--handle"`, false)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
@@ -896,12 +616,7 @@ program
       cliUtils.promptConfirmation();
     }
     if (options.handle) {
-      devMode.watchLiquidTest(
-        options.firm,
-        options.handle,
-        options.test,
-        options.html
-      );
+      devMode.watchLiquidTest(options.firm, options.handle, options.test, options.html);
     }
     if (options.updateTemplates) {
       devMode.watchLiquidFiles(options.firm);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,16 +34,10 @@ program
   .description("Import reconciliation templates")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option(
-    "-h, --handle <handle>",
-    "Import a specific firm reconciliation by handle"
-  )
+  .option("-h, --handle <handle>","Import a specific firm reconciliation by handle")
   .option("-i, --id <id>", "Import a specific reconciliation by id")
   .option("-a, --all", "Import all reconciliations")
-  .option(
-    "-e, --existing",
-    "Import all reconciliations (already stored in the repository)"
-  )
+  .option("-e, --existing","Import all reconciliations (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action(async (options) => {
     const settings = runCommandChecks(
@@ -77,16 +71,9 @@ program
   .description("Update an existing reconciliation template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option(
-    "-h, --handle <handle>",
-    "Specify the reconcilation to be used (mandatory)"
-  )
+  .option("-h, --handle <handle>","Specify the reconcilation to be used (mandatory)")
   .option("-a, --all", "Update all reconciliations")
-  .option(
-    "-m, --message <message>",
-    "Add a message to Silverfin's changelog (optional)",
-    undefined
-  )
+  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -117,23 +104,10 @@ program
 program
   .command("create-reconciliation")
   .description("Create a new reconciliation text")
-  .option(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option(
-    "-p, --partner <partner-id>",
-    "Specify the partner to be used"
-  )
-  .option(
-    "-h, --handle <handle>",
-    "Specify the handle of the reconciliation text to be created"
-  )
-  .option(
-    "-a, --all",
-    "Try to create all the reconciliation texts stored in the repository"
-  )
+  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-p, --partner <partner-id>","Specify the partner to be used")
+  .option("-h, --handle <handle>","Specify the handle of the reconciliation text to be created")
+  .option("-a, --all","Try to create all the reconciliation texts stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -167,10 +141,7 @@ program
   .option("-n, --name <name>", "Import a specific export file by name")
   .option("-i, --id <id>", "Import a specific export file by id")
   .option("-a, --all", "Import all existing export files")
-  .option(
-    "-e, --existing",
-    "Import all export files (already stored in the repository)"
-  )
+  .option("-e, --existing","Import all export files (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     const settings = runCommandChecks(
@@ -206,11 +177,7 @@ program
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
   .option("-n, --name <name>", "Specify the export file to be used (mandatory)")
   .option("-a, --all", "Update all export files")
-  .option(
-    "-m, --message <message>",
-    "Add a message to Silverfin's changelog (optional)",
-    undefined
-  )
+  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -241,23 +208,10 @@ program
 program
   .command("create-export-file")
   .description("Create a new export file template")
-  .option(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option(
-    "-p, --partner <partner-id>", 
-    "Specify the partner to be used"
-  )
-  .option(
-    "-n, --name <name>",
-    "Specify the name of the export file to be created"
-  )
-  .option(
-    "-a, --all",
-    "Try to create all export files stored in the repository"
-  )
+  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-p, --partner <partner-id>", "Specify the partner to be used")
+  .option("-n, --name <name>","Specify the name of the export file to be created")
+  .option("-a, --all","Try to create all export files stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -290,10 +244,7 @@ program
   .option("-n, --name <name>", "Import a specific account template by name")
   .option("-i, --id <id>", "Import a specific account template by id")
   .option("-a, --all", "Import all existing account templates")
-  .option(
-    "-e, --existing",
-    "Import all account templates (already stored in the repository)"
-  )
+  .option("-e, --existing","Import all account templates (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     const settings = runCommandChecks(
@@ -327,16 +278,9 @@ program
   .description("Update an existing account template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option(
-    "-n, --name <name>",
-    "Specify the account template to be used (mandatory)"
-  )
+  .option("-n, --name <name>","Specify the account template to be used (mandatory)")
   .option("-a, --all", "Update all account templates")
-  .option(
-    "-m, --message <message>",
-    "Add a message to Silverfin's changelog (optional)",
-    undefined
-  )
+  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -367,23 +311,10 @@ program
 program
   .command("create-account-template")
   .description("Create a new account template")
-  .option(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option(
-    "-p, --partner <partner-id>",
-    "Specify the partner to be used"
-  )
-  .option(
-    "-n, --name <name>",
-    "Specify the name of the account template to be created"
-  )
-  .option(
-    "-a, --all",
-    "Try to create all account templates stored in the repository"
-  )
+  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-p, --partner <partner-id>","Specify the partner to be used")
+  .option("-n, --name <name>","Specify the name of the account template to be created")
+  .option("-a, --all","Try to create all account templates stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -417,10 +348,7 @@ program
   .option("-s, --shared-part <name>", "Import a specific shared part")
   .option("-i, --id <id>", "Import a specific shared part by id")
   .option("-a, --all", "Import all shared parts")
-  .option(
-    "-e, --existing",
-    "Import all shared parts (already stored in the repository)"
-  )
+  .option("-e, --existing","Import all shared parts (already stored in the repository)")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action(async (options) => {
     const settings = runCommandChecks(
@@ -454,16 +382,9 @@ program
   .description("Update an existing shared part")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option(
-    "-s, --shared-part <name>",
-    "Specify the shared part to be used (mandatory)"
-  )
+  .option("-s, --shared-part <name>","Specify the shared part to be used (mandatory)")
   .option("-a, --all", "Update all shared parts")
-  .option(
-    "-m, --message <message>",
-    "Add a message to Silverfin's changelog (optional)",
-    undefined
-  )
+  .option("-m, --message <message>","Add a message to Silverfin's changelog (optional)",undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
@@ -494,23 +415,10 @@ program
 program
   .command("create-shared-part")
   .description("Create a new shared part")
-  .option(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option(
-    "-p, --partner <partner-id>",
-    "Specify the partner to be used"
-  )
-  .option(
-    "-s, --shared-part <name>",
-    "Specify the name of the shared part to be created"
-  )
-  .option(
-    "-a, --all",
-    "Try to create all the shared parts stored in the repository"
-  )
+  .option("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-p, --partner <partner-id>","Specify the partner to be used")
+  .option("-s, --shared-part <name>","Specify the name of the shared part to be created")
+  .option("-a, --all","Try to create all the shared parts stored in the repository")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
@@ -537,31 +445,12 @@ program
   .description("Add an existing shared part to an existing template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option(
-    "-s, --shared-part <name>",
-    `Specify the shared part to be added (used together with "--handle" or "--export-file")`
-  )
-  .option(
-    "-h, --handle <handle>",
-    `Specify the reconciliation that needs to be updated (used together with "--shared-part")`
-  )
-  .option(
-    "-e, --export-file <name>",
-    `Specify the export file that needs to be updated (used together with "--shared-part")`
-  )
-  .option(
-    "-at, --account-template <name>",
-    `Specify the account template that needs to be updated (used together with "--shared-part")`
-  )
-  .option(
-    "-a, --all",
-    "Add all shared parts to all templates (based on the config file of shared parts and the handles assigned there to each template)"
-  )
-  .option(
-    "-f, --force",
-    `Force adding shared parts to all templates, even if they already have it. It can only be used together with "--all" (optional)`,
-    false
-  )
+  .option("-s, --shared-part <name>",`Specify the shared part to be added (used together with "--handle" or "--export-file")`)
+  .option("-h, --handle <handle>",`Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
+  .option("-e, --export-file <name>",`Specify the export file that needs to be updated (used together with "--shared-part")`)
+  .option("-at, --account-template <name>",`Specify the account template that needs to be updated (used together with "--shared-part")`)
+  .option("-a, --all","Add all shared parts to all templates (based on the config file of shared parts and the handles assigned there to each template)")
+  .option("-f, --force",`Force adding shared parts to all templates, even if they already have it. It can only be used together with "--all" (optional)`,false)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     const settings = runCommandChecks(
@@ -620,22 +509,10 @@ program
   .description("Remove an existing shared part from an existing template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .requiredOption(
-    "-s, --shared-part <name>",
-    `Specify the shared part to be removed (mandatory, used together with "--handle" or "--export-file")`
-  )
-  .option(
-    "-h, --handle <handle>",
-    `Specify the reconciliation that needs to be updated (used together with "--shared-part")`
-  )
-  .option(
-    "-e, --export-file <name>",
-    `Specify the export file that needs to be updated (used together with "--shared-part")`
-  )
-  .option(
-    "-at, --account-template <name>",
-    `Specify the account template that needs to be updated (used together with "--shared-part")`
-  )
+  .requiredOption("-s, --shared-part <name>",`Specify the shared part to be removed (mandatory, used together with "--handle" or "--export-file")`)
+  .option("-h, --handle <handle>",`Specify the reconciliation that needs to be updated (used together with "--shared-part")`)
+  .option("-e, --export-file <name>",`Specify the export file that needs to be updated (used together with "--shared-part")`)
+  .option("-at, --account-template <name>",`Specify the account template that needs to be updated (used together with "--shared-part")`)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     const settings = runCommandChecks(
@@ -686,31 +563,11 @@ program
     "-h, --handle <handle>",
     "Specify the reconciliation to be used (mandatory)"
   )
-  .option(
-    "-t, --test <test-name>",
-    "Specify the name of the test to be run (optional)",
-    ""
-  )
-  .option(
-    "--html-input",
-    "Get a static html of the input-view of the template generated with the Liquid Test data (optional)",
-    false
-  )
-  .option(
-    "--html-preview",
-    "Get a static html of the export-view of the template generated with the Liquid Test data (optional)",
-    false
-  )
-  .option(
-    "--preview-only",
-    "Skip the checking of the results of the Liquid Test in case you only want to generate a preview template (optional)",
-    false
-  )
-  .option(
-    "--status",
-    "Only return the status of the test runs as PASSED/FAILED (optional)",
-    false
-  )
+  .option("-t, --test <test-name>","Specify the name of the test to be run (optional)","")
+  .option("--html-input","Get a static html of the input-view of the template generated with the Liquid Test data (optional)",false)
+  .option("--html-preview","Get a static html of the export-view of the template generated with the Liquid Test data (optional)",false)
+  .option("--preview-only","Skip the checking of the results of the Liquid Test in case you only want to generate a preview template (optional)",false)
+  .option("--status","Only return the status of the test runs as PASSED/FAILED (optional)",false)
   .action((options) => {
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);
     if (options.status) {
@@ -745,14 +602,8 @@ program
     "Create Liquid Test (YAML file) from an existing reconciliation in a company file"
   )
   .requiredOption("-u, --url <url>", "Specify the url to be used (mandatory)")
-  .option(
-    "--unreconciled",
-    "By default, the reconciled status will be set as true. Add this option to set it as false (optional)"
-  )
-  .option(
-    "-t, --test <test-name>",
-    "Establish the name of the test. It should have no white-spaces (e.g. test_name)(optional)"
-  )
+  .option("--unreconciled","By default, the reconciled status will be set as true. Add this option to set it as false (optional)")
+  .option("-t, --test <test-name>","Establish the name of the test. It should have no white-spaces (e.g. test_name)(optional)")
   .action((options) => {
     reconciledStatus = options.unreconciled ? false : true;
     let testName = options.test ? options.test : "test_name";
@@ -770,21 +621,10 @@ program
 // Authorize PARTNER
 program
   .command("authorize-partner")
-  .description(
-    "Authorize a Silverfin partner environment by entering the API key and partner information"
-  )
-  .requiredOption(
-    "-i, --partner-id <partner-id>",
-    "Specify the partner environment id to be added"
-  )
-  .requiredOption(
-    "-k, --api-key <api-key>",
-    "Specify the api key of the partner environment to be added"
-  )
-  .option(
-    "-n, --partner-name <partner-name>",
-    "Specify the partner environment name to be added"
-  )
+  .description("Authorize a Silverfin partner environment by entering the API key and partner information")
+  .requiredOption("-i, --partner-id <partner-id>","Specify the partner environment id to be added")
+  .requiredOption("-k, --api-key <api-key>","Specify the api key of the partner environment to be added")
+  .option("-n, --partner-name <partner-name>","Specify the partner environment name to be added")
   .action((options) => {
     const stored = firmCredentials.storePartnerApiKey(
       options.partnerId,
@@ -801,9 +641,7 @@ program
 program
   .command("stats")
   .description("Generate an overview with some statistics")
-  .requiredOption(
-    "-s, --since <date>, Specify the date which is going to be used to filter the data from (format: YYYY-MM-DD) (mandatory)"
-  )
+  .requiredOption("-s, --since <date>, Specify the date which is going to be used to filter the data from (format: YYYY-MM-DD) (mandatory)")
   .action((options) => {
     stats.generateOverview(options.since);
   });
@@ -812,10 +650,7 @@ program
 program
   .command("config")
   .description("Configuration options")
-  .option(
-    "-s, --set-firm <firmId>",
-    "Store a firm id to use it as default (setting a firm id will overwrite any existing data)"
-  )
+  .option("-s, --set-firm <firmId>","Store a firm id to use it as default (setting a firm id will overwrite any existing data)")
   .option("-g, --get-firm", "Check if there is any firm id already stored")
   .option("-l, --list-all", "List all the firm IDs stored")
   .addOption(
@@ -1047,29 +882,11 @@ program
 program
   .command("development-mode")
   .description("Development mode - Watch for changes in files")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option(
-    "-h, --handle <handle>",
-    "Watch for changes in liquid and yaml files related to the reconcilation mentioned. Run a new Liquid Test on each save"
-  )
-  .option(
-    "-u, --update-templates",
-    "Watch for changes in any liquid file. Publish the new code of the template into the Platform on each save"
-  )
-  .option(
-    "-t, --test <test-name>",
-    `Specify the name of the test to be run (optional). It has to be used together with "--handle"`,
-    ""
-  )
-  .option(
-    "--html",
-    `Get a html file of the template's input-view generated with the Liquid Test information (optional). It has to be used together with "--handle"`,
-    false
-  )
+  .requiredOption("-f, --firm <firm-id>","Specify the firm to be used",firmIdDefault)
+  .option("-h, --handle <handle>","Watch for changes in liquid and yaml files related to the reconcilation mentioned. Run a new Liquid Test on each save")
+  .option("-u, --update-templates","Watch for changes in any liquid file. Publish the new code of the template into the Platform on each save")
+  .option("-t, --test <test-name>",`Specify the name of the test to be run (optional). It has to be used together with "--handle"`,"")
+  .option("--html",`Get a html file of the template's input-view generated with the Liquid Test information (optional). It has to be used together with "--handle"`,false)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkDefaultFirm(options.firm, firmIdDefault);

--- a/index.js
+++ b/index.js
@@ -20,9 +20,7 @@ async function fetchReconciliationById(type, envId, id) {
     const saved = await ReconciliationText.save(type, envId, template.data);
 
     if (saved) {
-      consola.success(
-        `Reconciliation "${template.data.handle}" imported from ${type} ${envId}`
-      );
+      consola.success(`Reconciliation "${template.data.handle}" imported from ${type} ${envId}`);
     }
 
     return {
@@ -50,11 +48,7 @@ async function fetchReconciliationByHandle(type, envId, handle) {
     }
 
     if (!id) {
-      existingTemplate = await SF.findReconciliationTextByHandle(
-        type,
-        envId,
-        handle
-      );
+      existingTemplate = await SF.findReconciliationTextByHandle(type, envId, handle);
 
       if (!existingTemplate) {
         consola.error(
@@ -86,8 +80,7 @@ async function fetchAllReconciliations(type, envId, page = 1) {
     try {
       const saved = await ReconciliationText.save(type, envId, template);
 
-      if (saved)
-        consola.success(`Reconciliation "${template.handle}" imported from ${type} ${envId}`);
+      if (saved) consola.success(`Reconciliation "${template.handle}" imported from ${type} ${envId}`);
     } catch (error) {
       consola.error(error);
     }
@@ -109,9 +102,7 @@ async function fetchExistingReconciliations(type, envId) {
       const configPresent = fsUtils.configExists("reconciliationText", handle);
 
       if (!configPresent) {
-        consola.error(
-          `Config file for reconciliationText "${handle}" not found`
-        );
+        consola.error(`Config file for reconciliationText "${handle}" not found`);
       }
 
       const templateConfig = fsUtils.readConfig("reconciliationText", handle);
@@ -128,12 +119,7 @@ async function fetchExistingReconciliations(type, envId) {
   }
 }
 
-async function publishReconciliationByHandle(
-  type,
-  envId,
-  handle,
-  message = "Updated with the Silverfin CLI"
-) {
+async function publishReconciliationByHandle(type, envId, handle, message = "Updated with the Silverfin CLI") {
   try {
     const configPresent = fsUtils.configExists("reconciliationText", handle);
 
@@ -163,12 +149,7 @@ async function publishReconciliationByHandle(
       delete template.is_active;
     }
 
-    const response = await SF.updateReconciliationText(
-      type,
-      envId,
-      templateId,
-      template
-    );
+    const response = await SF.updateReconciliationText(type, envId, templateId, template);
 
     if (response && response.data && response.data.handle) {
       consola.success(`Reconciliation updated: ${response.data.handle}`);
@@ -182,11 +163,7 @@ async function publishReconciliationByHandle(
   }
 }
 
-async function publishAllReconciliations(
-  type,
-  envId,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishAllReconciliations(type, envId, message = "updated through the Silverfin CLI") {
   let templates = fsUtils.getAllTemplatesOfAType("reconciliationText");
   for (let handle of templates) {
     if (!handle) continue;
@@ -196,26 +173,16 @@ async function publishAllReconciliations(
 
 async function newReconciliation(type, envId, handle) {
   try {
-    const existingTemplate = await SF.findReconciliationTextByHandle(
-      type,
-      envId,
-      handle
-    );
+    const existingTemplate = await SF.findReconciliationTextByHandle(type, envId, handle);
     if (existingTemplate) {
-      consola.warn(
-        `Reconciliation "${handle}" already exists on ${type} ${envId}. Skipping its creation`
-      );
+      consola.warn(`Reconciliation "${handle}" already exists on ${type} ${envId}. Skipping its creation`);
       return;
     }
 
     const template = await ReconciliationText.read(handle);
     if (!template) return;
     template.version_comment = "Created with the Silverfin CLI";
-    const response = await SF.createReconciliationText(
-      type,
-      envId,
-      template
-    );
+    const response = await SF.createReconciliationText(type, envId, template);
     // Store new id
     if (response && response.status == 201) {
       ReconciliationText.updateTemplateId(type, envId, handle, response.data.id);
@@ -236,7 +203,7 @@ async function newAllReconciliations(type, envId) {
 async function fetchExportFileByName(type, envId, name) {
   try {
     const template = await SF.findExportFileByName(type, envId, name);
-    
+
     if (!template) {
       consola.error(`Export file "${name}" wasn't found in ${type} ${envId}`);
       process.exit(1);
@@ -263,16 +230,14 @@ async function fetchExportFileById(type, envId, id) {
 
     const saved = ExportFile.save(type, envId, template);
     if (saved) {
-      consola.success(
-        `Export file "${template.name}" imported from ${type} ${envId}`
-      );
+      consola.success(`Export file "${template.name}" imported from ${type} ${envId}`);
     }
 
     return {
       type,
       envId,
       template,
-    }
+    };
   } catch (error) {
     consola.error(error);
     process.exit(1);
@@ -309,7 +274,7 @@ async function fetchExistingExportFiles(type, envId) {
   templates.forEach(async (name) => {
     const templateConfig = fsUtils.readConfig("exportFile", name);
     let templateId = fsUtils.getTemplateId(type, envId, templateConfig);
-    
+
     if (!templateId) {
       errorUtils.missingExportFileId(name);
       return false;
@@ -319,12 +284,7 @@ async function fetchExistingExportFiles(type, envId) {
   });
 }
 
-async function publishExportFileByName(
-  type,
-  envId,
-  name,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishExportFileByName(type, envId, name, message = "updated through the Silverfin CLI") {
   try {
     const configPresent = fsUtils.configExists("exportFile", name);
 
@@ -353,12 +313,7 @@ async function publishExportFileByName(
       template.version_significant_change = false;
     }
 
-    const response = await SF.updateExportFile(
-      type,
-      envId,
-      templateId,
-      template
-    );
+    const response = await SF.updateExportFile(type, envId, templateId, template);
 
     if (response && response.data && response.data.name) {
       consola.success(`Export file updated: ${response.data.name}`);
@@ -372,11 +327,7 @@ async function publishExportFileByName(
   }
 }
 
-async function publishAllExportFiles(
-  type,
-  envId,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishAllExportFiles(type, envId, message = "updated through the Silverfin CLI") {
   let templates = fsUtils.getAllTemplatesOfAType("exportFile");
   for (let name of templates) {
     if (!name) continue;
@@ -388,9 +339,7 @@ async function newExportFile(type, envId, name) {
   try {
     const existingTemplate = await SF.findExportFileByName(type, envId, name);
     if (existingTemplate) {
-      consola.warn(
-        `Export file "${name}" already exists on ${type} ${envId}. Skipping its creation`
-      );
+      consola.warn(`Export file "${name}" already exists on ${type} ${envId}. Skipping its creation`);
       return;
     }
     const template = await ExportFile.read(name);
@@ -466,8 +415,7 @@ async function fetchAllAccountTemplates(type, envId, page = 1) {
   templates.forEach(async (template) => {
     const saved = AccountTemplate.save(type, envId, template);
 
-    if (saved)
-      consola.success(`Account template "${template?.name_nl}" imported from ${type} ${envId}`);
+    if (saved) consola.success(`Account template "${template?.name_nl}" imported from ${type} ${envId}`);
   });
   fetchAllAccountTemplates(type, envId, page + 1);
 }
@@ -492,12 +440,7 @@ async function fetchExistingAccountTemplates(type, envId) {
   });
 }
 
-async function publishAccountTemplateByName(
-  type,
-  envId,
-  name,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishAccountTemplateByName(type, envId, name, message = "updated through the Silverfin CLI") {
   try {
     const configPresent = fsUtils.configExists("accountTemplate", name);
 
@@ -532,12 +475,7 @@ async function publishAccountTemplateByName(
       template.version_significant_change = false;
     }
 
-    const response = await SF.updateAccountTemplate(
-      type,
-      envId,
-      templateId,
-      template
-    );
+    const response = await SF.updateAccountTemplate(type, envId, templateId, template);
 
     if (response && response.data && response.data.name_nl) {
       consola.success(`Account template updated: ${response.data.name_nl}`);
@@ -551,11 +489,7 @@ async function publishAccountTemplateByName(
   }
 }
 
-async function publishAllAccountTemplates(
-  type,
-  envId,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishAllAccountTemplates(type, envId, message = "updated through the Silverfin CLI") {
   let templates = fsUtils.getAllTemplatesOfAType("accountTemplate");
   for (let name of templates) {
     if (!name) continue;
@@ -565,16 +499,10 @@ async function publishAllAccountTemplates(
 
 async function newAccountTemplate(type, envId, name) {
   try {
-    const existingTemplate = await SF.findAccountTemplateByName(
-      type,
-      envId,
-      name
-    );
+    const existingTemplate = await SF.findAccountTemplateByName(type, envId, name);
 
     if (existingTemplate) {
-      consola.warn(
-        `Account template "${name}" already exists on ${type} ${envId}. Skipping its creation`
-      );
+      consola.warn(`Account template "${name}" already exists on ${type} ${envId}. Skipping its creation`);
       return;
     }
     const template = await AccountTemplate.read(name);
@@ -582,11 +510,9 @@ async function newAccountTemplate(type, envId, name) {
     template.version_comment = "Created through the Silverfin CLI";
 
     // Only keep the mapping_list_ranges that belong to this firm or partner for the request
-    template.mapping_list_ranges = template.mapping_list_ranges.filter(
-      (range) => {
-        return range.type === "firm" && range.env_id === firmId;
-      }
-    );
+    template.mapping_list_ranges = template.mapping_list_ranges.filter((range) => {
+      return range.type === "firm" && range.env_id === firmId;
+    });
 
     const response = await SF.createAccountTemplate(type, envId, template);
     const handle = response.data.name_nl;
@@ -687,12 +613,7 @@ async function fetchExistingSharedParts(type, envId) {
   }
 }
 
-async function publishSharedPartByName(
-  type,
-  envId,
-  name,
-  message = "Updated through the Silverfin CLI"
-) {
+async function publishSharedPartByName(type, envId, name, message = "Updated through the Silverfin CLI") {
   try {
     const configPresent = fsUtils.configExists("sharedPart", name);
     if (!configPresent) {
@@ -718,12 +639,7 @@ async function publishSharedPartByName(
       template.version_significant_change = false;
     }
 
-    const response = await SF.updateSharedPart(
-      type,
-      envId,
-      templateId,
-      template
-    );
+    const response = await SF.updateSharedPart(type, envId, templateId, template);
 
     if (response && response.data && response.data.name) {
       consola.success(`Shared part updated: ${response.data.name}`);
@@ -737,11 +653,7 @@ async function publishSharedPartByName(
   }
 }
 
-async function publishAllSharedParts(
-  type,
-  envId,
-  message = "updated through the Silverfin CLI"
-) {
+async function publishAllSharedParts(type, envId, message = "updated through the Silverfin CLI") {
   let templates = fsUtils.getAllTemplatesOfAType("sharedPart");
   for (let name of templates) {
     if (!name) continue;
@@ -751,16 +663,10 @@ async function publishAllSharedParts(
 
 async function newSharedPart(type, envId, name) {
   try {
-    const existingSharedPart = await SF.findSharedPartByName(
-      type,
-      envId,
-      name
-    );
+    const existingSharedPart = await SF.findSharedPartByName(type, envId, name);
 
     if (existingSharedPart) {
-      consola.warn(
-        `Shared part "${name}" already exists on ${type} ${envId}. Skipping its creation`
-      );
+      consola.warn(`Shared part "${name}" already exists on ${type} ${envId}. Skipping its creation`);
       return;
     }
     const template = await SharedPart.read(name);
@@ -793,35 +699,18 @@ async function newAllSharedParts(type, envId) {
  * @param {string} templateType has to be either `reconciliationText`, `exportFile`or `accountTemplate`
  * @returns {boolean} - Returns true if the shared part was added successfully
  */
-async function addSharedPart(
-  type,
-  envId,
-  sharedPartName,
-  templateHandle,
-  templateType
-) {
+async function addSharedPart(type, envId, sharedPartName, templateHandle, templateType) {
   try {
     let templateConfig = await fsUtils.readConfig(templateType, templateHandle);
-    let sharedPartConfig = await fsUtils.readConfig(
-      "sharedPart",
-      sharedPartName
-    );
+    let sharedPartConfig = await fsUtils.readConfig("sharedPart", sharedPartName);
 
     let templateId = fsUtils.getTemplateId(type, envId, templateConfig);
 
-    let sharedPartId =
-      type == "firm"
-        ? sharedPartConfig?.id?.[envId]
-        : sharedPartConfig?.partner_id?.[envId];
+    let sharedPartId = type == "firm" ? sharedPartConfig?.id?.[envId] : sharedPartConfig?.partner_id?.[envId];
 
     // Missing Reconciliation ID. Try to identify it based on the handle
     if (!templateId) {
-      const updated = await getTemplateId(
-        type,
-        envId,
-        templateType,
-        templateHandle
-      );
+      const updated = await getTemplateId(type, envId, templateType, templateHandle);
       if (!updated) return false;
       templateConfig = await fsUtils.readConfig(templateType, templateHandle);
       templateId = fsUtils.getTemplateId(type, envId, templateConfig);
@@ -829,18 +718,10 @@ async function addSharedPart(
 
     // Missing Shared Part ID. Try to identify it based on the name
     if (!sharedPartId) {
-      const updated = await getTemplateId(
-        type,
-        envId,
-        "sharedPart",
-        sharedPartName
-      );
+      const updated = await getTemplateId(type, envId, "sharedPart", sharedPartName);
       if (!updated) return false;
       sharedPartConfig = await fsUtils.readConfig("sharedPart", sharedPartName);
-      sharedPartId =
-        type == "firm"
-          ? sharedPartConfig?.id?.[envId]
-          : sharedPartConfig?.partner_id?.[envId];
+      sharedPartId = type == "firm" ? sharedPartConfig?.id?.[envId] : sharedPartConfig?.partner_id?.[envId];
     }
 
     // Add shared part to template
@@ -857,18 +738,11 @@ async function addSharedPart(
         break;
     }
 
-    let response = await addSharedPartOnPlatform(
-      type,
-      envId,
-      sharedPartId,
-      templateId
-    );
+    let response = await addSharedPartOnPlatform(type, envId, sharedPartId, templateId);
 
     // Success or failure
     if (!response || !response.status || !response.status === 201) {
-      consola.warn(
-        `Adding shared part "${sharedPartName}" to "${templateHandle}" failed (${templateType}).`
-      );
+      consola.warn(`Adding shared part "${sharedPartName}" to "${templateHandle}" failed (${templateType}).`);
       return false;
     }
 
@@ -879,10 +753,7 @@ async function addSharedPart(
       sharedPartConfig.used_in = [];
     } else {
       // Previously stored ?
-      templateIndex = sharedPartConfig.used_in.findIndex(
-        (template) =>
-          templateHandle === template.handle || templateHandle === template.name
-      );
+      templateIndex = sharedPartConfig.used_in.findIndex((template) => templateHandle === template.handle || templateHandle === template.name);
     }
 
     if (templateIndex === -1) {
@@ -910,8 +781,7 @@ async function addSharedPart(
           usedInTemplateConfig.partner_id = {};
         }
 
-        usedInTemplateConfig.partner_id[envId] =
-          templateConfig?.partner_id[envId];
+        usedInTemplateConfig.partner_id[envId] = templateConfig?.partner_id[envId];
       }
 
       sharedPartConfig.used_in[templateIndex] = usedInTemplateConfig;
@@ -921,9 +791,7 @@ async function addSharedPart(
     fsUtils.writeConfig(templateType, templateHandle, templateConfig);
     fsUtils.writeConfig("sharedPart", sharedPartName, sharedPartConfig);
 
-    consola.success(
-      `Shared part "${sharedPartName}" added to "${templateHandle}" (${templateType}).`
-    );
+    consola.success(`Shared part "${sharedPartName}" added to "${templateHandle}" (${templateType}).`);
 
     return sharedPartConfig;
   } catch (error) {
@@ -943,36 +811,23 @@ async function addAllSharedParts(type, envId, force = false) {
   const sharedPartsArray = fsUtils.getAllTemplatesOfAType("sharedPart");
 
   for await (let sharedPartName of sharedPartsArray) {
-    let sharedPartConfig = await fsUtils.readConfig(
-      "sharedPart",
-      sharedPartName
-    );
+    let sharedPartConfig = await fsUtils.readConfig("sharedPart", sharedPartName);
 
     if (!sharedPartConfig.used_in) {
-      consola.warn(
-        `Shared part ${sharedPartName} has no used_in array. Skipping.`
-      );
+      consola.warn(`Shared part ${sharedPartName} has no used_in array. Skipping.`);
       continue;
     }
 
     if (!sharedPartConfig?.[envConfigKey][envId]) {
-      consola.warn(
-        `Shared part ${sharedPartName} has no id associated to ${type} ${envId}. Skipping.`
-      );
+      consola.warn(`Shared part ${sharedPartName} has no id associated to ${type} ${envId}. Skipping.`);
       continue;
     }
 
     // Fetch shared part from the platform
     const sharedPartId = sharedPartConfig[envConfigKey][envId];
-    const sharedPartData = await SF.readSharedPartById(
-      type,
-      envId,
-      sharedPartId
-    );
+    const sharedPartData = await SF.readSharedPartById(type, envId, sharedPartId);
     if (!sharedPartData) {
-      consola.warn(
-        `Shared part ${sharedPartName} not found in ${type} ${envId}. Skipping.`
-      );
+      consola.warn(`Shared part ${sharedPartName} not found in ${type} ${envId}. Skipping.`);
       continue;
     }
     const existingLinks = sharedPartData.data.used_in;
@@ -980,20 +835,13 @@ async function addAllSharedParts(type, envId, force = false) {
     for await (let template of sharedPartConfig.used_in) {
       template = SharedPart.checkTemplateType(template);
       if (!template.handle && !template.name) {
-        consola.warn(
-          `Template stored in used_in has no handle or name. Skipping.`
-        );
+        consola.warn(`Template stored in used_in has no handle or name. Skipping.`);
         continue;
       }
 
-      const configPresent = fsUtils.configExists(
-        template.type,
-        template.handle
-      );
+      const configPresent = fsUtils.configExists(template.type, template.handle);
       if (!configPresent) {
-        consola.warn(
-          `Template ${template.type} ${template.handle} not found in local repository. Skipping.`
-        );
+        consola.warn(`Template ${template.type} ${template.handle} not found in local repository. Skipping.`);
         continue;
       }
 
@@ -1002,15 +850,10 @@ async function addAllSharedParts(type, envId, force = false) {
         let alreadyAdded = await existingLinks.find((existing) => {
           existing = SharedPart.checkTemplateType(existing);
           // we check both id and type to avoid (rare) false positives
-          return (
-            existing.id === template[envConfigKey][envId] &&
-            existing.type === template.type
-          );
+          return existing.id === template[envConfigKey][envId] && existing.type === template.type;
         });
         if (alreadyAdded) {
-          consola.info(
-            `Template ${template.type} ${template.handle} already has this shared part. Skipping.`
-          );
+          consola.info(`Template ${template.type} ${template.handle} already has this shared part. Skipping.`);
           continue;
         }
       }
@@ -1018,40 +861,23 @@ async function addAllSharedParts(type, envId, force = false) {
       // add arbitrary delay to avoid rate limiting
       await new Promise((resolve) => setTimeout(resolve, 500));
 
-      addSharedPart(
-        type,
-        envId,
-        sharedPartConfig.name,
-        template.handle,
-        template.type
-      );
+      addSharedPart(type, envId, sharedPartConfig.name, template.handle, template.type);
     }
   }
 }
 
-async function removeSharedPart(
-  type,
-  envId,
-  sharedPartHandle,
-  templateHandle,
-  templateType
-) {
+async function removeSharedPart(type, envId, sharedPartHandle, templateHandle, templateType) {
   try {
     const templateConfig = fsUtils.readConfig(templateType, templateHandle);
     const sharedPartConfig = fsUtils.readConfig("sharedPart", sharedPartHandle);
     let templateId = fsUtils.getTemplateId(type, envId, templateConfig);
 
     if (!templateConfig || !templateId) {
-      consola.warn(
-        `Template id not found for ${templateHandle} (${templateType}). Skipping.`
-      );
+      consola.warn(`Template id not found for ${templateHandle} (${templateType}). Skipping.`);
       return false;
     }
 
-    const sharedPartId =
-      type == "firm"
-        ? sharedPartConfig?.id?.[envId]
-        : sharedPartConfig?.partner_id?.[envId];
+    const sharedPartId = type == "firm" ? sharedPartConfig?.id?.[envId] : sharedPartConfig?.partner_id?.[envId];
 
     if (!sharedPartId) {
       consola.warn(`Shared part id not found for ${templateHandle}. Skipping.`);
@@ -1072,40 +898,23 @@ async function removeSharedPart(
         removeSharedPart = SF.removeSharedPartFromAccountTemplate;
         break;
     }
-    let response = await removeSharedPart(
-      type,
-      envId,
-      sharedPartId,
-      templateId
-    );
+    let response = await removeSharedPart(type, envId, sharedPartId, templateId);
 
     if (response && response?.status === 200) {
-      consola.debug(
-        `Remove shared part with id ${sharedPartId} removed from ${templateType} with id ${templateId} on the platform.`
-      );
+      consola.debug(`Remove shared part with id ${sharedPartId} removed from ${templateType} with id ${templateId} on the platform.`);
     }
 
     // Remove reference from shared part config
-    const templateIndex = sharedPartConfig.used_in.findIndex(
-      (template) =>
-        templateHandle === template.handle || templateHandle === template.name
-    );
+    const templateIndex = sharedPartConfig.used_in.findIndex((template) => templateHandle === template.handle || templateHandle === template.name);
 
     if (templateIndex === -1) {
-      consola.debug(
-        `${templateType} with id ${templateId} not found in shared part config. No update in local shared part config occured.`
-      );
+      consola.debug(`${templateType} with id ${templateId} not found in shared part config. No update in local shared part config occured.`);
     } else {
       const usedInTemplateConfig = sharedPartConfig.used_in[templateIndex];
 
       // In case there's only one id & partner_id in the template config, remove the whole template config
-      const totalIds =
-        Object.keys(usedInTemplateConfig?.id || []).length +
-        Object.keys(usedInTemplateConfig?.partner_id || []).length;
-      const targetId =
-        type == "firm"
-          ? usedInTemplateConfig?.id[envId]
-          : usedInTemplateConfig?.partner_id[envId];
+      const totalIds = Object.keys(usedInTemplateConfig?.id || []).length + Object.keys(usedInTemplateConfig?.partner_id || []).length;
+      const targetId = type == "firm" ? usedInTemplateConfig?.id[envId] : usedInTemplateConfig?.partner_id[envId];
 
       // Remove reference of specific firm or partner id in the template config in the shared part used in array
       if (targetId) {
@@ -1126,9 +935,7 @@ async function removeSharedPart(
       fsUtils.writeConfig("sharedPart", sharedPartHandle, sharedPartConfig);
     }
 
-    consola.success(
-      `Shared part "${sharedPartHandle}" removed from template "${templateHandle}" (${templateType}).`
-    );
+    consola.success(`Shared part "${sharedPartHandle}" removed from template "${templateHandle}" (${templateType}).`);
   } catch (error) {
     errorUtils.errorHandler(error);
   }
@@ -1141,11 +948,7 @@ async function getTemplateId(type, envId, templateType, handle) {
   let templateText;
   switch (templateType) {
     case "reconciliationText":
-      templateText = await SF.findReconciliationTextByHandle(
-        type,
-        envId,
-        handle
-      );
+      templateText = await SF.findReconciliationTextByHandle(type, envId, handle);
       break;
     case "exportFile":
       templateText = await SF.findExportFileByName(type, envId, handle);
@@ -1179,9 +982,7 @@ async function getTemplateId(type, envId, templateType, handle) {
   }
 
   fsUtils.writeConfig(templateType, handle, config);
-  consola.success(
-    `Template ${handle}: ID updated from ${type} (${templateType})`
-  );
+  consola.success(`Template ${handle}: ID updated from ${type} (${templateType})`);
   return true;
 }
 
@@ -1195,8 +996,7 @@ async function getAllTemplatesId(type, envId, templateType) {
     let templates = fsUtils.getAllTemplatesOfAType(templateType);
     for (let templateName of templates) {
       let configTemplate = fsUtils.readConfig(templateType, templateName);
-      let handle =
-        configTemplate.handle || configTemplate.name || configTemplate.name_nl;
+      let handle = configTemplate.handle || configTemplate.name || configTemplate.name_nl;
       if (!handle) {
         continue;
       }

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -140,8 +140,7 @@ class AxiosFactory {
                     access_token: firmTokens.accessToken,
                   };
                 } else {
-                  axiosInstance.defaults.headers.common["Authorization"] =
-                    `Bearer ${firmTokens.accessToken}`;
+                  axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${firmTokens.accessToken}`;
                   originalConfig.headers.Authorization = `Bearer ${firmTokens.accessToken}`;
                 }
 
@@ -190,10 +189,7 @@ class AxiosFactory {
       process.exit(1);
     }
 
-    let axiosDetails = this.#prepareAxiosDetailsForPartners(
-      envId,
-      partnerToken
-    );
+    let axiosDetails = this.#prepareAxiosDetailsForPartners(envId, partnerToken);
     let axiosInstance = axios.create(axiosDetails);
     axiosInstance = this.#addPartnerTokenRefresher(axiosInstance);
 
@@ -218,8 +214,7 @@ class AxiosFactory {
 
                 await this.#refreshPartnerApiKey(partnerId);
 
-                const newPartnerToken =
-                  firmCredentials.getPartnerCredentials(partnerId).token;
+                const newPartnerToken = firmCredentials.getPartnerCredentials(partnerId).token;
 
                 // Set the new access token for current and future requests
                 axiosInstance.defaults.params.api_key = newPartnerToken;
@@ -279,10 +274,7 @@ class AxiosFactory {
       // We create an instance without interceptors to avoid an infinite loop
       const axiosInstance = this.#createSimpleAxiosInstanceForFirms(firmId);
 
-      const response = await axiosInstance.post(
-        `${this.BASE_URL}/f/${firmId}/oauth/token`,
-        data
-      );
+      const response = await axiosInstance.post(`${this.BASE_URL}/f/${firmId}/oauth/token`, data);
 
       firmCredentials.storeNewTokenPair(firmId, response.data);
       consola.debug(`Refreshed tokens for firm ${firmId}`);
@@ -300,18 +292,12 @@ class AxiosFactory {
     try {
       consola.debug(`Refreshing API key for partner ${partnerId}`);
 
-      const partnerToken =
-        firmCredentials.getPartnerCredentials(partnerId).token;
+      const partnerToken = firmCredentials.getPartnerCredentials(partnerId).token;
 
       // Create a new instance with not interceptors to avoid an infinite loop
-      const newAxiosDetails = this.#prepareAxiosDetailsForPartners(
-        partnerId,
-        partnerToken
-      );
+      const newAxiosDetails = this.#prepareAxiosDetailsForPartners(partnerId, partnerToken);
       const newAxiosInstance = axios.create(newAxiosDetails);
-      const response = await newAxiosInstance.post(
-        `${this.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerToken}`
-      );
+      const response = await newAxiosInstance.post(`${this.BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerToken}`);
 
       firmCredentials.storePartnerApiKey(partnerId, response.data.api_key);
 
@@ -325,13 +311,9 @@ class AxiosFactory {
 
   static #handleFailedRefresh(error) {
     if (error.response) {
-      consola.error(
-        `Response Status: ${error.response.status} (${error.response.statusText})`
-      );
+      consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
     }
-    consola.error(
-      `Error refreshing credentials. Try running the authentication process again`
-    );
+    consola.error(`Error refreshing credentials. Try running the authentication process again`);
     process.exit(1);
   }
 }

--- a/lib/api/firmCredentials.js
+++ b/lib/api/firmCredentials.js
@@ -35,18 +35,11 @@ class FirmCredentials {
 
   /** Write all credentials to file */
   saveCredentials() {
-    fs.writeFileSync(
-      this.#SF_CREDENTIALS_PATH,
-      JSON.stringify(this.data, null, 2),
-      "utf8",
-      (err) => {
-        if (err) {
-          consola.error(
-            new Error(`Error while writing credentials file: ${err}`)
-          );
-        }
+    fs.writeFileSync(this.#SF_CREDENTIALS_PATH, JSON.stringify(this.data, null, 2), "utf8", (err) => {
+      if (err) {
+        consola.error(new Error(`Error while writing credentials file: ${err}`));
       }
-    );
+    });
   }
 
   // FIRM CREDENTIALS
@@ -115,10 +108,7 @@ class FirmCredentials {
    */
   listAuthorizedFirms() {
     return Object.keys(this.data)
-      .filter(
-        (element) =>
-          element !== "defaultFirmIDs" && element !== "partnerCredentials"
-      )
+      .filter((element) => element !== "defaultFirmIDs" && element !== "partnerCredentials")
       .map((element) => [element, this.data[element].firmName]);
   }
 
@@ -158,16 +148,11 @@ class FirmCredentials {
    * @returns {Object} Object containing `name` and `token` or `null` if they don't exist
    */
   getPartnerCredentials(partner_id) {
-    if (
-      !this.data.hasOwnProperty("partnerCredentials") ||
-      !this.data.partnerCredentials.hasOwnProperty(partner_id)
-    ) {
+    if (!this.data.hasOwnProperty("partnerCredentials") || !this.data.partnerCredentials.hasOwnProperty(partner_id)) {
       const existingPartners = this.listAuthorizedPartners();
       consola.error(`Missing authorization for partner id: ${partner_id}`);
       consola.log(`Only found partner ids for:`);
-      existingPartners.forEach((item) =>
-        consola.log(`${item.id}${item.name ? " - " + item.name : ""}`)
-      );
+      existingPartners.forEach((item) => consola.log(`${item.id}${item.name ? " - " + item.name : ""}`));
       process.exit(1);
     }
 
@@ -183,15 +168,13 @@ class FirmCredentials {
    */
   listAuthorizedPartners() {
     if (this.data.hasOwnProperty("partnerCredentials")) {
-      const partners = Object.keys(this.data.partnerCredentials).map(
-        (element) => {
-          const partnerInfo = {
-            id: element,
-            name: this.data.partnerCredentials[element].name,
-          };
-          return partnerInfo;
-        }
-      );
+      const partners = Object.keys(this.data.partnerCredentials).map((element) => {
+        const partnerInfo = {
+          id: element,
+          name: this.data.partnerCredentials[element].name,
+        };
+        return partnerInfo;
+      });
 
       return partners;
     }

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -71,17 +71,12 @@ async function findReconciliationTextByHandle(type, envId, handle, page = 1) {
   if (reconciliations.length == 0) {
     return null;
   }
-  let reconciliationTexts = reconciliations.filter(
-    (element) => element["handle"] === handle
-  );
+  let reconciliationTexts = reconciliations.filter((element) => element["handle"] === handle);
 
   if (reconciliationTexts.length != 0) {
     for (let reconciliationText of reconciliationTexts) {
       // Template from Partners. Skip it
-      if (
-        reconciliationText.hasOwnProperty("marketplace_template_id") &&
-        reconciliationText.marketplace_template_id != null
-      ) {
+      if (reconciliationText.hasOwnProperty("marketplace_template_id") && reconciliationText.marketplace_template_id != null) {
         continue;
       }
       // Only return reconciliations were liquid code is not hidden
@@ -93,18 +88,10 @@ async function findReconciliationTextByHandle(type, envId, handle, page = 1) {
   return findReconciliationTextByHandle(type, envId, handle, page + 1);
 }
 
-async function updateReconciliationText(
-  type,
-  envId,
-  reconciliationId,
-  attributes
-) {
+async function updateReconciliationText(type, envId, reconciliationId, attributes) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `reconciliations/${reconciliationId}`,
-      attributes
-    );
+    const response = await instance.post(`reconciliations/${reconciliationId}`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -113,18 +100,10 @@ async function updateReconciliationText(
   }
 }
 
-async function readReconciliationTextDetails(
-  type,
-  envId,
-  companyId,
-  periodId,
-  reconciliationId
-) {
+async function readReconciliationTextDetails(type, envId, companyId, periodId, reconciliationId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.get(
-      `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}`
-    );
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -133,20 +112,10 @@ async function readReconciliationTextDetails(
   }
 }
 
-async function getReconciliationCustom(
-  type,
-  envId,
-  companyId,
-  periodId,
-  reconciliationId,
-  page = 1
-) {
+async function getReconciliationCustom(type, envId, companyId, periodId, reconciliationId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.get(
-      `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`,
-      { params: { page: page, per_page: 200 } }
-    );
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`, { params: { page: page, per_page: 200 } });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -155,18 +124,10 @@ async function getReconciliationCustom(
   }
 }
 
-async function getReconciliationResults(
-  type,
-  envId,
-  companyId,
-  periodId,
-  reconciliationId
-) {
+async function getReconciliationResults(type, envId, companyId, periodId, reconciliationId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.get(
-      `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/results`
-    );
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/results`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -208,9 +169,7 @@ async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
   if (sharedParts.length == 0) {
     return null;
   }
-  const sharedPart = sharedParts.find(
-    (element) => element["name"] === sharedPartName
-  );
+  const sharedPart = sharedParts.find((element) => element["name"] === sharedPartName);
   if (sharedPart) {
     return sharedPart;
   } else {
@@ -221,10 +180,7 @@ async function findSharedPartByName(type, envId, sharedPartName, page = 1) {
 async function updateSharedPart(type, envId, sharedPartId, attributes) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `shared_parts/${sharedPartId}`,
-      attributes
-    );
+    const response = await instance.post(`shared_parts/${sharedPartId}`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -245,17 +201,10 @@ async function createSharedPart(type, envId, attributes) {
   }
 }
 
-async function addSharedPartToReconciliation(
-  type,
-  envId,
-  sharedPartId,
-  reconciliationId
-) {
+async function addSharedPartToReconciliation(type, envId, sharedPartId, reconciliationId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.post(`reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -264,17 +213,10 @@ async function addSharedPartToReconciliation(
   }
 }
 
-async function removeSharedPartFromReconciliation(
-  type,
-  envId,
-  sharedPartId,
-  reconciliationId
-) {
+async function removeSharedPartFromReconciliation(type, envId, sharedPartId, reconciliationId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.delete(
-      `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.delete(`reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -298,10 +240,7 @@ async function createExportFile(type, envId, attributes) {
 async function updateExportFile(type, envId, exportFileId, attributes) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `export_files/${exportFileId}`,
-      attributes
-    );
+    const response = await instance.post(`export_files/${exportFileId}`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -342,9 +281,7 @@ async function findExportFileByName(type, envId, exportFileName, page = 1) {
   if (exportFiles.length == 0) {
     return null;
   }
-  const exportFile = exportFiles.find(
-    (element) => element["name"] === exportFileName
-  );
+  const exportFile = exportFiles.find((element) => element["name"] === exportFileName);
   if (exportFile) {
     return await readExportFileById(type, envId, exportFile.id);
   } else {
@@ -352,17 +289,10 @@ async function findExportFileByName(type, envId, exportFileName, page = 1) {
   }
 }
 
-async function addSharedPartToExportFile(
-  type,
-  envId,
-  sharedPartId,
-  exportFileId
-) {
+async function addSharedPartToExportFile(type, envId, sharedPartId, exportFileId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `export_files/${exportFileId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.post(`export_files/${exportFileId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -371,17 +301,10 @@ async function addSharedPartToExportFile(
   }
 }
 
-async function removeSharedPartFromExportFile(
-  type,
-  envId,
-  sharedPartId,
-  exportFileId
-) {
+async function removeSharedPartFromExportFile(type, envId, sharedPartId, exportFileId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.delete(
-      `export_files/${exportFileId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.delete(`export_files/${exportFileId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -402,18 +325,10 @@ async function createAccountTemplate(type, envId, attributes) {
   }
 }
 
-async function updateAccountTemplate(
-  type,
-  envId,
-  accountTemplateId,
-  attributes
-) {
+async function updateAccountTemplate(type, envId, accountTemplateId, attributes) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `account_templates/${accountTemplateId}`,
-      attributes
-    );
+    const response = await instance.post(`account_templates/${accountTemplateId}`, attributes);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -439,9 +354,7 @@ async function readAccountTemplates(type, envId, page = 1) {
 async function readAccountTemplateById(type, envId, accountTemplateId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.get(
-      `account_templates/${accountTemplateId}`
-    );
+    const response = await instance.get(`account_templates/${accountTemplateId}`);
     apiUtils.responseSuccessHandler(response);
     return response.data;
   } catch (error) {
@@ -450,43 +363,24 @@ async function readAccountTemplateById(type, envId, accountTemplateId) {
   }
 }
 
-async function findAccountTemplateByName(
-  type,
-  envId,
-  accountTemplateName,
-  page = 1
-) {
+async function findAccountTemplateByName(type, envId, accountTemplateName, page = 1) {
   const accountTemplates = await readAccountTemplates(type, envId, page);
   // No data
   if (accountTemplates.length == 0) {
     return null;
   }
-  const accountTemplate = accountTemplates.find(
-    (element) => element["name_nl"] === accountTemplateName
-  );
+  const accountTemplate = accountTemplates.find((element) => element["name_nl"] === accountTemplateName);
   if (accountTemplate) {
     return await readAccountTemplateById(type, envId, accountTemplate.id);
   } else {
-    return findAccountTemplateByName(
-      type,
-      envId,
-      accountTemplateName,
-      page + 1
-    );
+    return findAccountTemplateByName(type, envId, accountTemplateName, page + 1);
   }
 }
 
-async function addSharedPartToAccountTemplate(
-  type,
-  envId,
-  sharedPartId,
-  accountTemplateId
-) {
+async function addSharedPartToAccountTemplate(type, envId, sharedPartId, accountTemplateId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.post(
-      `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.post(`account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -495,17 +389,10 @@ async function addSharedPartToAccountTemplate(
   }
 }
 
-async function removeSharedPartFromAccountTemplate(
-  type,
-  envId,
-  sharedPartId,
-  accountTemplateId
-) {
+async function removeSharedPartFromAccountTemplate(type, envId, sharedPartId, accountTemplateId) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.delete(
-      `account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`
-    );
+    const response = await instance.delete(`account_templates/${accountTemplateId}/shared_parts/${sharedPartId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -592,9 +479,7 @@ async function getCompanyCustom(firmId, companyId) {
 async function getWorkflows(firmId, companyId, periodId) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
-    const response = await instance.get(
-      `/companies/${companyId}/periods/${periodId}/workflows`
-    );
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/workflows`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -603,19 +488,10 @@ async function getWorkflows(firmId, companyId, periodId) {
   }
 }
 
-async function getWorkflowInformation(
-  firmId,
-  companyId,
-  periodId,
-  workflowId,
-  page = 1
-) {
+async function getWorkflowInformation(firmId, companyId, periodId, workflowId, page = 1) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
-    const response = await instance.get(
-      `/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`,
-      { params: { page: page, per_page: 200 } }
-    );
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`, { params: { page: page, per_page: 200 } });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -624,80 +500,41 @@ async function getWorkflowInformation(
   }
 }
 
-async function findReconciliationInWorkflow(
-  firmId,
-  reconciliationHandle,
-  companyId,
-  periodId,
-  workflowId,
-  page = 1
-) {
-  const response = await getWorkflowInformation(
-    firmId,
-    companyId,
-    periodId,
-    workflowId,
-    page
-  );
+async function findReconciliationInWorkflow(firmId, reconciliationHandle, companyId, periodId, workflowId, page = 1) {
+  const response = await getWorkflowInformation(firmId, companyId, periodId, workflowId, page);
   const workflowArray = response.data;
   // No data
   if (workflowArray.length == 0) {
-    consola.log(
-      `Reconciliation ${reconciliationHandle} not found in workflow id ${workflowId}`
-    );
+    consola.log(`Reconciliation ${reconciliationHandle} not found in workflow id ${workflowId}`);
     return;
   }
-  const reconciliationText = workflowArray.find(
-    (reconciliation) => reconciliation.handle == reconciliationHandle
-  );
+  const reconciliationText = workflowArray.find((reconciliation) => reconciliation.handle == reconciliationHandle);
   if (reconciliationText) {
     return reconciliationText;
   } else {
-    return findReconciliationInWorkflow(
-      firmId,
-      reconciliationHandle,
-      companyId,
-      periodId,
-      workflowId,
-      page + 1
-    );
+    return findReconciliationInWorkflow(firmId, reconciliationHandle, companyId, periodId, workflowId, page + 1);
   }
 }
 
-async function findReconciliationInWorkflows(
-  firmId,
-  reconciliationHandle,
-  companyId,
-  periodId
-) {
+async function findReconciliationInWorkflows(firmId, reconciliationHandle, companyId, periodId) {
   // Get data from all workflows
   const responseWorkflows = await getWorkflows(firmId, companyId, periodId);
   // Check in each workflow
   for (workflow of responseWorkflows.data) {
-    let reconciliationInformation = await findReconciliationInWorkflow(
-      firmId,
-      reconciliationHandle,
-      companyId,
-      periodId,
-      workflow.id
-    );
+    let reconciliationInformation = await findReconciliationInWorkflow(firmId, reconciliationHandle, companyId, periodId, workflow.id);
     // Found
     if (reconciliationInformation) {
       return reconciliationInformation;
     }
   }
   // Not found
-  consola.warn(
-    `Reconciliation "${reconciliationHandle}" not found in any workflow`
-  );
+  consola.warn(`Reconciliation "${reconciliationHandle}" not found in any workflow`);
 }
 
 async function getAccountDetails(firmId, companyId, periodId, accountId) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
-    const response = await instance.get(
-      `companies/${companyId}/periods/${periodId}/accounts/${accountId}`
-    );
+    const response = await instance.get(`companies/${companyId}/periods/${periodId}/accounts/${accountId}`);
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -712,11 +549,7 @@ async function verifyLiquid(firmId, attributes) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const config = { headers: { "Content-Type": "application/json" } };
-    const response = await instance.post(
-      "reconciliations/verify_liquid",
-      attributes,
-      config
-    );
+    const response = await instance.post("reconciliations/verify_liquid", attributes, config);
     return response;
   } catch (error) {
     const response = await apiUtils.responseErrorHandler(error);

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -42,9 +42,7 @@ class SilverfinAuthorizer {
     try {
       const firmTokens = firmCredentials.getTokenPair(firmId);
       if (!firmTokens) {
-        consola.error(
-          `Firm ${firmId} is not authorized. Please authorize the firm first`
-        );
+        consola.error(`Firm ${firmId} is not authorized. Please authorize the firm first`);
         process.exit(1);
       }
 
@@ -58,18 +56,14 @@ class SilverfinAuthorizer {
         access_token: firmTokens.accessToken,
       };
       const instance = AxiosFactory.createInstance("firm", firmId);
-      const response = await instance.post(
-        `${BASE_URL}/f/${firmId}/oauth/token`,
-        data
-      );
+      const response = await instance.post(`${BASE_URL}/f/${firmId}/oauth/token`, data);
 
       firmCredentials.storeNewTokenPair(firmId, response.data);
 
       return true;
     } catch (error) {
       if (error.response) {
-        const description =
-          error?.response?.data?.error_description || error?.request?.data;
+        const description = error?.response?.data?.error_description || error?.request?.data;
 
         consola.error(
           `Response Status: ${error.response.status} (${error.response.statusText})`,
@@ -89,34 +83,23 @@ class SilverfinAuthorizer {
    */
   static async refreshPartner(partnerId) {
     try {
-      const partnerCredentials =
-        firmCredentials.getPartnerCredentials(partnerId);
+      const partnerCredentials = firmCredentials.getPartnerCredentials(partnerId);
 
       if (!partnerCredentials) {
-        consola.error(
-          `Partner ${partnerId} is not authorized. Please authorize the partner first`
-        );
+        consola.error(`Partner ${partnerId} is not authorized. Please authorize the partner first`);
         process.exit(1);
       }
 
       const BASE_URL = firmCredentials.getHost();
       const instance = AxiosFactory.createInstance("partner", partnerId);
-      const response = await instance.post(
-        `${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`
-      );
+      const response = await instance.post(`${BASE_URL}/api/partner/v1/refresh_api_key?api_key=${partnerCredentials.token}`);
 
-      firmCredentials.storePartnerApiKey(
-        partnerId,
-        response.data.api_key,
-        partnerCredentials?.name
-      );
+      firmCredentials.storePartnerApiKey(partnerId, response.data.api_key, partnerCredentials?.name);
 
       return true;
     } catch (error) {
       if (error.response) {
-        consola.error(
-          `Response Status: ${error.response.status} (${error.response.statusText}). An error occurred trying to refresh the partner API key`
-        );
+        consola.error(`Response Status: ${error.response.status} (${error.response.statusText}). An error occurred trying to refresh the partner API key`);
       }
       process.exit(1);
     }
@@ -125,16 +108,11 @@ class SilverfinAuthorizer {
   // PRIVATE METHODS
 
   static async #promptForId(firmId = undefined) {
-    consola.info(
-      `NOTE: if you need to exit this process you can press "Ctrl/Cmmd + C"`
-    );
+    consola.info(`NOTE: if you need to exit this process you can press "Ctrl/Cmmd + C"`);
 
     let firmIdPrompt;
     if (firmId) {
-      firmIdPrompt = prompt(
-        `Enter the firm ID (leave blank to use ${firmId}): `,
-        { value: firmId }
-      );
+      firmIdPrompt = prompt(`Enter the firm ID (leave blank to use ${firmId}): `, { value: firmId });
     } else {
       firmIdPrompt = prompt("Enter the firm ID: ");
     }
@@ -145,9 +123,7 @@ class SilverfinAuthorizer {
     consola.info(`You need to authorize your APP in the browser now`);
 
     const redirectUri = encodeURIComponent("urn:ietf:wg:oauth:2.0:oob");
-    const scope = encodeURIComponent(
-      "administration:read administration:write financials:read financials:write workflows:read"
-    );
+    const scope = encodeURIComponent("administration:read administration:write financials:read financials:write workflows:read");
     const SF_API_CLIENT_ID = process.env.SF_API_CLIENT_ID;
     const url = `${this.BASE_URL}/f/${firmId}/oauth/authorize?client_id=${SF_API_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
 
@@ -183,14 +159,8 @@ class SilverfinAuthorizer {
 
       return true;
     } catch (error) {
-      consola.error(
-        `Response Status: ${error.response.status} (${error.response.statusText})`
-      );
-      consola.error(
-        `Error description: ${JSON.stringify(
-          error.response.data.error_description
-        )}`
-      );
+      consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
+      consola.error(`Error description: ${JSON.stringify(error.response.data.error_description)}`);
       process.exit(1);
     }
   }

--- a/lib/cli/cliUpdates.js
+++ b/lib/cli/cliUpdates.js
@@ -5,8 +5,7 @@ const { promisify } = require("util");
 const exec = promisify(require("child_process").exec);
 const { consola } = require("consola");
 
-const PACKAGE_URL =
-  "https://raw.githubusercontent.com/silverfin/silverfin-cli/main/package.json";
+const PACKAGE_URL = "https://raw.githubusercontent.com/silverfin/silverfin-cli/main/package.json";
 
 async function getLatestVersion() {
   response = await axios.get(PACKAGE_URL);
@@ -38,18 +37,8 @@ async function checkVersions() {
   }
   if (compareVersions(latestVersion, currentVersion)) {
     consola.log(`--------------`);
-    consola.log(
-      "There is a new version available of this CLI (" +
-        chalk.red(`${currentVersion}`) +
-        " ->  " +
-        chalk.green(`${latestVersion}`) +
-        ")"
-    );
-    consola.log(
-      "Run " +
-        chalk.italic.bold(`silverfin update`) +
-        " to get the latest version"
-    );
+    consola.log("There is a new version available of this CLI (" + chalk.red(`${currentVersion}`) + " ->  " + chalk.green(`${latestVersion}`) + ")");
+    consola.log("Run " + chalk.italic.bold(`silverfin update`) + " to get the latest version");
     consola.log(`--------------`);
   }
 }
@@ -67,21 +56,13 @@ async function performUpdate() {
     consola.log(`--------------`);
     consola.log(updateOutput.stdout);
     consola.log(`--------------`);
-    consola.success(
-      chalk.bold(
-        `Silverfin CLI succesfully updated to version ${updatedPkgVersion.stdout}`
-      )
-    );
+    consola.success(chalk.bold(`Silverfin CLI succesfully updated to version ${updatedPkgVersion.stdout}`));
 
     return updateOutput;
   } catch (error) {
     consola.log(`--------------`);
     consola.error(`${chalk.red("ERROR.")} Update of Silverfin CLI failed`);
-    consola.log(
-      `You can try running the following command: ${chalk.bold(
-        `npm install -g ${pkg.repository.url}`
-      )}`
-    );
+    consola.log(`You can try running the following command: ${chalk.bold(`npm install -g ${pkg.repository.url}`)}`);
     consola.log(`If that still fails, try updating NPM first.`);
   }
 }

--- a/lib/cli/devMode.js
+++ b/lib/cli/devMode.js
@@ -14,19 +14,9 @@ const chokidar = require("chokidar");
  * @param {boolean} renderInput - Open browser and show the HTML from input view
  */
 async function watchLiquidTest(firmId, handle, testName, renderInput) {
-  consola.info(
-    `Watching for changes related to reconciliation "${handle}" to run a new test...`
-  );
-  consola.warn(
-    `Don't forget to terminate this process when you don't need it anymore! (Ctrl + C)`
-  );
-  const filePath = path.resolve(
-    process.cwd(),
-    "reconciliation_texts",
-    handle,
-    "tests",
-    `${handle}_liquid_test.yml`
-  );
+  consola.info(`Watching for changes related to reconciliation "${handle}" to run a new test...`);
+  consola.warn(`Don't forget to terminate this process when you don't need it anymore! (Ctrl + C)`);
+  const filePath = path.resolve(process.cwd(), "reconciliation_texts", handle, "tests", `${handle}_liquid_test.yml`);
   if (!fs.existsSync(filePath)) {
     consola.warn("YAML file not found: ", filePath);
     return;
@@ -35,13 +25,7 @@ async function watchLiquidTest(firmId, handle, testName, renderInput) {
   // Watch YAML
   chokidar.watch(filePath).on("change", async (path) => {
     // Run test
-    await liquidTestRunner.runTestsWithOutput(
-      firmId,
-      handle,
-      testName,
-      false,
-      renderInput
-    );
+    await liquidTestRunner.runTestsWithOutput(firmId, handle, testName, false, renderInput);
   });
 
   // Watch liquid files
@@ -49,13 +33,7 @@ async function watchLiquidTest(firmId, handle, testName, renderInput) {
   for (let filePath of liquidFiles) {
     chokidar.watch(filePath).on("change", async (path) => {
       // Run test
-      await liquidTestRunner.runTestsWithOutput(
-        firmId,
-        handle,
-        testName,
-        false,
-        renderInput
-      );
+      await liquidTestRunner.runTestsWithOutput(firmId, handle, testName, false, renderInput);
     });
   }
 }
@@ -65,12 +43,8 @@ async function watchLiquidTest(firmId, handle, testName, renderInput) {
  * @param {Number} firmId
  */
 function watchLiquidFiles(firmId) {
-  consola.info(
-    "Watching for changes in all liquid files to publish their updates..."
-  );
-  consola.warn(
-    `Don't forget to terminate this process when you don't need it anymore! (Ctrl + C)`
-  );
+  consola.info("Watching for changes in all liquid files to publish their updates...");
+  consola.warn(`Don't forget to terminate this process when you don't need it anymore! (Ctrl + C)`);
   const files = fsUtils.listExistingFiles("liquid");
 
   // The fs.watch function in Node.js can sometimes be unstable and trigger multiple events for a single change, especially on certain platforms like macOS.

--- a/lib/cli/stats.js
+++ b/lib/cli/stats.js
@@ -21,9 +21,7 @@ async function generateOverview(sinceDate) {
 // Type could be: A (added), M (modified), D (deleted)
 async function yamlFilesActivity(sinceDate) {
   const countByType = {};
-  const filesChanged = exec.execSync(
-    `git whatchanged --since="${sinceDate}" --name-status --pretty="format:"`
-  );
+  const filesChanged = exec.execSync(`git whatchanged --since="${sinceDate}" --name-status --pretty="format:"`);
   if (!filesChanged) {
     consola.info("No files were changed since the date provided");
     return countByType;
@@ -138,18 +136,8 @@ async function listExternallyManagedTemplates(templateType, templateNames) {
 
 async function setMainPath(templateType, templateName) {
   const FOLDER = fsUtils.FOLDERS[templateType];
-  const mainPath = path.join(
-    process.cwd(),
-    FOLDER,
-    templateName,
-    "main.liquid"
-  );
-  const namePath = path.join(
-    process.cwd(),
-    FOLDER,
-    templateName,
-    `${templateName}.liquid`
-  );
+  const mainPath = path.join(process.cwd(), FOLDER, templateName, "main.liquid");
+  const namePath = path.join(process.cwd(), FOLDER, templateName, `${templateName}.liquid`);
   let filePath = undefined;
   if (fs.existsSync(mainPath)) {
     filePath = mainPath;
@@ -202,96 +190,49 @@ async function getTemplatesSummary() {
   };
 
   // Reconciliations
-  const reconciliationsNonEmpty =
-    await listNonEmptyTemplates("reconciliationText");
-  const reconciliationsExtMan = await listExternallyManagedTemplates(
-    "reconciliationText",
-    reconciliationsNonEmpty
-  );
+  const reconciliationsNonEmpty = await listNonEmptyTemplates("reconciliationText");
+  const reconciliationsExtMan = await listExternallyManagedTemplates("reconciliationText", reconciliationsNonEmpty);
   const reconciliationsTests = await countYamlFiles("reconciliationText");
   summary.reconciliations.total = reconciliationsNonEmpty.length;
   summary.reconciliations.externallyManaged = reconciliationsExtMan.length;
-  summary.reconciliations.externallyManagedPerc = percentageRoundTwo(
-    summary.reconciliations.externallyManaged,
-    summary.reconciliations.total
-  );
+  summary.reconciliations.externallyManagedPerc = percentageRoundTwo(summary.reconciliations.externallyManaged, summary.reconciliations.total);
   summary.reconciliations.yamlFiles = reconciliationsTests.files;
-  summary.reconciliations.yamlFilesPerc = percentageRoundTwo(
-    summary.reconciliations.yamlFiles,
-    summary.reconciliations.total
-  );
+  summary.reconciliations.yamlFilesPerc = percentageRoundTwo(summary.reconciliations.yamlFiles, summary.reconciliations.total);
   summary.reconciliations.unitTests = reconciliationsTests.tests;
 
   // Shared Parts
   const sharedPartsNonEmpty = await listNonEmptyTemplates("sharedPart");
-  const sharedPartsExtMan = await listExternallyManagedTemplates(
-    "sharedPart",
-    sharedPartsNonEmpty
-  );
+  const sharedPartsExtMan = await listExternallyManagedTemplates("sharedPart", sharedPartsNonEmpty);
   summary.sharedParts.total = sharedPartsNonEmpty.length;
   summary.sharedParts.externallyManaged = sharedPartsExtMan.length;
-  summary.sharedParts.externallyManagedPerc = percentageRoundTwo(
-    summary.sharedParts.externallyManaged,
-    summary.sharedParts.total
-  );
+  summary.sharedParts.externallyManagedPerc = percentageRoundTwo(summary.sharedParts.externallyManaged, summary.sharedParts.total);
 
   // Export Files
   const exportFilesNonEmpty = await listNonEmptyTemplates("exportFile");
-  const exportFilesExtMan = await listExternallyManagedTemplates(
-    "exportFile",
-    exportFilesNonEmpty
-  );
+  const exportFilesExtMan = await listExternallyManagedTemplates("exportFile", exportFilesNonEmpty);
   summary.exportFiles.total = exportFilesNonEmpty.length;
   summary.exportFiles.externallyManaged = exportFilesExtMan.length;
-  summary.exportFiles.externallyManagedPerc = percentageRoundTwo(
-    summary.exportFiles.externallyManaged,
-    summary.exportFiles.total
-  );
+  summary.exportFiles.externallyManagedPerc = percentageRoundTwo(summary.exportFiles.externallyManaged, summary.exportFiles.total);
 
   // Account Templates
-  const accountTemplatesNonEmpty =
-    await listNonEmptyTemplates("accountTemplate");
-  const accountTemplatesExtMan = await listExternallyManagedTemplates(
-    "accountTemplate",
-    accountTemplatesNonEmpty
-  );
+  const accountTemplatesNonEmpty = await listNonEmptyTemplates("accountTemplate");
+  const accountTemplatesExtMan = await listExternallyManagedTemplates("accountTemplate", accountTemplatesNonEmpty);
   const accountTemplatesTests = await countYamlFiles("accountTemplate");
   summary.accountTemplates.total = accountTemplatesNonEmpty.length;
   summary.accountTemplates.externallyManaged = accountTemplatesExtMan.length;
-  summary.accountTemplates.externallyManagedPerc = percentageRoundTwo(
-    summary.accountTemplates.externallyManaged, 
-    summary.accountTemplates.total
-  );
+  summary.accountTemplates.externallyManagedPerc = percentageRoundTwo(summary.accountTemplates.externallyManaged, summary.accountTemplates.total);
   summary.accountTemplates.yamlFiles = accountTemplatesTests.files;
-  summary.accountTemplates.yamlFilesPerc = percentageRoundTwo(
-    summary.accountTemplates.yamlFiles,
-    summary.accountTemplates.total
-  );
+  summary.accountTemplates.yamlFilesPerc = percentageRoundTwo(summary.accountTemplates.yamlFiles, summary.accountTemplates.total);
   summary.accountTemplates.unitTests = accountTemplatesTests.tests;
 
   // All
-  summary.all.total =
-    summary.reconciliations.total +
-    summary.sharedParts.total +
-    summary.exportFiles.total +
-    summary.accountTemplates.total;
+  summary.all.total = summary.reconciliations.total + summary.sharedParts.total + summary.exportFiles.total + summary.accountTemplates.total;
   summary.all.externallyManaged =
-    summary.reconciliations.externallyManaged +
-    summary.sharedParts.externallyManaged +
-    summary.exportFiles.externallyManaged +
-    summary.accountTemplates.externallyManaged;
-  summary.all.externallyManagedPerc = percentageRoundTwo(
-    summary.all.externallyManaged,
-    summary.all.total
-  )
-  summary.all.yamlFiles =
-    summary.reconciliations.yamlFiles + summary.accountTemplates.yamlFiles;
-  summary.all.yamlFilesPerc = percentageRoundTwo(
-    summary.all.yamlFiles,
-    summary.reconciliations.total+summary.accountTemplates.total
-  );
-  summary.all.unitTests =
-    summary.reconciliations.unitTests + summary.accountTemplates.unitTests;
+    summary.reconciliations.externallyManaged + summary.sharedParts.externallyManaged + summary.exportFiles.externallyManaged + summary.accountTemplates.externallyManaged;
+  summary.all.externallyManagedPerc = percentageRoundTwo(summary.all.externallyManaged, summary.all.total);
+  summary.all.yamlFiles = summary.reconciliations.yamlFiles + summary.accountTemplates.yamlFiles;
+  summary.all.yamlFilesPerc = percentageRoundTwo(summary.all.yamlFiles, summary.reconciliations.total + summary.accountTemplates.total);
+  summary.all.unitTests = summary.reconciliations.unitTests + summary.accountTemplates.unitTests;
 
   return summary;
 }
@@ -310,39 +251,29 @@ function displayOverview(sinceDate, today, templateSummary, yamlSummary) {
   consola.log("------------------------------------");
   consola.log("");
   consola.log(`New YAML files created in the period: ${yamlSummary.created}`);
-  consola.log(
-    `Updates to existing YAML files in the period: ${yamlSummary.updated}`
-  );
+  consola.log(`Updates to existing YAML files in the period: ${yamlSummary.updated}`);
   consola.log("");
   consola.log("------------------------------------");
   consola.log("");
   consola.log(`${chalk.bold("Reconciliations:")}`);
   consola.log(`Templates: ${templateSummary.reconciliations.total}`);
-  consola.log(
-    `Externally Managed: ${templateSummary.reconciliations.externallyManaged} (${templateSummary.reconciliations.externallyManagedPerc}%)`
-  );
+  consola.log(`Externally Managed: ${templateSummary.reconciliations.externallyManaged} (${templateSummary.reconciliations.externallyManagedPerc}%)`);
   consola.log(`YAML files: ${templateSummary.reconciliations.yamlFiles} (${templateSummary.reconciliations.yamlFilesPerc}%)`);
   consola.log(`Unit Tests: ${templateSummary.reconciliations.unitTests}`);
   consola.log("");
   consola.log(`${chalk.bold("Account Templates:")}`);
   consola.log(`Templates: ${templateSummary.accountTemplates.total}`);
-  consola.log(
-    `Externally Managed: ${templateSummary.accountTemplates.externallyManaged} (${templateSummary.accountTemplates.externallyManagedPerc}%)`
-  );
+  consola.log(`Externally Managed: ${templateSummary.accountTemplates.externallyManaged} (${templateSummary.accountTemplates.externallyManagedPerc}%)`);
   consola.log(`YAML files: ${templateSummary.accountTemplates.yamlFiles} (${templateSummary.accountTemplates.yamlFilesPerc}%)`);
   consola.log(`Unit Tests: ${templateSummary.accountTemplates.unitTests}`);
   consola.log("");
   consola.log(`${chalk.bold("Shared Parts:")}`);
   consola.log(`Templates: ${templateSummary.sharedParts.total}`);
-  consola.log(
-    `Externally Managed: ${templateSummary.sharedParts.externallyManaged} (${templateSummary.sharedParts.externallyManagedPerc}%)`
-  );
+  consola.log(`Externally Managed: ${templateSummary.sharedParts.externallyManaged} (${templateSummary.sharedParts.externallyManagedPerc}%)`);
   consola.log("");
   consola.log(`${chalk.bold("Export Files:")}`);
   consola.log(`Templates: ${templateSummary.exportFiles.total}`);
-  consola.log(
-    `Externally Managed: ${templateSummary.exportFiles.externallyManaged} (${templateSummary.exportFiles.externallyManagedPerc}%)`
-  );
+  consola.log(`Externally Managed: ${templateSummary.exportFiles.externallyManaged} (${templateSummary.exportFiles.externallyManagedPerc}%)`);
   consola.log("");
   consola.log(`${chalk.bold("All:")}`);
   consola.log(`Templates: ${templateSummary.all.total}`);
@@ -384,7 +315,6 @@ function createRow(sinceDate, today, templateSummary, yamlSummary) {
     templateSummary.all.yamlFilesPerc,
     templateSummary.reconciliations.yamlFilesPerc,
     templateSummary.accountTemplates.yamlFilesPerc,
-
   ];
   const row = `\r\n${rowContent.join(";")}`;
   return row;

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -36,9 +36,7 @@ function handleUncaughtErrors() {
 
 // Prompt Confirmation
 function promptConfirmation() {
-  const confirm = prompt(
-    "This will overwrite existing templates. Do you want to proceed? (y/n): "
-  );
+  const confirm = prompt("This will overwrite existing templates. Do you want to proceed? (y/n): ");
   if (confirm.toLocaleLowerCase() !== "yes" && confirm.toLowerCase() !== "y") {
     consola.warn("Operation cancelled");
     process.exit(1);
@@ -70,26 +68,15 @@ function checkUniqueOption(uniqueParameters = [], options) {
 
   // Check if minimum one of the options is used
   if (optionsToCheck.length === 0) {
-    let formattedParameters = uniqueParameters.map((parameter) =>
-      formatOption(parameter)
-    );
-    consola.error(
-      `One of the following options must be used: ${formattedParameters.join(
-        ", "
-      )}`
-    );
+    let formattedParameters = uniqueParameters.map((parameter) => formatOption(parameter));
+    consola.error(`One of the following options must be used: ${formattedParameters.join(", ")}`);
     process.exit(1);
   }
 
   // Check if the options aren't used together
   if (optionsToCheck.length !== 1) {
-    let formattedParameters = uniqueParameters.map((parameter) =>
-      formatOption(parameter)
-    );
-    consola.error(
-      "Used incompatible options. Only one of the following options must be used: " +
-        formattedParameters.join(", ")
-    );
+    let formattedParameters = uniqueParameters.map((parameter) => formatOption(parameter));
+    consola.error("Used incompatible options. Only one of the following options must be used: " + formattedParameters.join(", "));
     process.exit(1);
   }
 
@@ -97,23 +84,13 @@ function checkUniqueOption(uniqueParameters = [], options) {
 }
 
 // Check which options are required in combination with a firm id
-function checkRequiredFirmOrPartner(
-  options,
-  requiredOptions,
-  partnerSupported = true
-) {
-  const firmOrPartnerOptionsUsed = Object.keys(options).some((option) =>
-    requiredOptions.includes(option)
-  );
+function checkRequiredFirmOrPartner(options, requiredOptions, partnerSupported = true) {
+  const firmOrPartnerOptionsUsed = Object.keys(options).some((option) => requiredOptions.includes(option));
   const { firm, partner } = options;
 
   if (firmOrPartnerOptionsUsed && !firm && !partner) {
     consola.error(
-      `A firm${
-        partnerSupported ? " or partner id" : ""
-      } is required, please use --firm${
-        partnerSupported ? " , --partner" : ""
-      } or set a default firm id when using this command`
+      `A firm${partnerSupported ? " or partner id" : ""} is required, please use --firm${partnerSupported ? " , --partner" : ""} or set a default firm id when using this command`
     );
 
     process.exit(1);
@@ -134,26 +111,15 @@ function getCommandSettings(options) {
   return commandSettings;
 }
 
-function runCommandChecks(
-  requiredTemplateOptions,
-  options,
-  firmIdDefault,
-  messageRequired = false,
-  skipConfirmation = false
-) {
+function runCommandChecks(requiredTemplateOptions, options, firmIdDefault, messageRequired = false, skipConfirmation = false) {
   if (options.partner) {
     if (messageRequired && !options.message) {
-      consola.error(
-        `Message required when updating a partner template. Please use "--message"`
-      );
+      consola.error(`Message required when updating a partner template. Please use "--message"`);
       process.exit(1);
     }
   }
 
-  checkRequiredFirmOrPartner(
-    options,
-    requiredTemplateOptions,
-  );
+  checkRequiredFirmOrPartner(options, requiredTemplateOptions);
   checkUniqueOption(requiredTemplateOptions, options);
   const settings = getCommandSettings(options);
 

--- a/lib/liquidTestGenerator.js
+++ b/lib/liquidTestGenerator.js
@@ -13,9 +13,7 @@ async function testGenerator(url, testName) {
 
   // Check if firm is authhorized
   if (!firmCredentials.data.hasOwnProperty(parameters.firmId)) {
-    consola.error(
-      `You have no authorization to access firm id ${parameters.firmId}`
-    );
+    consola.error(`You have no authorization to access firm id ${parameters.firmId}`);
     process.exit(1);
   }
   firmId = parameters.firmId;
@@ -24,43 +22,21 @@ async function testGenerator(url, testName) {
   liquidTestObject[testName].expectation.reconciled = reconciledStatus;
 
   // Get Reconciliation Details
-  const responseDetails = await SF.readReconciliationTextDetails(
-    "firm",
-    parameters.firmId,
-    parameters.companyId,
-    parameters.ledgerId,
-    parameters.reconciliationId
-  );
+  const responseDetails = await SF.readReconciliationTextDetails("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, parameters.reconciliationId);
   const reconciliationHandle = responseDetails.data.handle;
 
   // Get Workflow Information
   const starredStatus = {
-    ...SF.findReconciliationInWorkflow(
-      parameters.firmId,
-      reconciliationHandle,
-      parameters.companyId,
-      parameters.ledgerId,
-      parameters.workflowId
-    ),
+    ...SF.findReconciliationInWorkflow(parameters.firmId, reconciliationHandle, parameters.companyId, parameters.ledgerId, parameters.workflowId),
   }.starred;
 
   // Get period data
-  const responsePeriods = await SF.getPeriods(
-    parameters.firmId,
-    parameters.companyId
-  );
-  const currentPeriodData = SF.findPeriod(
-    parameters.ledgerId,
-    responsePeriods.data
-  );
+  const responsePeriods = await SF.getPeriods(parameters.firmId, parameters.companyId);
+  const currentPeriodData = SF.findPeriod(parameters.ledgerId, responsePeriods.data);
 
   // Set Current Period
-  liquidTestObject[testName].context.period = String(
-    currentPeriodData.fiscal_year.end_date
-  );
-  liquidTestObject[testName].data.periods[
-    currentPeriodData.fiscal_year.end_date
-  ] = liquidTestObject[testName].data.periods["replace_period_name"];
+  liquidTestObject[testName].context.period = String(currentPeriodData.fiscal_year.end_date);
+  liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date] = liquidTestObject[testName].data.periods["replace_period_name"];
   delete liquidTestObject[testName].data.periods["replace_period_name"];
 
   // Check Previous Period
@@ -68,50 +44,26 @@ async function testGenerator(url, testName) {
   const periodsMaxIndex = responsePeriods.data.length - 1;
   if (currentPeriodIndex < periodsMaxIndex) {
     const previousPeriodData = responsePeriods.data[currentPeriodIndex + 1];
-    if (
-      previousPeriodData &&
-      previousPeriodData.fiscal_year.end_date !=
-        currentPeriodData.fiscal_year.end_date
-    ) {
+    if (previousPeriodData && previousPeriodData.fiscal_year.end_date != currentPeriodData.fiscal_year.end_date) {
       // Add empty previous period to Liquid Test
-      liquidTestObject[testName].data.periods[
-        previousPeriodData.fiscal_year.end_date
-      ] = null;
+      liquidTestObject[testName].data.periods[previousPeriodData.fiscal_year.end_date] = null;
     }
   }
 
   // Get all the text properties (Customs from current template)
-  const responseCustom = await SF.getReconciliationCustom(
-    "firm",
-    parameters.firmId,
-    parameters.companyId,
-    parameters.ledgerId,
-    parameters.reconciliationId
-  );
+  const responseCustom = await SF.getReconciliationCustom("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, parameters.reconciliationId);
   const currentReconCustom = Utils.processCustom(responseCustom.data);
-  liquidTestObject[testName].data.periods[
-    currentPeriodData.fiscal_year.end_date
-  ].reconciliations[reconciliationHandle] = {
+  liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[reconciliationHandle] = {
     starred: starredStatus,
     custom: currentReconCustom,
   };
 
   // Get all the results generated in current template
-  const responseResults = await SF.getReconciliationResults(
-    "firm",
-    parameters.firmId,
-    parameters.companyId,
-    parameters.ledgerId,
-    parameters.reconciliationId
-  );
+  const responseResults = await SF.getReconciliationResults("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, parameters.reconciliationId);
   liquidTestObject[testName].expectation.results = responseResults.data;
 
   // Get the code of the template
-  const reconciliationCode = await SF.findReconciliationTextByHandle(
-    "firm",
-    parameters.firmId,
-    reconciliationHandle
-  );
+  const reconciliationCode = await SF.findReconciliationTextByHandle("firm", parameters.firmId, reconciliationHandle);
   if (!reconciliationCode) {
     consola.warn(`Reconciliation "${reconciliationHandle}" wasn't found`);
     process.exit();
@@ -119,60 +71,33 @@ async function testGenerator(url, testName) {
 
   // Search for results from other reconciliations used in the liquid code (main and text_parts)
   let resultsObj;
-  resultsObj = Utils.searchForResultsFromDependenciesInLiquid(
-    reconciliationCode,
-    reconciliationHandle
-  );
+  resultsObj = Utils.searchForResultsFromDependenciesInLiquid(reconciliationCode, reconciliationHandle);
 
   // Search for custom drops from other reconcilations used in the liquid code (main and text_parts)
   let customsObj;
-  customsObj = Utils.searchForCustomsFromDependenciesInLiquid(
-    reconciliationCode,
-    reconciliationHandle
-  );
+  customsObj = Utils.searchForCustomsFromDependenciesInLiquid(reconciliationCode, reconciliationHandle);
 
   // Search for shared parts in the liquid code (main and text_parts)
-  const sharedPartsUsed = Utils.lookForSharedPartsInLiquid(
-    reconciliationCode,
-    reconciliationHandle
-  );
+  const sharedPartsUsed = Utils.lookForSharedPartsInLiquid(reconciliationCode, reconciliationHandle);
   if (sharedPartsUsed && sharedPartsUsed.length != 0) {
     for (sharedPartName of sharedPartsUsed) {
       // Look for shared part id
-      let sharedPartResponse = await SF.findSharedPartByName(
-        "firm",
-        parameters.firmId,
-        sharedPartName
-      );
+      let sharedPartResponse = await SF.findSharedPartByName("firm", parameters.firmId, sharedPartName);
       let sharedPartId = sharedPartResponse.id;
       // Get shared part details
-      let sharedPartDetails = await SF.readSharedPartById(
-        "firm",
-        parameters.firmId,
-        sharedPartId
-      );
+      let sharedPartDetails = await SF.readSharedPartById("firm", parameters.firmId, sharedPartId);
       // Look for nested shared parts (in that case, add them to this same loop)
-      let nestedSharedParts = Utils.lookForSharedPartsInLiquid(
-        sharedPartDetails.data
-      );
+      let nestedSharedParts = Utils.lookForSharedPartsInLiquid(sharedPartDetails.data);
       for (nested of nestedSharedParts) {
         if (!sharedPartsUsed.includes(nested)) {
           sharedPartsUsed.push(nested);
         }
       }
       // Search for results from other reconciliations in shared part (we append to existing collection)
-      resultsObj = Utils.searchForResultsFromDependenciesInLiquid(
-        sharedPartDetails.data,
-        sharedPartDetails.data.name,
-        resultsObj
-      );
+      resultsObj = Utils.searchForResultsFromDependenciesInLiquid(sharedPartDetails.data, sharedPartDetails.data.name, resultsObj);
 
       // Search for custom drops from other reconcilations in shared parts (we append to existing collection)
-      customsObj = Utils.searchForCustomsFromDependenciesInLiquid(
-        sharedPartDetails.data,
-        sharedPartDetails.data.name,
-        customsObj
-      );
+      customsObj = Utils.searchForCustomsFromDependenciesInLiquid(sharedPartDetails.data, sharedPartDetails.data.name, customsObj);
     }
   }
 
@@ -182,41 +107,19 @@ async function testGenerator(url, testName) {
     for (const [handle, resultsArray] of Object.entries(resultsObj)) {
       try {
         // Find reconciliation in Workflow to get id (depdeency template can be in a different Workflow)
-        let reconciliation = await SF.findReconciliationInWorkflows(
-          parameters.firmId,
-          handle,
-          parameters.companyId,
-          parameters.ledgerId
-        );
+        let reconciliation = await SF.findReconciliationInWorkflows(parameters.firmId, handle, parameters.companyId, parameters.ledgerId);
         if (reconciliation) {
           // Fetch results
-          let reconciliationResults = await SF.getReconciliationResults(
-            "firm",
-            parameters.firmId,
-            parameters.companyId,
-            parameters.ledgerId,
-            reconciliation.id
-          );
+          let reconciliationResults = await SF.getReconciliationResults("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, reconciliation.id);
           // Add handle and results block to Liquid Test
-          liquidTestObject[testName].data.periods[
-            currentPeriodData.fiscal_year.end_date
-          ].reconciliations[handle] =
-            liquidTestObject[testName].data.periods[
-              currentPeriodData.fiscal_year.end_date
-            ].reconciliations[handle] || {};
-          liquidTestObject[testName].data.periods[
-            currentPeriodData.fiscal_year.end_date
-          ].reconciliations[handle].results =
-            liquidTestObject[testName].data.periods[
-              currentPeriodData.fiscal_year.end_date
-            ].reconciliations[handle].results || {};
+          liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle] =
+            liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle] || {};
+          liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle].results =
+            liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle].results || {};
           // Search for results
           for (resultTag of resultsArray) {
             // Add result to Liquid Test
-            liquidTestObject[testName].data.periods[
-              currentPeriodData.fiscal_year.end_date
-            ].reconciliations[handle].results[resultTag] =
-              reconciliationResults.data[resultTag];
+            liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle].results[resultTag] = reconciliationResults.data[resultTag];
           }
         }
       } catch (err) {
@@ -236,44 +139,23 @@ async function testGenerator(url, testName) {
     for (const [handle, customsArray] of Object.entries(customsObj)) {
       try {
         // Find reconciliation in Workflow to get id (depdeency template can be in a different Workflow)
-        let reconciliation = await SF.findReconciliationInWorkflows(
-          parameters.firmId,
-          handle,
-          parameters.companyId,
-          parameters.ledgerId
-        );
+        let reconciliation = await SF.findReconciliationInWorkflows(parameters.firmId, handle, parameters.companyId, parameters.ledgerId);
         if (reconciliation) {
           // Fetch test properties
-          let reconciliationCustomResponse = await SF.getReconciliationCustom(
-            "firm",
-            parameters.firmId,
-            parameters.companyId,
-            parameters.ledgerId,
-            reconciliation.id
-          );
-          let reconciliationCustomDrops = Utils.processCustom(
-            reconciliationCustomResponse.data
-          );
+          let reconciliationCustomResponse = await SF.getReconciliationCustom("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, reconciliation.id);
+          let reconciliationCustomDrops = Utils.processCustom(reconciliationCustomResponse.data);
           // Filter Customs
           let dropsKeys = Object.keys(reconciliationCustomDrops);
-          const matchingKeys = dropsKeys.filter(
-            (key) => customsArray.indexOf(key) !== -1
-          );
+          const matchingKeys = dropsKeys.filter((key) => customsArray.indexOf(key) !== -1);
           const filteredCustomDrops = {};
           for (key of matchingKeys) {
             filteredCustomDrops[key] = reconciliationCustomDrops[key];
           }
           // Add handle to Liquid Test
-          liquidTestObject[testName].data.periods[
-            currentPeriodData.fiscal_year.end_date
-          ].reconciliations[handle] =
-            liquidTestObject[testName].data.periods[
-              currentPeriodData.fiscal_year.end_date
-            ].reconciliations[handle] || {};
+          liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle] =
+            liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle] || {};
           // Add custom drops
-          liquidTestObject[testName].data.periods[
-            currentPeriodData.fiscal_year.end_date
-          ].reconciliations[handle].custom = filteredCustomDrops;
+          liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].reconciliations[handle].custom = filteredCustomDrops;
         }
       } catch (err) {
         consola.error(err);
@@ -282,24 +164,15 @@ async function testGenerator(url, testName) {
   }
 
   // Get company drop used in the liquid code (main and text_parts)
-  const companyObj = Utils.getCompanyDependencies(
-    reconciliationCode,
-    reconciliationHandle
-  );
+  const companyObj = Utils.getCompanyDependencies(reconciliationCode, reconciliationHandle);
 
-  if (
-    companyObj.standardDropElements.length !== 0 ||
-    companyObj.customDropElements.length !== 0
-  ) {
+  if (companyObj.standardDropElements.length !== 0 || companyObj.customDropElements.length !== 0) {
     liquidTestObject[testName].data.company = {};
   }
 
   // Get Company Data - company drop
   if (companyObj.standardDropElements.length !== 0) {
-    const responseCompanyDrop = await SF.getCompanyDrop(
-      parameters.firmId,
-      parameters.companyId
-    );
+    const responseCompanyDrop = await SF.getCompanyDrop(parameters.firmId, parameters.companyId);
     const companyData = responseCompanyDrop.data; // { foo: bar, baz: bat ... }
 
     for (drop of companyObj.standardDropElements) {
@@ -313,10 +186,7 @@ async function testGenerator(url, testName) {
 
   // Get Company Data - custom drop
   if (companyObj.customDropElements.length !== 0) {
-    const responseCompanyCustom = await SF.getCompanyCustom(
-      parameters.firmId,
-      parameters.companyId
-    );
+    const responseCompanyCustom = await SF.getCompanyCustom(parameters.firmId, parameters.companyId);
     const companyCustom = responseCompanyCustom.data; // [ { namespace: foo, key: bar, value: baz }... ]
     liquidTestObject[testName].data.company.custom = {};
 
@@ -330,8 +200,7 @@ async function testGenerator(url, testName) {
       if (foundItem) {
         let namespaceKey = `${namespace}.${key}`;
         // Add to Liquid Test
-        liquidTestObject[testName].data.company.custom[namespaceKey] =
-          foundItem.value;
+        liquidTestObject[testName].data.company.custom[namespaceKey] = foundItem.value;
       }
     }
   }
@@ -339,24 +208,15 @@ async function testGenerator(url, testName) {
   // Search for account ids in customs
   const accountIds = Utils.lookForAccountsIDs(liquidTestObject);
   if (accountIds.length != 0) {
-    liquidTestObject[testName].data.periods[
-      currentPeriodData.fiscal_year.end_date
-    ].accounts = {};
+    liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].accounts = {};
     for (accountId of accountIds) {
       accountId = accountId.replace("#", "");
       // Current Period
       try {
-        let accountResponse = await SF.getAccountDetails(
-          parameters.firmId,
-          parameters.companyId,
-          parameters.ledgerId,
-          accountId
-        );
+        let accountResponse = await SF.getAccountDetails(parameters.firmId, parameters.companyId, parameters.ledgerId, accountId);
         // If value is zero it won't be found ?
         if (accountResponse) {
-          liquidTestObject[testName].data.periods[
-            currentPeriodData.fiscal_year.end_date
-          ].accounts[accountResponse.data.account.number] = {
+          liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].accounts[accountResponse.data.account.number] = {
             id: accountResponse.data.account.id,
             name: accountResponse.data.account.name,
             value: Number(accountResponse.data.value),

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -60,18 +60,11 @@ function buildTestParams(firmId, handle, testName = "", renderMode) {
   const templateContent = ReconciliationText.read(handle);
   templateContent.handle = handle;
   templateContent.reconciliation_type = config.reconciliation_type;
-  const sharedParts = fsUtils.listSharedPartsUsedInTemplate(
-    firmId,
-    "reconciliationText",
-    handle
-  );
+  const sharedParts = fsUtils.listSharedPartsUsedInTemplate(firmId, "reconciliationText", handle);
   if (sharedParts.length !== 0) {
     templateContent.text_shared_parts = [];
     for (let sharedPart of sharedParts) {
-      let sharedPartContent = fs.readFileSync(
-        `shared_parts/${sharedPart}/${sharedPart}.liquid`,
-        "utf-8"
-      );
+      let sharedPartContent = fs.readFileSync(`shared_parts/${sharedPart}/${sharedPart}.liquid`, "utf-8");
       templateContent.text_shared_parts.push({
         name: sharedPart,
         content: sharedPartContent,
@@ -124,13 +117,7 @@ async function fetchResult(firmId, testRunId) {
 
 function listErrors(items, type) {
   const itemsKeys = Object.keys(items);
-  consola.log(
-    chalk.red(
-      `${itemsKeys.length} ${type} expectation${
-        itemsKeys.length > 1 ? "s" : ""
-      } failed`
-    )
-  );
+  consola.log(chalk.red(`${itemsKeys.length} ${type} expectation${itemsKeys.length > 1 ? "s" : ""} failed`));
   itemsKeys.forEach((itemName) => {
     let itemDetails = items[itemName];
     consola.log(`At line number ${itemDetails.line_number}`);
@@ -170,9 +157,7 @@ function listErrors(items, type) {
     }
 
     consola.log(
-      `For ${type} ${chalk.blue.bold(itemName)} got ${chalk.blue.bold(
-        displayedGot
-      )} (${chalk.italic(gotDataType)}) but expected ${chalk.blue.bold(
+      `For ${type} ${chalk.blue.bold(itemName)} got ${chalk.blue.bold(displayedGot)} (${chalk.italic(gotDataType)}) but expected ${chalk.blue.bold(
         displayedExpected
       )} (${chalk.italic(expectedDataType)})`
     );
@@ -207,10 +192,7 @@ function checkTestErrorsPresent(testName, testsFeedback) {
       if (section === "reconciled" && sectionElement !== null) {
         errorsPresent = true;
         break;
-      } else if (
-        (section === "results" || section === "rollforwards") &&
-        Object.keys(sectionElement).length > 0
-      ) {
+      } else if ((section === "results" || section === "rollforwards") && Object.keys(sectionElement).length > 0) {
         errorsPresent = true;
         break;
       }
@@ -223,9 +205,7 @@ function processTestRunResponse(testRun, previewOnly) {
   // Possible status: started, completed, test_error, internal_error
   switch (testRun.status) {
     case "internal_error":
-      consola.error(
-        "Internal error. Try to run the test again or contact support if the issue persists."
-      );
+      consola.error("Internal error. Try to run the test again or contact support if the issue persists.");
       break;
     case "test_error":
       consola.error("Ran into an error an couldn't complete test run");
@@ -235,35 +215,22 @@ function processTestRunResponse(testRun, previewOnly) {
       const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
       if (errorsPresent === false) {
         if (previewOnly) {
-          consola.success(
-            chalk.green("SUCCESSFULLY RENDERED HTML (SKIPPED TESTS)")
-          );
+          consola.success(chalk.green("SUCCESSFULLY RENDERED HTML (SKIPPED TESTS)"));
         } else {
           consola.success(chalk.green("ALL TESTS HAVE PASSED"));
         }
       } else {
         consola.log("");
-        consola.log(
-          chalk.red(
-            `${Object.keys(testRun.tests).length} TEST${
-              Object.keys(testRun.tests).length > 1 ? "S" : ""
-            } FAILED`
-          )
-        );
+        consola.log(chalk.red(`${Object.keys(testRun.tests).length} TEST${Object.keys(testRun.tests).length > 1 ? "S" : ""} FAILED`));
 
         const tests = Object.keys(testRun.tests).sort();
         tests.forEach((testName) => {
-          let testErrorsPresent = checkTestErrorsPresent(
-            testName,
-            testRun.tests
-          );
+          let testErrorsPresent = checkTestErrorsPresent(testName, testRun.tests);
           // No errors in this test
           if (!testErrorsPresent) {
             return;
           }
-          consola.log(
-            "---------------------------------------------------------------"
-          );
+          consola.log("---------------------------------------------------------------");
           consola.log(chalk.bold(testName));
 
           let testElements = testRun.tests[testName];
@@ -286,16 +253,8 @@ function processTestRunResponse(testRun, previewOnly) {
           // Reconciled
           if (testElements.reconciled !== null) {
             consola.log(chalk.red("Reconciliation expectation failed"));
-            consola.log(
-              `At line number ${testElements.reconciled.line_number}`
-            );
-            consola.log(
-              `got ${chalk.blue.bold(
-                testElements.reconciled.got
-              )} but expected ${chalk.blue.bold(
-                testElements.reconciled.expected
-              )}`
-            );
+            consola.log(`At line number ${testElements.reconciled.line_number}`);
+            consola.log(`got ${chalk.blue.bold(testElements.reconciled.got)} but expected ${chalk.blue.bold(testElements.reconciled.expected)}`);
             consola.log("");
           }
 
@@ -334,12 +293,8 @@ async function getHTML(url, testName, openBrowser = false, htmlMode) {
         if (commandExistsSync("wsl-open")) {
           exec(`wsl-open ${filePath}`);
         } else {
-          consola.info(
-            "In order to automatically open HTML files on WSL, we need to install the wsl-open script."
-          );
-          consola.log(
-            "You might be prompted for your password in order for us to install 'sudo npm install -g wsl-open'"
-          );
+          consola.info("In order to automatically open HTML files on WSL, we need to install the wsl-open script.");
+          consola.log("You might be prompted for your password in order for us to install 'sudo npm install -g wsl-open'");
           execSync("sudo npm install -g wsl-open");
           consola.log("Installed wsl-open script");
           exec(`wsl-open ${filePath}`);
@@ -374,12 +329,7 @@ async function getHTMLrenders(renderMode, testName, testRun, openBrowser) {
   };
   const htmlModesToRender = htmlModes[renderMode];
   for (let htmlMode of htmlModesToRender) {
-    await getHTML(
-      testRun.tests[testName][htmlMode],
-      testName,
-      openBrowser,
-      htmlMode
-    );
+    await getHTML(testRun.tests[testName][htmlMode], testName, openBrowser, htmlMode);
   }
 }
 
@@ -398,13 +348,7 @@ async function handleHTMLfiles(testName = "", testRun, renderMode) {
 }
 
 // Used by VSCode Extension
-async function runTests(
-  firmId,
-  handle,
-  testName = "",
-  previewOnly = false,
-  renderMode = "none"
-) {
+async function runTests(firmId, handle, testName = "", previewOnly = false, renderMode = "none") {
   try {
     const testParams = buildTestParams(firmId, handle, testName, renderMode);
     if (!testParams) return;
@@ -430,35 +374,15 @@ async function runTests(
   }
 }
 
-async function runTestsWithOutput(
-  firmId,
-  handle,
-  testName = "",
-  previewOnly = false,
-  htmlInput = false,
-  htmlPreview = false
-) {
+async function runTestsWithOutput(firmId, handle, testName = "", previewOnly = false, htmlInput = false, htmlPreview = false) {
   try {
     const renderMode = runTestUtils.checkRenderMode(htmlInput, htmlPreview);
-    const testsRun = await runTests(
-      firmId,
-      handle,
-      testName,
-      previewOnly,
-      renderMode
-    );
+    const testsRun = await runTests(firmId, handle, testName, previewOnly, renderMode);
     if (!testsRun) return;
 
-    processTestRunResponse(
-      testsRun?.testRun || testsRun?.previewRun,
-      previewOnly
-    );
+    processTestRunResponse(testsRun?.testRun || testsRun?.previewRun, previewOnly);
 
-    if (
-      testsRun.previewRun &&
-      testsRun.previewRun.status !== "test_error" &&
-      renderMode !== "none"
-    ) {
+    if (testsRun.previewRun && testsRun.previewRun.status !== "test_error" && renderMode !== "none") {
       handleHTMLfiles(testName, testsRun.previewRun, renderMode);
     }
   } catch (error) {

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -4,16 +4,7 @@ const templateUtils = require("../utils/templateUtils");
 const { consola } = require("consola");
 
 class AccountTemplate {
-  static CONFIG_ITEMS = [
-    "name_en",
-    "name_fr",
-    "name_nl",
-    "externally_managed",
-    "account_range",
-    "mapping_list_ranges",
-    "published",
-    "hide_code",
-  ];
+  static CONFIG_ITEMS = ["name_en", "name_fr", "name_nl", "externally_managed", "account_range", "mapping_list_ranges", "published", "hide_code"];
   static TEMPLATE_TYPE = "accountTemplate";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -28,17 +19,13 @@ class AccountTemplate {
     if (!template?.name_nl) {
       consola.warn(
         `Template name_nl is missing "${
-          template?.name_en ||
-          template?.name_fr ||
-          template?.name_da ||
-          template?.name_de
+          template?.name_en || template?.name_fr || template?.name_da || template?.name_de
         }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because the NL name is the only required field for a template name.`
       );
       return false;
     } // NL must be enabled in "Advanced Settings" in Silverfin
     if (templateUtils.missingLiquidCode(template)) return false;
-    if (!templateUtils.checkValidName(template?.name_nl, this.TEMPLATE_TYPE))
-      return false;
+    if (!templateUtils.checkValidName(template?.name_nl, this.TEMPLATE_TYPE)) return false;
 
     const name = template.name_nl;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name);
@@ -54,15 +41,9 @@ class AccountTemplate {
 
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    const configDetails = this.#prepareConfigDetails(
-      type,
-      envId,
-      template,
-      existingConfig
-    );
+    const configDetails = this.#prepareConfigDetails(type, envId, template, existingConfig);
 
-    const addNewId = (currentType, typeCheck, envId, template) =>
-      currentType == typeCheck ? { [envId]: template.id } : {};
+    const addNewId = (currentType, typeCheck, envId, template) => (currentType == typeCheck ? { [envId]: template.id } : {});
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
@@ -101,7 +82,7 @@ class AccountTemplate {
   /** Update template's id for the corresponding firm in template's config file */
   static updateTemplateId(type, envId, name, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    fsUtils.setTemplateId(type, envId, templateConfig, templateId)
+    fsUtils.setTemplateId(type, envId, templateConfig, templateId);
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
@@ -140,23 +121,14 @@ class AccountTemplate {
     */
 
     const existingMappingRanges = existingConfig.mapping_list_ranges || [];
-    const latestMappingListIds = template.mapping_list_ranges.map((range) =>
-      type == "partner"
-        ? range.partner_account_mapping_list_id
-        : range.account_mapping_list_id
-    );
+    const latestMappingListIds = template.mapping_list_ranges.map((range) => (type == "partner" ? range.partner_account_mapping_list_id : range.account_mapping_list_id));
 
     let updatedMappingRanges = [...existingMappingRanges];
 
     // Remove the mapping list ranges from this partner / firm env_id which are no longer part of the response
     updatedMappingRanges =
       updatedMappingRanges?.filter(
-        (range) =>
-          latestMappingListIds.includes(
-            type == "partner"
-              ? range.partner_account_mapping_list_id
-              : range.account_mapping_list_id
-          ) || range.env_id !== envId
+        (range) => latestMappingListIds.includes(type == "partner" ? range.partner_account_mapping_list_id : range.account_mapping_list_id) || range.env_id !== envId
       ) || [];
 
     for (let latestMappingListRange of template.mapping_list_ranges) {
@@ -165,15 +137,11 @@ class AccountTemplate {
 
       if (type == "partner") {
         existingIndex = existingMappingRanges.findIndex(
-          (existingMappingListRange) =>
-            existingMappingListRange.partner_account_mapping_list_id ===
-            latestMappingListRange.partner_account_mapping_list_id
+          (existingMappingListRange) => existingMappingListRange.partner_account_mapping_list_id === latestMappingListRange.partner_account_mapping_list_id
         );
       } else {
         existingIndex = existingMappingRanges.findIndex(
-          (existingMappingListRange) =>
-            existingMappingListRange.account_mapping_list_id ===
-            latestMappingListRange.account_mapping_list_id
+          (existingMappingListRange) => existingMappingListRange.account_mapping_list_id === latestMappingListRange.account_mapping_list_id
         );
       }
 
@@ -221,11 +189,7 @@ class AccountTemplate {
   static #createMainLiquid(name) {
     const relativePath = `./${this.TEMPLATE_FOLDER}/${name}`;
     if (!fs.existsSync(`${relativePath}/main.liquid`)) {
-      fsUtils.createLiquidFile(
-        relativePath,
-        "main",
-        "{% comment %} MAIN PART {% endcomment %}"
-      );
+      fsUtils.createLiquidFile(relativePath, "main", "{% comment %} MAIN PART {% endcomment %}");
     }
   }
 

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -3,14 +3,7 @@ const fsUtils = require("../utils/fsUtils");
 const templateUtils = require("../utils/templateUtils");
 
 class ExportFile {
-  static CONFIG_ITEMS = [
-    "name",
-    "file_name",
-    "externally_managed",
-    "encoding",
-    "published",
-    "hide_code",
-  ];
+  static CONFIG_ITEMS = ["name", "file_name", "externally_managed", "encoding", "published", "hide_code"];
   static TEMPLATE_TYPE = "exportFile";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -23,8 +16,7 @@ class ExportFile {
    */
   static save(type, envId, template) {
     if (templateUtils.missingLiquidCode(template)) return false;
-    if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
-      return false;
+    if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE)) return false;
 
     const name = template.name;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name, false);
@@ -38,8 +30,7 @@ class ExportFile {
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
     const configDetails = this.#prepareConfigDetails(template, existingConfig);
 
-    const addNewId = (currentType, typeCheck, envId, template) =>
-      currentType == typeCheck ? { [envId]: template.id } : {};
+    const addNewId = (currentType, typeCheck, envId, template) => (currentType == typeCheck ? { [envId]: template.id } : {});
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
@@ -76,7 +67,7 @@ class ExportFile {
   /** Update template's id for the corresponding firm in template's config file */
   static updateTemplateId(type, envId, name, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    fsUtils.setTemplateId(type, envId, templateConfig, templateId)
+    fsUtils.setTemplateId(type, envId, templateConfig, templateId);
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
@@ -112,11 +103,7 @@ class ExportFile {
   static #createMainLiquid(name) {
     const relativePath = `./${this.TEMPLATE_FOLDER}/${name}`;
     if (!fs.existsSync(`${relativePath}/main.liquid`)) {
-      fsUtils.createLiquidFile(
-        relativePath,
-        "main",
-        "{% comment %} MAIN PART {% endcomment %}"
-      );
+      fsUtils.createLiquidFile(relativePath, "main", "{% comment %} MAIN PART {% endcomment %}");
     }
   }
 

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -22,14 +22,8 @@ class ReconciliationText {
     "use_full_width",
     "downloadable_as_docx",
   ];
-  static RECONCILIATION_TYPE_OPTIONS = [
-    "reconciliation_not_necessary",
-    "can_be_reconciled_without_data",
-    "only_reconciled_with_data",
-  ];
-  static EXTERNALLY_MANAGED_ITEMS = [
-    "downloadable_as_docx"
-  ];
+  static RECONCILIATION_TYPE_OPTIONS = ["reconciliation_not_necessary", "can_be_reconciled_without_data", "only_reconciled_with_data"];
+  static EXTERNALLY_MANAGED_ITEMS = ["downloadable_as_docx"];
   static TEMPLATE_TYPE = "reconciliationText";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -43,8 +37,7 @@ class ReconciliationText {
   static async save(type, envId, template) {
     if (this.#missingHandle(template)) return false;
     if (templateUtils.missingLiquidCode(template)) return false;
-    if (!templateUtils.checkValidName(template.handle, this.TEMPLATE_TYPE))
-      return false;
+    if (!templateUtils.checkValidName(template.handle, this.TEMPLATE_TYPE)) return false;
 
     const handle = template.handle;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, handle, true);
@@ -52,12 +45,7 @@ class ReconciliationText {
     // Liquid files
     const mainPart = template.text;
     const textParts = templateUtils.filterParts(template);
-    fsUtils.createTemplateFiles(
-      this.TEMPLATE_TYPE,
-      handle,
-      mainPart,
-      textParts
-    );
+    fsUtils.createTemplateFiles(this.TEMPLATE_TYPE, handle, mainPart, textParts);
 
     // Liquid Test YAML
     let testContent = "# Add your Liquid Tests here";
@@ -69,8 +57,7 @@ class ReconciliationText {
     // Fetch existing config file
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
     const configDetails = this.#prepareConfigDetails(template, existingConfig);
-    const addNewId = (currentType, typeCheck, envId, template) =>
-      currentType == typeCheck ? { [envId]: template.id } : {};
+    const addNewId = (currentType, typeCheck, envId, template) => (currentType == typeCheck ? { [envId]: template.id } : {});
 
     const configContent = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
@@ -118,15 +105,13 @@ class ReconciliationText {
   /** Update template's id for the corresponding firm in template's config file */
   static updateTemplateId(type, envId, handle, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, handle);
-    fsUtils.setTemplateId(type, envId, templateConfig, templateId)
+    fsUtils.setTemplateId(type, envId, templateConfig, templateId);
     fsUtils.writeConfig(this.TEMPLATE_TYPE, handle, templateConfig);
   }
 
   static #missingHandle(template) {
     if (!template.handle) {
-      consola.warn(
-        `Template with id "${template.id}" has no handle, add a handle before importing it from Silverfin. Skipped`
-      );
+      consola.warn(`Template with id "${template.id}" has no handle, add a handle before importing it from Silverfin. Skipped`);
       return true;
     }
     return false;
@@ -152,13 +137,11 @@ class ReconciliationText {
   }
 
   static #filterConfigItems(templateConfig) {
-
     const skippedItems = [];
 
     const filteredConfig = this.CONFIG_ITEMS.reduce((acc, attribute) => {
       // Skip externally managed items if externally_managed is false
-      if (this.EXTERNALLY_MANAGED_ITEMS.includes(attribute) &&
-        templateConfig.externally_managed === false) {
+      if (this.EXTERNALLY_MANAGED_ITEMS.includes(attribute) && templateConfig.externally_managed === false) {
         skippedItems.push(attribute);
         return acc;
       }
@@ -170,9 +153,7 @@ class ReconciliationText {
     }, {});
 
     if (skippedItems.length > 0) {
-      consola.warn(
-        `The following attributes were skipped because they can only be updated when the template is externally managed: ${skippedItems.join(", ")}.`
-      );
+      consola.warn(`The following attributes were skipped because they can only be updated when the template is externally managed: ${skippedItems.join(", ")}.`);
     }
     return filteredConfig;
   }
@@ -184,14 +165,8 @@ class ReconciliationText {
   }
 
   static #checkReconciliationType(template) {
-    if (
-      !this.RECONCILIATION_TYPE_OPTIONS.includes(template.reconciliation_type)
-    ) {
-      consola.warn(
-        `Wrong reconciliation type. It must be one of the following: ${this.RECONCILIATION_TYPE_OPTIONS.join(
-          ", "
-        )}. Skipping its definition.`
-      );
+    if (!this.RECONCILIATION_TYPE_OPTIONS.includes(template.reconciliation_type)) {
+      consola.warn(`Wrong reconciliation type. It must be one of the following: ${this.RECONCILIATION_TYPE_OPTIONS.join(", ")}. Skipping its definition.`);
       delete template.reconciliation_type;
     }
     return template;
@@ -200,11 +175,7 @@ class ReconciliationText {
   static #createMainLiquid(handle) {
     const relativePath = `./${this.TEMPLATE_FOLDER}/${handle}`;
     if (!fs.existsSync(`${relativePath}/main.liquid`)) {
-      fsUtils.createLiquidFile(
-        relativePath,
-        "main",
-        "{% comment %} MAIN PART {% endcomment %}"
-      );
+      fsUtils.createLiquidFile(relativePath, "main", "{% comment %} MAIN PART {% endcomment %}");
     }
   }
 

--- a/lib/templates/sharedPart.js
+++ b/lib/templates/sharedPart.js
@@ -17,8 +17,7 @@ class SharedPart {
    * @param {object} template The template object provided by the Silverfin API
    */
   static async save(type, envId, template) {
-    if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE))
-      return false;
+    if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE)) return false;
 
     fsUtils.createSharedPartFolders(template.name);
 
@@ -29,15 +28,9 @@ class SharedPart {
     // Config Json File
     let existingConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, template.name);
 
-    let usedIn = await this.#processUsedIn(
-      type,
-      envId,
-      template.used_in,
-      existingConfig
-    );
+    let usedIn = await this.#processUsedIn(type, envId, template.used_in, existingConfig);
 
-    const addNewId = (currentType, typeCheck, envId, template) =>
-      currentType == typeCheck ? { [envId]: template.id } : {};
+    const addNewId = (currentType, typeCheck, envId, template) => (currentType == typeCheck ? { [envId]: template.id } : {});
 
     const config = {
       id: { ...existingConfig?.id, ...addNewId(type, "firm", envId, template) },
@@ -71,8 +64,8 @@ class SharedPart {
   /** Update template's id for the corresponding firm in template's config file */
   static updateTemplateId(type, envId, name, templateId) {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
-    fsUtils.setTemplateId(type, envId, templateConfig, templateId)
-    
+    fsUtils.setTemplateId(type, envId, templateConfig, templateId);
+
     fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
   }
 
@@ -90,9 +83,7 @@ class SharedPart {
       if (!handle) continue;
 
       // Check if there's already an existing used_in configuration for other firms/partners
-      const templateExistingInConfig = usedIn.findIndex(
-        (existingUsedTemplate) => existingUsedTemplate.handle == handle
-      );
+      const templateExistingInConfig = usedIn.findIndex((existingUsedTemplate) => existingUsedTemplate.handle == handle);
       let existingUsedTemplate = usedIn[templateExistingInConfig];
 
       if (existingUsedTemplate) {
@@ -136,44 +127,26 @@ class SharedPart {
 
   static async #findTemplateHandle(type, envId, template) {
     // Search in repository
-    let handle = fsUtils.findHandleByID(
-      type,
-      envId,
-      template.type,
-      template.id
-    );
+    let handle = fsUtils.findHandleByID(type, envId, template.type, template.id);
 
     if (!handle) {
-      const handle_attribute =
-        templateUtils.TEMPLATES_NAME_ATTRIBUTE[template.type];
+      const handle_attribute = templateUtils.TEMPLATES_NAME_ATTRIBUTE[template.type];
       switch (template.type) {
         case "reconciliationText":
-          let reconciliationText = await SF.readReconciliationTextById(
-            type,
-            envId,
-            template.id
-          );
+          let reconciliationText = await SF.readReconciliationTextById(type, envId, template.id);
 
           if (reconciliationText) {
             handle = reconciliationText.data[handle_attribute];
           }
           break;
         case "exportFile":
-          let exportFile = await SF.readExportFileById(
-            type,
-            envId,
-            template.id
-          );
+          let exportFile = await SF.readExportFileById(type, envId, template.id);
           if (exportFile) {
             handle = exportFile[handle_attribute];
           }
           break;
         case "accountTemplate":
-          let accountTemplate = await SF.readAccountTemplateById(
-            type,
-            envId,
-            template.id
-          );
+          let accountTemplate = await SF.readAccountTemplateById(type, envId, template.id);
 
           if (accountTemplate) {
             handle = accountTemplate?.name_nl;
@@ -188,11 +161,7 @@ class SharedPart {
   static #createMainLiquid(name) {
     const relativePath = `./${this.TEMPLATE_FOLDER}/${name}`;
     if (!fs.existsSync(`${relativePath}/${name}.liquid`)) {
-      fsUtils.createLiquidFile(
-        relativePath,
-        name,
-        "{% comment %} MAIN PART {% endcomment %}"
-      );
+      fsUtils.createLiquidFile(relativePath, name, "{% comment %} MAIN PART {% endcomment %}");
     }
   }
 

--- a/lib/utils/apiUtils.js
+++ b/lib/utils/apiUtils.js
@@ -8,16 +8,12 @@ function checkAuthorizePartners(partner_id) {
 }
 
 function checkRequiredEnvVariables() {
-  const missingVariables = ["SF_API_CLIENT_ID", "SF_API_SECRET"].filter(
-    (key) => !process.env[key]
-  );
+  const missingVariables = ["SF_API_CLIENT_ID", "SF_API_SECRET"].filter((key) => !process.env[key]);
   if (missingVariables.length) {
     consola.error(`Error: Missing API credentials: [${missingVariables}]`);
     consola.log(`Credentials should be defined as environmental variables.`);
     consola.log(`Call export ${missingVariables[0]}=...`);
-    consola.log(
-      `If you don't have credentials yet, you need to register your app with Silverfin to get them`
-    );
+    consola.log(`If you don't have credentials yet, you need to register your app with Silverfin to get them`);
     process.exit(1);
   }
 }
@@ -25,49 +21,33 @@ function checkRequiredEnvVariables() {
 function responseSuccessHandler(response) {
   if (response?.status) {
     consola.debug(
-      `Response Status: ${response.status} (${
-        response?.statusText
-      }) - method: ${response?.config?.method || response?.method} - url: ${
-        response?.config?.url || response?.url
-      }`
+      `Response Status: ${response.status} (${response?.statusText}) - method: ${response?.config?.method || response?.method} - url: ${response?.config?.url || response?.url}`
     );
   }
 }
 
 async function responseErrorHandler(error) {
   if (error && error.response) {
-    consola.debug(
-      `Response Status: ${error.response.status} (${error.response.statusText}) - method: ${error.response.config.method} - url: ${error.response.config.url}`
-    );
+    consola.debug(`Response Status: ${error.response.status} (${error.response.statusText}) - method: ${error.response.config.method} - url: ${error.response.config.url}`);
   }
   if (error?.response) {
     // Valid Request. Not Found
     if (error.response.status === 404) {
-      consola.error(
-        `Response Error (404): ${JSON.stringify(error.response.data.error)}`
-      );
+      consola.error(`Response Error (404): ${JSON.stringify(error.response.data.error)}`);
       return;
     }
     // Bad Request
     if (error.response.status === 400) {
-      consola.error(
-        `Response Error (400): ${JSON.stringify(error.response.data.error)}`
-      );
+      consola.error(`Response Error (400): ${JSON.stringify(error.response.data.error)}`);
       return;
     }
     // Unprocessable Entity
     if (error.response.status === 422) {
-      consola.error(
-        `Response Error (422): ${JSON.stringify(error.response.data)}`,
-        "\n",
-        `You don't have the rights to update the previous parameters`
-      );
+      consola.error(`Response Error (422): ${JSON.stringify(error.response.data)}`, "\n", `You don't have the rights to update the previous parameters`);
       process.exit(1);
     }
     if (error.response.status === 401) {
-      consola.debug(
-        `Response Error (401): ${JSON.stringify(error.response.data)}`
-      );
+      consola.debug(`Response Error (401): ${JSON.stringify(error.response.data)}`);
     }
     // Forbidden
     if (error.response.status === 403) {

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -6,9 +6,7 @@ const { consola } = require("consola");
 function uncaughtErrors(error) {
   if (error.stack) {
     console.error("----------------------------");
-    console.error(
-      `!!! Please open an issue including this log on ${pkg.bugs.url}`
-    );
+    console.error(`!!! Please open an issue including this log on ${pkg.bugs.url}`);
     console.error("");
     consola.error(error.message);
     console.error(`silverfin: v${pkg.version}, node: ${process.version}`);
@@ -21,9 +19,7 @@ function uncaughtErrors(error) {
 
 function errorHandler(error) {
   if (error.code == "ENOENT") {
-    consola.error(
-      `The path ${error.path} was not found, please ensure you've imported or created all required files`
-    );
+    consola.error(`The path ${error.path} was not found, please ensure you've imported or created all required files`);
     process.exit(1);
   } else {
     uncaughtErrors(error);
@@ -37,21 +33,13 @@ function missingConfig(identifier) {
 
 function missingReconciliationId(handle) {
   consola.error(`Reconciliation ${handle}: ID is missing.`);
-  consola.log(
-    `Try running: ${chalk.bold(
-      `silverfin get-reconciliation-id --handle ${handle}`
-    )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
-  );
+  consola.log(`Try running: ${chalk.bold(`silverfin get-reconciliation-id --handle ${handle}`)} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`);
   return false;
 }
 
 function missingSharedPartId(name) {
   consola.error(`Shared part ${name}: ID is missing. Aborted`);
-  consola.info(
-    `Try running: ${chalk.bold(
-      `silverfin get-shared-part-id --shared-part ${name}`
-    )} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`
-  );
+  consola.info(`Try running: ${chalk.bold(`silverfin get-shared-part-id --shared-part ${name}`)} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`);
   return false;
 }
 

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -25,21 +25,10 @@ function createFolder(path) {
 }
 
 function createTemplateFolders(templateType, handle, testFolder = true) {
-  createFolder(
-    path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`)
-  );
-  createFolder(
-    path.join(
-      process.cwd(),
-      `${FOLDERS[templateType]}`,
-      `${handle}`,
-      "text_parts"
-    )
-  );
+  createFolder(path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`));
+  createFolder(path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "text_parts"));
   if (testFolder) {
-    createFolder(
-      path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "tests")
-    );
+    createFolder(path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "tests"));
   }
 }
 
@@ -49,11 +38,7 @@ function createSharedPartFolders(handle) {
 
 const errorCallbackLiquidTest = (error) => {
   if (error) {
-    consola.error(
-      "An error occurred when creating the liquid testing file",
-      "\n",
-      error
-    );
+    consola.error("An error occurred when creating the liquid testing file", "\n", error);
   }
 };
 
@@ -63,18 +48,10 @@ async function createLiquidTestFiles(templateType, handle, testContent) {
 }
 
 async function createLiquidTestYaml(templateType, handle, testContent) {
-  const liquidTestPath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "tests",
-    `${handle}_liquid_test.yml`
-  );
+  const liquidTestPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "tests", `${handle}_liquid_test.yml`);
   const existingFile = fs.existsSync(liquidTestPath);
   if (existingFile) {
-    consola.debug(
-      `Liquid testing file ${handle}_liquid_test.yml already exists, so the file content was not overwritten`
-    );
+    consola.debug(`Liquid testing file ${handle}_liquid_test.yml already exists, so the file content was not overwritten`);
     return;
   }
   fs.writeFile(liquidTestPath, testContent, (error) => {
@@ -87,20 +64,11 @@ async function createLiquidTestYaml(templateType, handle, testContent) {
 }
 
 async function createLiquidTestReadme(templateType, handle) {
-  const readmePath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "tests",
-    "README.md"
-  );
+  const readmePath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "tests", "README.md");
   if (fs.existsSync(readmePath)) {
     return;
   }
-  const readmeLiquidTests = fs.readFileSync(
-    path.resolve(__dirname, "../../resources/liquidTests/README.md"),
-    "UTF-8"
-  );
+  const readmeLiquidTests = fs.readFileSync(path.resolve(__dirname, "../../resources/liquidTests/README.md"), "UTF-8");
   fs.writeFile(readmePath, readmeLiquidTests, (error) => {
     errorCallbackLiquidTest(error);
   });
@@ -110,23 +78,12 @@ async function createTemplateFiles(templateType, handle, textMain, textParts) {
   const emptyCallback = () => {};
 
   // Template: Main
-  const mainPath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "main.liquid"
-  );
+  const mainPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "main.liquid");
   fs.writeFile(mainPath, textMain, emptyCallback);
   // Template: Parts
   Object.keys(textParts).forEach((textPartName) => {
     if (!textPartName) return;
-    const partPath = path.join(
-      process.cwd(),
-      `${FOLDERS[templateType]}`,
-      `${handle}`,
-      "text_parts",
-      `${textPartName}.liquid`
-    );
+    const partPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "text_parts", `${textPartName}.liquid`);
     fs.writeFile(partPath, textParts[textPartName], emptyCallback);
   });
   consola.debug(`Liquid template file(s) created for ${handle}`);
@@ -134,33 +91,19 @@ async function createTemplateFiles(templateType, handle, textMain, textParts) {
 
 async function createLiquidFile(relativePath, fileName, textContent) {
   const emptyCallback = () => {};
-  fs.writeFileSync(
-    `${relativePath}/${fileName}.liquid`,
-    textContent,
-    emptyCallback
-  );
+  fs.writeFileSync(`${relativePath}/${fileName}.liquid`, textContent, emptyCallback);
   consola.debug(`${fileName} file created`);
 }
 
 function writeConfig(templateType, handle, config) {
   consola.debug(`Writing config for ${handle} (${templateType})`);
-  const configPath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "config.json"
-  );
+  const configPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "config.json");
   const emptyCallback = () => {};
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2), emptyCallback);
 }
 
 function configExists(templateType, handle) {
-  const configPath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`,
-    "config.json"
-  );
+  const configPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "config.json");
 
   return fs.existsSync(configPath);
 }
@@ -168,20 +111,13 @@ function configExists(templateType, handle) {
 function readConfig(templateType, handle) {
   try {
     createConfigIfMissing(templateType, handle);
-    const configPath = path.join(
-      process.cwd(),
-      `${FOLDERS[templateType]}`,
-      `${handle}`,
-      "config.json"
-    );
+    const configPath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`, "config.json");
 
     const configData = fs.readFileSync(configPath).toString();
 
     return JSON.parse(configData);
   } catch (error) {
-    consola.error(
-      `An error occurred when trying to read the config for "${handle}"`
-    );
+    consola.error(`An error occurred when trying to read the config for "${handle}"`);
 
     consola.error(error);
     process.exit(1);
@@ -194,11 +130,7 @@ function readConfig(templateType, handle) {
  * @param {string} handle Handle or name of the template
  */
 function createConfigIfMissing(templateType, handle) {
-  const templatePath = path.join(
-    process.cwd(),
-    `${FOLDERS[templateType]}`,
-    `${handle}`
-  );
+  const templatePath = path.join(process.cwd(), `${FOLDERS[templateType]}`, `${handle}`);
   createFolder(templatePath);
   const configPath = path.join(templatePath, "config.json");
   const existingConfig = fs.existsSync(configPath);
@@ -298,24 +230,16 @@ function getAllTemplatesOfAType(templateType) {
 function findHandleByID(type, envId, templateType, id) {
   try {
     if (!TEMPLATE_TYPES.includes(templateType)) {
-      throw `Error on id ${id} with template type ${templateType}: template type should be one of ${TEMPLATE_TYPES.join(
-        ", "
-      )}`;
+      throw `Error on id ${id} with template type ${templateType}: template type should be one of ${TEMPLATE_TYPES.join(", ")}`;
     }
     let templatesArray = getAllTemplatesOfAType(templateType);
     for (let templateHandle of templatesArray) {
       let templateConfig = readConfig(templateType, templateHandle);
 
-      const checkId =
-        type == "firm"
-          ? templateConfig.id && templateConfig.id[envId]
-          : templateConfig.partner_id && templateConfig.partner_id[envId];
+      const checkId = type == "firm" ? templateConfig.id && templateConfig.id[envId] : templateConfig.partner_id && templateConfig.partner_id[envId];
 
       if (checkId == id) {
-        const handle =
-          templateConfig.handle ||
-          templateConfig.name ||
-          templateConfig.name_nl;
+        const handle = templateConfig.handle || templateConfig.name || templateConfig.name_nl;
         return handle;
       }
     }
@@ -380,11 +304,7 @@ function listExistingFiles(typeCheck = "liquid") {
 // Main, parts and shared parts used
 // Return an array with their full paths
 function listExistingRelatedLiquidFiles(firmId, handle) {
-  const relatedSharedParts = listSharedPartsUsedInTemplate(
-    firmId,
-    "reconciliationText",
-    handle
-  );
+  const relatedSharedParts = listSharedPartsUsedInTemplate(firmId, "reconciliationText", handle);
   const allLiquidFiles = listExistingFiles("liquid");
   const patternReconciliation = `reconciliation_texts/${handle}/`;
   const reconciliationRegExp = new RegExp(patternReconciliation, "g");
@@ -407,12 +327,7 @@ function listExistingRelatedLiquidFiles(firmId, handle) {
 }
 
 // Recursive option for fs.watch is not available in every OS (e.g. Linux)
-function recursiveInspectDirectory({
-  basePath,
-  collection,
-  pathsArray = [],
-  typeCheck = "liquid",
-}) {
+function recursiveInspectDirectory({ basePath, collection, pathsArray = [], typeCheck = "liquid" }) {
   collection.forEach((filePath) => {
     let fullPath = path.resolve(basePath, filePath);
     let fileStats = fs.statSync(fullPath, () => {});
@@ -495,5 +410,5 @@ module.exports = {
   listExistingRelatedLiquidFiles,
   identifyTypeAndHandle,
   getTemplateId,
-  setTemplateId
+  setTemplateId,
 };

--- a/lib/utils/liquidTestUtils.js
+++ b/lib/utils/liquidTestUtils.js
@@ -36,9 +36,7 @@ function extractURL(url) {
     } else if (parts.indexOf("account_entry") !== -1) {
       type = "accountId";
     } else {
-      consola.error(
-        "Not possible to identify if it's a reconciliation text or account entry."
-      );
+      consola.error("Not possible to identify if it's a reconciliation text or account entry.");
       process.exit(1);
     }
     return {
@@ -49,9 +47,7 @@ function extractURL(url) {
       [type]: parts[7],
     };
   } catch (err) {
-    consola.error(
-      "The URL provided is not correct. Double check it and run the command again."
-    );
+    consola.error("The URL provided is not correct. Double check it and run the command again.");
     process.exit(1);
   }
 }
@@ -116,9 +112,7 @@ function getCompanyDependencies(reconcilationObject, reconciliationHandle) {
 
   // No main part ?
   if (!reconcilationObject || !reconcilationObject.text) {
-    consola.warn(
-      `Reconciliation "${reconciliationHandle}": no liquid code found`
-    );
+    consola.warn(`Reconciliation "${reconciliationHandle}": no liquid code found`);
     return { standardDropElements: [], customDropElements: [] };
   }
 
@@ -139,35 +133,23 @@ function getCompanyDependencies(reconcilationObject, reconciliationHandle) {
   });
 
   // Separate custom drop from standard drop
-  const customDropElements = companyFound.filter((tag) =>
-    tag.includes("custom")
-  ); // [ 'company.custom.foo.bar', ...]
+  const customDropElements = companyFound.filter((tag) => tag.includes("custom")); // [ 'company.custom.foo.bar', ...]
 
   // Get only standard drop elements
-  const standardDropElements = companyFound.filter(
-    (tag) => !customDropElements.includes(tag)
-  ); // [ 'company.foo´, ...]
+  const standardDropElements = companyFound.filter((tag) => !customDropElements.includes(tag)); // [ 'company.foo´, ...]
 
   return { standardDropElements, customDropElements };
 }
 
 // Do we need to get results from other templates? Check Liquid Code (handle & result names)
 // We can pass an existing collection {handle:[results]} from a previous call
-function searchForResultsFromDependenciesInLiquid(
-  reconcilationObject,
-  reconciliationHandle,
-  resultsCollection = {}
-) {
+function searchForResultsFromDependenciesInLiquid(reconcilationObject, reconciliationHandle, resultsCollection = {}) {
   // Normal Scenario
-  const reResultsFetched = RegExp(
-    /period\.reconciliations\.\w+\.results\.\w+/g
-  ); // period.reconciliations.handle.results.result_name
+  const reResultsFetched = RegExp(/period\.reconciliations\.\w+\.results\.\w+/g); // period.reconciliations.handle.results.result_name
 
   // No main part ?
   if (!reconcilationObject || !reconcilationObject.text) {
-    consola.warn(
-      `Reconciliation "${reconciliationHandle}": no liquid code found`
-    );
+    consola.warn(`Reconciliation "${reconciliationHandle}": no liquid code found`);
     return resultsCollection;
   }
 
@@ -200,9 +182,7 @@ function searchForResultsFromDependenciesInLiquid(
   // Assign: Scenarios
   // {% assign variable_name = period.reconciliations.handle %} && {{ variable_name.results.result_name }}
   // {% assign variable_name = period.reconciliations.handle.results %} && {{ variable_name.result_name }}
-  const reAssign = RegExp(
-    /\w+(\ )?=(\ )?period\.reconciliations\.\w+(\.results)?(\ |\%)/g
-  ); // period.reconciliations.handle or period.reconciliations.handle.results
+  const reAssign = RegExp(/\w+(\ )?=(\ )?period\.reconciliations\.\w+(\.results)?(\ |\%)/g); // period.reconciliations.handle or period.reconciliations.handle.results
   let resultsFoundAssign = reconcilationObject.text.match(reAssign) || [];
   const variables = resultsFoundAssign.map((element) => {
     let parts = element.split("="); // variable, period.reconciliation.handle...
@@ -212,8 +192,7 @@ function searchForResultsFromDependenciesInLiquid(
     let expression = `(\ |\%|\{)${variableName}(\.results)?\.\\w+(\ |\%|\})`; // variable.result_name or variable.results.result_name
     let reAssignResults = new RegExp(expression, "g");
     // Main
-    let assignResultsFound =
-      reconcilationObject.text.match(reAssignResults) || [];
+    let assignResultsFound = reconcilationObject.text.match(reAssignResults) || [];
     // Parts
     if (reconcilationObject.text_parts) {
       for (part of reconcilationObject.text_parts) {
@@ -250,21 +229,13 @@ function searchForResultsFromDependenciesInLiquid(
 
 // Do we need to get custom drops from other templates? Check Liquid Code (handle & custom names)
 // We can pass an existing collection {handle:[drop]} from a previous call
-function searchForCustomsFromDependenciesInLiquid(
-  reconcilationObject,
-  reconciliationHandle,
-  customCollection = {}
-) {
+function searchForCustomsFromDependenciesInLiquid(reconcilationObject, reconciliationHandle, customCollection = {}) {
   // Normal Scenario
-  const reCustomsFetched = RegExp(
-    /period\.reconciliations\.\w+\.custom\.\w+\.\w+/g
-  ); // period.reconciliations.handle.custom.namespace.key
+  const reCustomsFetched = RegExp(/period\.reconciliations\.\w+\.custom\.\w+\.\w+/g); // period.reconciliations.handle.custom.namespace.key
 
   // No main part ?
   if (!reconcilationObject || !reconcilationObject.text) {
-    consola.warn(
-      `Reconciliation "${reconciliationHandle}": no liquid code found`
-    );
+    consola.warn(`Reconciliation "${reconciliationHandle}": no liquid code found`);
     return customCollection;
   }
 
@@ -313,9 +284,7 @@ function lookForSharedPartsInLiquid(reconcilationObject, reconciliationHandle) {
 
   // No main part ?
   if (!reconcilationObject || !reconcilationObject.text) {
-    consola.warn(
-      `Reconciliation "${reconciliationHandle}": no liquid code found`
-    );
+    consola.warn(`Reconciliation "${reconciliationHandle}": no liquid code found`);
     return;
   }
 

--- a/lib/utils/liquidUtils.js
+++ b/lib/utils/liquidUtils.js
@@ -2,18 +2,7 @@ const { consola } = require("consola");
 
 // Search for all "input" tags in Liquid
 function lookForInputTags(liquidCode, input_type = "") {
-  const input_types = [
-    "account_collection",
-    "currency",
-    "integer",
-    "file",
-    "text",
-    "boolean",
-    "select",
-    "percentage",
-    "date",
-    "",
-  ];
+  const input_types = ["account_collection", "currency", "integer", "file", "text", "boolean", "select", "percentage", "date", ""];
   if (!input_types.includes(input_type)) {
     consola.error("Input type defined not supported");
     process.exit(1);

--- a/lib/utils/templateUtils.js
+++ b/lib/utils/templateUtils.js
@@ -61,11 +61,7 @@ function filterParts(template) {
 
 function missingLiquidCode(template) {
   if (!template?.text) {
-    consola.warn(
-      `Template "${
-        template?.handle || template?.name || template?.name_nl
-      }": this template's liquid code was empty or hidden so it was not imported.`
-    );
+    consola.warn(`Template "${template?.handle || template?.name || template?.name_nl}": this template's liquid code was empty or hidden so it was not imported.`);
     return true;
   }
   return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.30.0",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.30.0",
+      "version": "1.30.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -69,22 +69,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.0",
-        "@babel/generator": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.0",
-        "@babel/parser": "^7.26.0",
+        "@babel/helpers": "^7.26.7",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.26.0",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -100,14 +100,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -117,13 +117,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,27 +206,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -490,17 +490,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
+      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1250,9 +1250,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1284,9 +1284,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
     },
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "dev": true,
       "funding": [
         {
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1843,9 +1843,9 @@
       "license": "MIT"
     },
     "node_modules/consola": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
-      "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -1997,9 +1997,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.79",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.79.tgz",
-      "integrity": "sha512-nYOxJNxQ9Om4EC88BE4pPoNI8xwSFf8pU/BAeOl4Hh/b/i6V4biTAzwV7pXi3ARKeoYO5JZKMIXTryXSVer5RA==",
+      "version": "1.5.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.93.tgz",
+      "integrity": "sha512-M+29jTcfNNoR9NV7la4SwUqzWAxEwnc7ThA5e1m6LRSotmpfpCpLcIfgtSCVL+MllNLgAyM/5ru86iMRemPzDQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2306,9 +2306,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2870,9 +2870,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3697,9 +3697,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "prettier": {
     "trailingComma": "es5",
-    "tabWidth": 2
+    "tabWidth": 2,
+    "printWidth": 180
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -75,12 +75,8 @@ describe("AxiosFactory", () => {
       const instance = AxiosFactory.createInstance("firm", firmId);
 
       expect(instance).toBeDefined();
-      expect(instance.defaults.baseURL).toBe(
-        `https://test-api.com/api/v4/f/50000`
-      );
-      expect(instance.defaults.headers.Authorization).toBe(
-        "Bearer stored-access"
-      );
+      expect(instance.defaults.baseURL).toBe(`https://test-api.com/api/v4/f/50000`);
+      expect(instance.defaults.headers.Authorization).toBe("Bearer stored-access");
     });
 
     it("should throw an error for missing tokens and terminate process", () => {
@@ -91,9 +87,7 @@ describe("AxiosFactory", () => {
         AxiosFactory.createInstance("firm", firmId);
       }).toThrow("Process.exit called with code 1");
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Missing authorization for firm id: 50000"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Missing authorization for firm id: 50000");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
@@ -129,9 +123,7 @@ describe("AxiosFactory", () => {
         }
       });
 
-      axiosMockAdapter
-        .onPost(`${mockHost}/f/${firmId}/oauth/token`)
-        .reply(200, newTokenPairResponse);
+      axiosMockAdapter.onPost(`${mockHost}/f/${firmId}/oauth/token`).reply(200, newTokenPairResponse);
       jest.spyOn(axiosInstance, "post");
 
       const response = await axiosInstance.get("/test-endpoint");
@@ -139,10 +131,7 @@ describe("AxiosFactory", () => {
       expect(axiosMockAdapter.history.get.length).toBe(2);
       expect(axiosMockAdapter.history.post.length).toBe(1);
 
-      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-        String(firmId),
-        newTokenPairResponse
-      );
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(String(firmId), newTokenPairResponse);
       expect(response.data).toBe("Success");
     });
 
@@ -156,22 +145,16 @@ describe("AxiosFactory", () => {
       expect(axios.create).toHaveBeenCalled();
 
       axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
-      axiosMockAdapter
-        .onPost(`${mockHost}/f/${firmId}/oauth/token`)
-        .reply(401, "Unauthorized");
+      axiosMockAdapter.onPost(`${mockHost}/f/${firmId}/oauth/token`).reply(401, "Unauthorized");
 
-      await expect(axiosInstance.get("/test-endpoint")).rejects.toThrow(
-        "Process.exit called with code 1"
-      );
+      await expect(axiosInstance.get("/test-endpoint")).rejects.toThrow("Process.exit called with code 1");
 
       expect(axiosMockAdapter.history.get.length).toBe(1);
       expect(axiosMockAdapter.history.post.length).toBe(1);
 
       expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledTimes(0);
       expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(consola.error).toHaveBeenCalledWith(
-        "Error refreshing credentials. Try running the authentication process again"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Error refreshing credentials. Try running the authentication process again");
     });
 
     it("should throw any other response errors", async () => {
@@ -234,9 +217,7 @@ describe("AxiosFactory", () => {
       const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
 
       expect(axiosInstance).toBeDefined();
-      expect(axiosInstance.defaults.baseURL).toBe(
-        `https://test-api.com/api/partner/v1`
-      );
+      expect(axiosInstance.defaults.baseURL).toBe(`https://test-api.com/api/partner/v1`);
 
       expect(axiosInstance.defaults.headers.Authorization).toBeUndefined();
     });
@@ -268,9 +249,7 @@ describe("AxiosFactory", () => {
         AxiosFactory.createInstance("partner", partnerId);
       }).toThrow("Process.exit called with code 1");
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Missing authorization for partner id: 100"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Missing authorization for partner id: 100");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
@@ -278,12 +257,8 @@ describe("AxiosFactory", () => {
       const newApiKey = "new-api-key";
 
       firmCredentials.getHost.mockReturnValue(mockHost);
-      firmCredentials.getPartnerCredentials.mockReturnValueOnce(
-        mockPartnerTokens
-      ); // original request
-      firmCredentials.getPartnerCredentials.mockReturnValueOnce(
-        mockPartnerTokens
-      ); // refresh request
+      firmCredentials.getPartnerCredentials.mockReturnValueOnce(mockPartnerTokens); // original request
+      firmCredentials.getPartnerCredentials.mockReturnValueOnce(mockPartnerTokens); // refresh request
       firmCredentials.getPartnerCredentials.mockReturnValueOnce({
         token: newApiKey,
       }); // new request
@@ -305,11 +280,7 @@ describe("AxiosFactory", () => {
         }
       });
 
-      axiosMockAdapter
-        .onPost(
-          `${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`
-        )
-        .reply(200, { api_key: newApiKey });
+      axiosMockAdapter.onPost(`${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`).reply(200, { api_key: newApiKey });
       jest.spyOn(axiosInstance, "post");
 
       const response = await axiosInstance.get("/test-endpoint");
@@ -317,10 +288,7 @@ describe("AxiosFactory", () => {
       expect(axiosMockAdapter.history.get.length).toBe(2);
       expect(axiosMockAdapter.history.post.length).toBe(1);
 
-      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(
-        partnerId,
-        newApiKey
-      );
+      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(partnerId, newApiKey);
       expect(response.data).toBe("Success");
     });
 
@@ -334,25 +302,17 @@ describe("AxiosFactory", () => {
       expect(axios.create).toHaveBeenCalled();
 
       axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
-      axiosMockAdapter
-        .onPost(
-          `${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`
-        )
-        .reply(401, "Unauthorized");
+      axiosMockAdapter.onPost(`${mockHost}/api/partner/v1/refresh_api_key?api_key=stored-api-key`).reply(401, "Unauthorized");
       jest.spyOn(axiosInstance, "post");
 
-      await expect(axiosInstance.get("/test-endpoint")).rejects.toThrow(
-        "Process.exit called with code 1"
-      );
+      await expect(axiosInstance.get("/test-endpoint")).rejects.toThrow("Process.exit called with code 1");
 
       expect(axiosMockAdapter.history.get.length).toBe(1);
       expect(axiosMockAdapter.history.post.length).toBe(1);
 
       expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledTimes(0);
       expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(consola.error).toHaveBeenCalledWith(
-        "Error refreshing credentials. Try running the authentication process again"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Error refreshing credentials. Try running the authentication process again");
     });
 
     it("should throw any other response error", async () => {
@@ -365,9 +325,7 @@ describe("AxiosFactory", () => {
       expect(axios.create).toHaveBeenCalled();
 
       axiosMockAdapter.onGet("/test-endpoint").reply(404, "Not found");
-      axiosMockAdapter
-        .onPost(`${mockHost}/f/${partnerId}/oauth/token`)
-        .reply(400);
+      axiosMockAdapter.onPost(`${mockHost}/f/${partnerId}/oauth/token`).reply(400);
 
       await expect(axiosInstance.get("/test-endpoint")).rejects.toThrow();
 
@@ -439,13 +397,9 @@ describe("AxiosFactory", () => {
       const axiosInstance = AxiosFactory.createInstance("firm", firmId);
 
       expect(axiosInstance).toBeDefined();
-      expect(axiosInstance.defaults.baseURL).toBe(
-        `https://test-api.staging.getsilverfin.com/api/v4/f/50000`
-      );
+      expect(axiosInstance.defaults.baseURL).toBe(`https://test-api.staging.getsilverfin.com/api/v4/f/50000`);
 
-      expect(axiosInstance.defaults.headers.Authorization).toBe(
-        "Basic test_basic_auth"
-      );
+      expect(axiosInstance.defaults.headers.Authorization).toBe("Basic test_basic_auth");
       expect(axiosInstance.defaults.params).toEqual({
         access_token: "stored-access",
       });
@@ -463,13 +417,9 @@ describe("AxiosFactory", () => {
       const axiosInstance = AxiosFactory.createInstance("partner", partnerId);
 
       expect(axiosInstance).toBeDefined();
-      expect(axiosInstance.defaults.baseURL).toBe(
-        `https://test-api.staging.getsilverfin.com/api/partner/v1`
-      );
+      expect(axiosInstance.defaults.baseURL).toBe(`https://test-api.staging.getsilverfin.com/api/partner/v1`);
 
-      expect(axiosInstance.defaults.headers.Authorization).toBe(
-        "Basic test_basic_auth"
-      );
+      expect(axiosInstance.defaults.headers.Authorization).toBe("Basic test_basic_auth");
       expect(axiosInstance.defaults.params).toEqual({
         partner_id: partnerId,
         api_key: mockPartnerTokens.token,
@@ -522,13 +472,9 @@ describe("AxiosFactory", () => {
       const axiosInstance = AxiosFactory.createAuthInstanceForFirm(firmId);
 
       expect(axiosInstance).toBeDefined();
-      expect(axiosInstance.defaults.baseURL).toBe(
-        `https://test-api.staging.getsilverfin.com/api/v4/f/50000`
-      );
+      expect(axiosInstance.defaults.baseURL).toBe(`https://test-api.staging.getsilverfin.com/api/v4/f/50000`);
 
-      expect(axiosInstance.defaults.headers.Authorization).toBe(
-        "Basic test_basic_auth"
-      );
+      expect(axiosInstance.defaults.headers.Authorization).toBe("Basic test_basic_auth");
     });
   });
 });

--- a/tests/lib/api/firmCredentials.test.js
+++ b/tests/lib/api/firmCredentials.test.js
@@ -33,12 +33,7 @@ describe("FirmCredentials", () => {
 
       firmCredentials.setHost(testHost);
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.any(String),
-        JSON.stringify({ defaultFirmIDs: {}, host: testHost }, null, 2),
-        "utf8",
-        expect.any(Function)
-      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.any(String), JSON.stringify({ defaultFirmIDs: {}, host: testHost }, null, 2), "utf8", expect.any(Function));
 
       expect(writtenData.host).toBe(testHost);
       expect(firmCredentials.getHost()).toBe(testHost);

--- a/tests/lib/api/silverfinAuthorizer.test.js
+++ b/tests/lib/api/silverfinAuthorizer.test.js
@@ -92,35 +92,18 @@ describe("SilverfinAuthorizer", () => {
     it("should successfully store new tokens when they dont exist", async () => {
       await SilverfinAuthorizer.authorizeFirm(mockStoredFirmId);
 
-      expect(mockPrompt).toHaveBeenNthCalledWith(
-        1,
-        "Enter the firm ID (leave blank to use 5000): ",
-        { value: "5000" }
-      );
-      expect(mockPrompt).toHaveBeenNthCalledWith(
-        2,
-        "Enter your API authorization code: ",
-        { echo: "*" }
-      );
+      expect(mockPrompt).toHaveBeenNthCalledWith(1, "Enter the firm ID (leave blank to use 5000): ", { value: "5000" });
+      expect(mockPrompt).toHaveBeenNthCalledWith(2, "Enter your API authorization code: ", { echo: "*" });
 
-      expect(open).toHaveBeenCalledWith(
-        expect.stringContaining("api.test.com/f/123/oauth/authorize")
-      );
+      expect(open).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/authorize"));
 
-      expect(AxiosFactory.createAuthInstanceForFirm).toHaveBeenCalledWith(
-        mockFirmId
-      );
+      expect(AxiosFactory.createAuthInstanceForFirm).toHaveBeenCalledWith(mockFirmId);
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        expect.stringContaining("api.test.com/f/123/oauth/token")
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/token"));
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user/firm");
 
-      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-        mockFirmId,
-        mockTokenResponse.data
-      );
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(mockFirmId, mockTokenResponse.data);
 
       expect(consola.error).not.toHaveBeenCalled();
     });
@@ -128,20 +111,13 @@ describe("SilverfinAuthorizer", () => {
     it("should succesfully store new tokens when they exist", async () => {
       await SilverfinAuthorizer.authorizeFirm(mockFirmId);
 
-      expect(open).toHaveBeenCalledWith(
-        expect.stringContaining("api.test.com/f/123/oauth/authorize")
-      );
+      expect(open).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/authorize"));
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        expect.stringContaining("api.test.com/f/123/oauth/token")
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/token"));
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith("/user/firm");
 
-      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-        mockFirmId,
-        mockTokenResponse.data
-      );
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(mockFirmId, mockTokenResponse.data);
 
       expect(consola.error).not.toHaveBeenCalled();
     });
@@ -163,9 +139,7 @@ describe("SilverfinAuthorizer", () => {
 
       expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Firm ID is missing. Please provide a valid one."
-      );
+      expect(consola.error).toHaveBeenCalledWith("Firm ID is missing. Please provide a valid one.");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
@@ -186,9 +160,7 @@ describe("SilverfinAuthorizer", () => {
         await SilverfinAuthorizer.authorizeFirm(mockFirmId);
       }).rejects.toThrow("Process.exit called with code 1");
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Response Status: 400 (Bad Request)"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Response Status: 400 (Bad Request)");
       expect(consola.error).toHaveBeenCalledWith(
         'Error description: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."'
       );
@@ -198,18 +170,13 @@ describe("SilverfinAuthorizer", () => {
 
     it("should not raise errors when getting the firm name fails", async () => {
       mockAxiosInstance.get.mockReset();
-      mockAxiosInstance.get.mockRejectedValueOnce(
-        new Error("Failed to get firm name")
-      );
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error("Failed to get firm name"));
 
       await SilverfinAuthorizer.authorizeFirm(mockFirmId);
 
       expect(consola.error).not.toHaveBeenCalled();
 
-      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-        mockFirmId,
-        mockTokenResponse.data
-      );
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(mockFirmId, mockTokenResponse.data);
     });
   });
 
@@ -223,24 +190,18 @@ describe("SilverfinAuthorizer", () => {
 
       await SilverfinAuthorizer.refreshFirm(mockFirmId);
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        "https://api.test.com/f/123/oauth/token",
-        {
-          client_id: "test_client_id",
-          client_secret: "test_secret",
-          redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
-          grant_type: "refresh_token",
-          refresh_token: "stored-refresh",
-          access_token: "stored-access",
-        }
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith("https://api.test.com/f/123/oauth/token", {
+        client_id: "test_client_id",
+        client_secret: "test_secret",
+        redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+        grant_type: "refresh_token",
+        refresh_token: "stored-refresh",
+        access_token: "stored-access",
+      });
 
       expect(consola.error).not.toHaveBeenCalled();
 
-      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(
-        mockFirmId,
-        mockTokenResponse.data
-      );
+      expect(firmCredentials.storeNewTokenPair).toHaveBeenCalledWith(mockFirmId, mockTokenResponse.data);
     });
 
     it("should raise an error when there are no previous tokens", async () => {
@@ -253,9 +214,7 @@ describe("SilverfinAuthorizer", () => {
       expect(mockAxiosInstance.post).not.toHaveBeenCalled();
       expect(mockAxiosInstance.get).not.toHaveBeenCalled();
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Firm 123 is not authorized. Please authorize the firm first"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Firm 123 is not authorized. Please authorize the firm first");
 
       expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();
     });
@@ -293,9 +252,7 @@ describe("SilverfinAuthorizer", () => {
 
   describe("refreshPartner", () => {
     it("should store the new API key", async () => {
-      firmCredentials.getPartnerCredentials.mockReturnValue(
-        mockPartnerStoredToken
-      );
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerStoredToken);
       const mockTokenResponse = {
         data: {
           api_key: "new-api-key",
@@ -306,17 +263,11 @@ describe("SilverfinAuthorizer", () => {
 
       await SilverfinAuthorizer.refreshPartner(mockPartnerId);
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        "https://api.test.com/api/partner/v1/refresh_api_key?api_key=stored-token"
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith("https://api.test.com/api/partner/v1/refresh_api_key?api_key=stored-token");
 
       expect(consola.error).not.toHaveBeenCalled();
 
-      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(
-        mockPartnerId,
-        mockTokenResponse.data.api_key,
-        mockPartnerStoredToken.name
-      );
+      expect(firmCredentials.storePartnerApiKey).toHaveBeenCalledWith(mockPartnerId, mockTokenResponse.data.api_key, mockPartnerStoredToken.name);
     });
 
     it("should raise an error when there are no previous tokens", async () => {
@@ -329,17 +280,13 @@ describe("SilverfinAuthorizer", () => {
       expect(mockAxiosInstance.post).not.toHaveBeenCalled();
       expect(mockAxiosInstance.get).not.toHaveBeenCalled();
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Partner partner_123 is not authorized. Please authorize the partner first"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Partner partner_123 is not authorized. Please authorize the partner first");
 
       expect(firmCredentials.storePartnerApiKey).not.toHaveBeenCalled();
     });
 
     it("should handle response errors", async () => {
-      firmCredentials.getPartnerCredentials.mockReturnValue(
-        mockPartnerStoredToken
-      );
+      firmCredentials.getPartnerCredentials.mockReturnValue(mockPartnerStoredToken);
       mockAxiosInstance.post.mockReset();
       mockAxiosInstance.post.mockRejectedValueOnce({
         response: {
@@ -352,9 +299,7 @@ describe("SilverfinAuthorizer", () => {
         await SilverfinAuthorizer.refreshPartner(mockPartnerId);
       }).rejects.toThrow("Process.exit called with code 1");
 
-      expect(consola.error).toHaveBeenCalledWith(
-        "Response Status: 401 (Unauthorized). An error occurred trying to refresh the partner API key"
-      );
+      expect(consola.error).toHaveBeenCalledWith("Response Status: 401 (Unauthorized). An error occurred trying to refresh the partner API key");
 
       expect(firmCredentials.storePartnerApiKey).not.toHaveBeenCalled();
     });

--- a/tests/lib/templates/reconciliationTexts.test.js
+++ b/tests/lib/templates/reconciliationTexts.test.js
@@ -3,9 +3,7 @@ const fsPromises = require("fs").promises;
 const path = require("path");
 const fsUtils = require("../../../lib/utils/fsUtils");
 const templateUtils = require("../../../lib/utils/templateUtils");
-const {
-  ReconciliationText,
-} = require("../../../lib/templates/reconciliationText");
+const { ReconciliationText } = require("../../../lib/templates/reconciliationText");
 
 jest.mock("../../../lib/utils/templateUtils");
 jest.mock("consola");
@@ -75,28 +73,12 @@ describe("ReconciliationText", () => {
     };
 
     const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(
-      tempDir,
-      "reconciliation_texts",
-      handle
-    );
+    const expectedFolderPath = path.join(tempDir, "reconciliation_texts", handle);
     const configPath = path.join(expectedFolderPath, "config.json");
     const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
-    const testLiquidPath = path.join(
-      expectedFolderPath,
-      "tests",
-      `${handle}_liquid_test.yml`
-    );
-    const part1LiquidPath = path.join(
-      expectedFolderPath,
-      "text_parts",
-      "part_1.liquid"
-    );
-    const oldPartLiquidPath = path.join(
-      expectedFolderPath,
-      "text_parts",
-      "old_part.liquid"
-    );
+    const testLiquidPath = path.join(expectedFolderPath, "tests", `${handle}_liquid_test.yml`);
+    const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
+    const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
 
     beforeEach(() => {
       if (!fs.existsSync(tempDir)) {
@@ -115,9 +97,7 @@ describe("ReconciliationText", () => {
     it("should return false if the template handle is missing", async () => {
       const result = await ReconciliationText.save("firm", 100, { id: 808080 });
       expect(result).toBe(false);
-      expect(require("consola").warn).toHaveBeenCalledWith(
-        'Template with id "808080" has no handle, add a handle before importing it from Silverfin. Skipped'
-      );
+      expect(require("consola").warn).toHaveBeenCalledWith('Template with id "808080" has no handle, add a handle before importing it from Silverfin. Skipped');
     });
 
     it("should return false if the liquid code is missing", async () => {
@@ -131,10 +111,7 @@ describe("ReconciliationText", () => {
       templateUtils.checkValidName.mockReturnValue(false);
       const result = await ReconciliationText.save("firm", 100, template);
       expect(result).toBe(false);
-      expect(templateUtils.checkValidName).toHaveBeenCalledWith(
-        "example_handle",
-        "reconciliationText"
-      );
+      expect(templateUtils.checkValidName).toHaveBeenCalledWith("example_handle", "reconciliationText");
     });
 
     it("should create the necessary files and store template's relevant details", async () => {
@@ -148,30 +125,19 @@ describe("ReconciliationText", () => {
       expect(fs.existsSync(expectedFolderPath)).toBe(true);
       // Check main liquid file
       expect(fs.existsSync(mainLiquidPath)).toBe(true);
-      const mainLiquidContent = await fsPromises.readFile(
-        mainLiquidPath,
-        "utf-8"
-      );
+      const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
       expect(mainLiquidContent).toBe(template.text);
       // Check text parts liquid files
       expect(fs.existsSync(part1LiquidPath)).toBe(true);
-      const part1LiquidContent = await fsPromises.readFile(
-        part1LiquidPath,
-        "utf-8"
-      );
+      const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
       expect(part1LiquidContent).toBe("Part 1 content");
       // Check liquid test file
       expect(fs.existsSync(testLiquidPath)).toBe(true);
-      const testLiquidContent = await fsPromises.readFile(
-        testLiquidPath,
-        "utf-8"
-      );
+      const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
       expect(testLiquidContent).toBe(template.tests);
       // Check config file
       expect(fs.existsSync(configPath)).toBe(true);
-      const configSaved = JSON.parse(
-        await fsPromises.readFile(configPath, "utf-8")
-      );
+      const configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
       expect(configSaved).toEqual(configToWrite);
     });
 
@@ -181,16 +147,12 @@ describe("ReconciliationText", () => {
       templateUtils.filterParts.mockReturnValue(textParts);
 
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts"));
-      fs.mkdirSync(
-        path.join(tempDir, "reconciliation_texts", "example_handle")
-      );
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle"));
       fs.writeFileSync(configPath, JSON.stringify(existingConfig));
 
       // Check existing config file before save
       expect(fs.existsSync(configPath)).toBe(true);
-      let configSaved = JSON.parse(
-        await fsPromises.readFile(configPath, "utf-8")
-      );
+      let configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
       expect(configSaved).toEqual(existingConfig);
 
       await ReconciliationText.save("firm", 100, template);
@@ -208,17 +170,8 @@ describe("ReconciliationText", () => {
       templateUtils.filterParts.mockReturnValue(textParts);
 
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts"));
-      fs.mkdirSync(
-        path.join(tempDir, "reconciliation_texts", "example_handle")
-      );
-      fs.mkdirSync(
-        path.join(
-          tempDir,
-          "reconciliation_texts",
-          "example_handle",
-          "text_parts"
-        )
-      );
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle"));
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle", "text_parts"));
       fs.writeFileSync(configPath, JSON.stringify(existingConfig));
       fs.writeFileSync(mainLiquidPath, "Main part: existing content");
       fs.writeFileSync(part1LiquidPath, "Part 1: existing content");
@@ -226,16 +179,10 @@ describe("ReconciliationText", () => {
       await ReconciliationText.save("firm", 100, template);
 
       // Check main liquid file
-      const mainLiquidContent = await fsPromises.readFile(
-        mainLiquidPath,
-        "utf-8"
-      );
+      const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
       expect(mainLiquidContent).toBe(template.text);
       // Check text parts liquid files
-      const part1LiquidContent = await fsPromises.readFile(
-        part1LiquidPath,
-        "utf-8"
-      );
+      const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
       expect(part1LiquidContent).toBe(textParts.part_1);
     });
 
@@ -247,22 +194,15 @@ describe("ReconciliationText", () => {
       const existingLiquidTest = "Existing Liquid Test";
 
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts"));
-      fs.mkdirSync(
-        path.join(tempDir, "reconciliation_texts", "example_handle")
-      );
-      fs.mkdirSync(
-        path.join(tempDir, "reconciliation_texts", "example_handle", "tests")
-      );
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle"));
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle", "tests"));
       fs.writeFileSync(configPath, JSON.stringify(existingConfig));
       fs.writeFileSync(testLiquidPath, existingLiquidTest);
 
       await ReconciliationText.save("firm", 100, template);
 
       // Check liquid test file
-      const testLiquidContent = await fsPromises.readFile(
-        testLiquidPath,
-        "utf-8"
-      );
+      const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
       expect(testLiquidContent).toBe(existingLiquidTest);
     });
 
@@ -275,27 +215,15 @@ describe("ReconciliationText", () => {
       const existingPartContent = "Old part: existing Part Content";
 
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts"));
-      fs.mkdirSync(
-        path.join(tempDir, "reconciliation_texts", "example_handle")
-      );
-      fs.mkdirSync(
-        path.join(
-          tempDir,
-          "reconciliation_texts",
-          "example_handle",
-          "text_parts"
-        )
-      );
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle"));
+      fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle", "text_parts"));
       fs.writeFileSync(configPath, JSON.stringify(existingConfig));
       fs.writeFileSync(oldPartLiquidPath, existingPartContent);
 
       await ReconciliationText.save("firm", 100, template);
 
       // Check Old Part liquid file
-      const oldPartLiquidContent = await fsPromises.readFile(
-        oldPartLiquidPath,
-        "utf-8"
-      );
+      const oldPartLiquidContent = await fsPromises.readFile(oldPartLiquidPath, "utf-8");
       expect(oldPartLiquidContent).toBe(existingPartContent);
     });
   });
@@ -306,16 +234,8 @@ describe("ReconciliationText", () => {
     const templateDir = path.join(tempDir, "reconciliation_texts", handle);
     const configPath = path.join(templateDir, "config.json");
     const mainLiquidPath = path.join(templateDir, "main.liquid");
-    const testLiquidPath = path.join(
-      templateDir,
-      "tests",
-      `${handle}_liquid_test.yml`
-    );
-    const part1LiquidPath = path.join(
-      templateDir,
-      "text_parts",
-      "part_1.liquid"
-    );
+    const testLiquidPath = path.join(templateDir, "tests", `${handle}_liquid_test.yml`);
+    const part1LiquidPath = path.join(templateDir, "text_parts", "part_1.liquid");
 
     const configContent = {
       id: { 100: 808080 },
@@ -360,10 +280,7 @@ describe("ReconciliationText", () => {
       templateUtils.checkValidName.mockReturnValue(false);
       const result = ReconciliationText.read("invalid_handle");
       expect(result).toBe(false);
-      expect(templateUtils.checkValidName).toHaveBeenCalledWith(
-        "invalid_handle",
-        "reconciliationText"
-      );
+      expect(templateUtils.checkValidName).toHaveBeenCalledWith("invalid_handle", "reconciliationText");
     });
 
     it("should read and process the template correctly", () => {
@@ -443,10 +360,7 @@ describe("ReconciliationText", () => {
         text_parts: { empty_part: "text_parts/empty_part.liquid" },
       };
       fs.writeFileSync(configPath, JSON.stringify(emptyPartConfig));
-      fs.writeFileSync(
-        path.join(templateDir, "text_parts", "empty_part.liquid"),
-        ""
-      );
+      fs.writeFileSync(path.join(templateDir, "text_parts", "empty_part.liquid"), "");
 
       const result = ReconciliationText.read(handle);
 
@@ -457,7 +371,7 @@ describe("ReconciliationText", () => {
       const invalidCombinationConfig = {
         ...configContent,
         externally_managed: false,
-        downloadable_as_docx: true
+        downloadable_as_docx: true,
       };
       fs.writeFileSync(configPath, JSON.stringify(invalidCombinationConfig));
 
@@ -473,7 +387,7 @@ describe("ReconciliationText", () => {
       const validCombinationConfig = {
         ...configContent,
         externally_managed: true,
-        downloadable_as_docx: true
+        downloadable_as_docx: true,
       };
       fs.writeFileSync(configPath, JSON.stringify(validCombinationConfig));
 
@@ -481,6 +395,5 @@ describe("ReconciliationText", () => {
 
       expect(result.downloadable_as_docx).toBe(true);
     });
-
   });
 });


### PR DESCRIPTION
## Description

Improved the --help guidance for account templates and export files to always use double quotes around the name.
e.g. `-n, --name "<name>"       Import a specific export file by name | Make sure to always enclose the name in double quotes`

Fixes # (link to the corresponding issue if applicable)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
