### PR TITLE
Implement export file new name locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ async function fetchExportFileByName(type, envId, name) {
 
     const saved = ExportFile.save(type, envId, template);
     if (saved) {
-      consola.success(`Export file "${template?.name}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
     }
   } catch (error) {
     consola.error(error);
@@ -258,7 +258,7 @@ async function fetchAllExportFiles(type, envId, page = 1) {
     const saved = ExportFile.save(type, envId, template);
 
     if (saved) {
-      consola.success(`Export file "${template?.name}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
     }
   });
   fetchAllExportFiles(type, envId, page + 1);

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ async function fetchExportFileByName(type, envId, name) {
 
     const saved = ExportFile.save(type, envId, template);
     if (saved) {
-      consola.success(`Export file "${name}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
     }
   } catch (error) {
     consola.error(error);
@@ -258,7 +258,7 @@ async function fetchAllExportFiles(type, envId, page = 1) {
     const saved = ExportFile.save(type, envId, template);
 
     if (saved) {
-      consola.success(`Export file "${template.name}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
     }
   });
   fetchAllExportFiles(type, envId, page + 1);
@@ -315,8 +315,8 @@ async function publishExportFileByName(type, envId, name, message = "updated thr
 
     const response = await SF.updateExportFile(type, envId, templateId, template);
 
-    if (response && response.data && response.data.name) {
-      consola.success(`Export file updated: ${response.data.name}`);
+    if (response && response.data && response.data.name_nl) {
+      consola.success(`Export file updated: ${response.data.name_nl}`);
       return true;
     } else {
       consola.error(`Export file update failed: ${name}`);
@@ -346,11 +346,11 @@ async function newExportFile(type, envId, name) {
     if (!template) return;
     template.version_comment = "Created through the Silverfin CLI";
     const response = await SF.createExportFile(type, envId, template);
-
+    const handle = response.data.name_nl;
     // Store new id
     if (response && response.status == 201) {
-      ExportFile.updateTemplateId(type, envId, name, response.data.id);
-      consola.success(`Export file "${name}" created on ${type} ${envId}`);
+      ExportFile.updateTemplateId(type, envId, handle, response.data.id);
+      consola.success(`Export file "${handle}" created on ${type} ${envId}`);
     }
   } catch (error) {
     errorUtils.errorHandler(error);

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ async function fetchExportFileByName(type, envId, name) {
 
     const saved = ExportFile.save(type, envId, template);
     if (saved) {
-      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name}" imported from ${type} ${envId}`);
     }
   } catch (error) {
     consola.error(error);
@@ -258,7 +258,7 @@ async function fetchAllExportFiles(type, envId, page = 1) {
     const saved = ExportFile.save(type, envId, template);
 
     if (saved) {
-      consola.success(`Export file "${template?.name_nl}" imported from ${type} ${envId}`);
+      consola.success(`Export file "${template?.name}" imported from ${type} ${envId}`);
     }
   });
   fetchAllExportFiles(type, envId, page + 1);

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -281,7 +281,7 @@ async function findExportFileByName(type, envId, exportFileName, page = 1) {
   if (exportFiles.length == 0) {
     return null;
   }
-  const exportFile = exportFiles.find((element) => element["name"] === exportFileName);
+  const exportFile = exportFiles.find((element) => element["name_nl"] === exportFileName);
   if (exportFile) {
     return await readExportFileById(type, envId, exportFile.id);
   } else {

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -16,14 +16,8 @@ class AccountTemplate {
    * @param {object} template The object to be processed and saved
    */
   static save(type, envId, template) {
-    if (!template?.name_nl) {
-      consola.warn(
-        `Template name_nl is missing "${
-          template?.name_en || template?.name_fr || template?.name_da || template?.name_de
-        }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because the NL name is the only required field for a template name.`
-      );
-      return false;
-    } // NL must be enabled in "Advanced Settings" in Silverfin
+    // NL must be enabled in "Advanced Settings" in Silverfin
+    if (templateUtils.missingNameNL(template)) return false;
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template?.name_nl, this.TEMPLATE_TYPE)) return false;
 

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -65,10 +65,7 @@ class AccountTemplate {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
 
     // Handle legacy name conversion
-    templateConfig = this.#populateMissingNameLocales(templateConfig); 
-
-    // Write updated config back to file
-    fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
+    templateConfig = this.#populateMissingNameLocales(templateConfig);
 
     if (!this.#validateFolderName(name, templateConfig)) return false;
     let template = this.#filterConfigItems(templateConfig);
@@ -201,6 +198,10 @@ class AccountTemplate {
       templateConfig.name_en = templateConfig.name;
       templateConfig.name_fr = templateConfig.name;
       delete templateConfig.name;
+
+      // Write updated config back to file
+      consola.debug(`Template ${templateConfig.name_nl}: adjusting name fields in config.json`);
+      fsUtils.writeConfig(this.TEMPLATE_TYPE, templateConfig.name_nl, templateConfig);
     }
     return templateConfig;
   }

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -62,9 +62,17 @@ class AccountTemplate {
   static read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name);
-    // Config.json
-    const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
+    let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
+
+    // Handle legacy name conversion
+    templateConfig = this.#populateMissingNameLocales(templateConfig); 
+
+    // Write updated config back to file
+    fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
+
+    if (!this.#validateFolderName(name, templateConfig)) return false;
     let template = this.#filterConfigItems(templateConfig);
+
     // Liquid
     this.#createMainLiquid(name);
     template.text = this.#readMainLiquid(name, templateConfig);
@@ -185,6 +193,25 @@ class AccountTemplate {
     if (!fs.existsSync(`${relativePath}/main.liquid`)) {
       fsUtils.createLiquidFile(relativePath, "main", "{% comment %} MAIN PART {% endcomment %}");
     }
+  }
+
+  static #populateMissingNameLocales(templateConfig) {
+    if (templateConfig.name && !templateConfig.name_nl) {
+      templateConfig.name_nl = templateConfig.name;
+      templateConfig.name_en = templateConfig.name;
+      templateConfig.name_fr = templateConfig.name;
+      delete templateConfig.name;
+    }
+    return templateConfig;
+  }
+
+  static #validateFolderName(name, config) {
+    if (name !== config.name_nl) {
+      consola.warn(`Folder name "${name}" does not match name_nl "${config.name_nl}" in config. Please change it accordingly and try again.`);
+
+      return false;
+    }
+    return true;
   }
 
   static #readMainLiquid(name, templateConfig) {

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -4,7 +4,7 @@ const templateUtils = require("../utils/templateUtils");
 const { consola } = require("consola");
 
 class ExportFile {
-  static CONFIG_ITEMS = ["name", "name_en", "name_fr", "name_nl", "file_name", "externally_managed", "encoding", "published", "hide_code"];
+  static CONFIG_ITEMS = ["name_en", "name_fr", "name_nl", "file_name", "externally_managed", "encoding", "published", "hide_code"];
   static TEMPLATE_TYPE = "exportFile";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -56,18 +56,13 @@ class ExportFile {
   static read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name, false);
-    const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
+    let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
 
     // Handle legacy name conversion
-    if (templateConfig.name && !templateConfig.name_nl) {
-      templateConfig.name_nl = templateConfig.name;
-      templateConfig.name_en = templateConfig.name;
-      templateConfig.name_fr = templateConfig.name;
-      delete templateConfig.name;
+    templateConfig = this.#populateMissingNameLocales(templateConfig); 
 
-      // Write updated config back to file
-      fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
-    }
+    // Write updated config back to file
+    fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
 
     if (!this.#validateFolderName(name, templateConfig)) return false;
     let template = this.#filterConfigItems(templateConfig);
@@ -114,6 +109,16 @@ class ExportFile {
       }
       return acc;
     }, {});
+  }
+
+  static #populateMissingNameLocales(templateConfig) {
+    if (templateConfig.name && !templateConfig.name_nl) {
+      templateConfig.name_nl = templateConfig.name;
+      templateConfig.name_en = templateConfig.name;
+      templateConfig.name_fr = templateConfig.name;
+      delete templateConfig.name;
+    }
+    return templateConfig;
   }
 
   static #createMainLiquid(name) {

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -59,10 +59,7 @@ class ExportFile {
     let templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
 
     // Handle legacy name conversion
-    templateConfig = this.#populateMissingNameLocales(templateConfig); 
-
-    // Write updated config back to file
-    fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
+    templateConfig = this.#populateMissingNameLocales(templateConfig);
 
     if (!this.#validateFolderName(name, templateConfig)) return false;
     let template = this.#filterConfigItems(templateConfig);
@@ -117,6 +114,10 @@ class ExportFile {
       templateConfig.name_en = templateConfig.name;
       templateConfig.name_fr = templateConfig.name;
       delete templateConfig.name;
+
+      // Write updated config back to file
+      consola.debug(`Template ${templateConfig.name_nl}: adjusting name fields in config.json`);
+      fsUtils.writeConfig(this.TEMPLATE_TYPE, templateConfig.name_nl, templateConfig);
     }
     return templateConfig;
   }

--- a/lib/templates/exportFile.js
+++ b/lib/templates/exportFile.js
@@ -1,9 +1,10 @@
 const fs = require("fs");
 const fsUtils = require("../utils/fsUtils");
 const templateUtils = require("../utils/templateUtils");
+const { consola } = require("consola");
 
 class ExportFile {
-  static CONFIG_ITEMS = ["name", "file_name", "externally_managed", "encoding", "published", "hide_code"];
+  static CONFIG_ITEMS = ["name", "name_en", "name_fr", "name_nl", "file_name", "externally_managed", "encoding", "published", "hide_code"];
   static TEMPLATE_TYPE = "exportFile";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}
@@ -15,10 +16,12 @@ class ExportFile {
    * @param {object} template
    */
   static save(type, envId, template) {
+    // NL must be enabled in "Advanced Settings" in Silverfin
+    if (templateUtils.missingNameNL(template)) return false;
     if (templateUtils.missingLiquidCode(template)) return false;
     if (!templateUtils.checkValidName(template.name, this.TEMPLATE_TYPE)) return false;
 
-    const name = template.name;
+    const name = template.name_nl;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name, false);
 
     // Liquid files
@@ -53,9 +56,22 @@ class ExportFile {
   static read(name) {
     if (!templateUtils.checkValidName(name, this.TEMPLATE_TYPE)) return false;
     fsUtils.createTemplateFolders(this.TEMPLATE_TYPE, name, false);
-    // Config.json
     const templateConfig = fsUtils.readConfig(this.TEMPLATE_TYPE, name);
+
+    // Handle legacy name conversion
+    if (templateConfig.name && !templateConfig.name_nl) {
+      templateConfig.name_nl = templateConfig.name;
+      templateConfig.name_en = templateConfig.name;
+      templateConfig.name_fr = templateConfig.name;
+      delete templateConfig.name;
+
+      // Write updated config back to file
+      fsUtils.writeConfig(this.TEMPLATE_TYPE, name, templateConfig);
+    }
+
+    if (!this.#validateFolderName(name, templateConfig)) return false;
     let template = this.#filterConfigItems(templateConfig);
+
     // Liquid
     this.#createMainLiquid(name);
     template.text = this.#readMainLiquid(name, templateConfig);
@@ -120,6 +136,15 @@ class ExportFile {
       array.push({ name, content });
       return array;
     }, []);
+  }
+
+  static #validateFolderName(name, config) {
+    if (name !== config.name_nl) {
+      consola.warn(`Folder name "${name}" does not match name_nl "${config.name_nl}" in config. Please change it accordingly and try again.`);
+
+      return false;
+    }
+    return true;
   }
 }
 

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -32,13 +32,13 @@ function missingConfig(identifier) {
 }
 
 function missingReconciliationId(handle) {
-  consola.error(`Reconciliation ${handle}: ID is missing.`);
+  consola.error(`Reconciliation ${handle}: ID is missing. Please check your command for typos and check if the folder name matches the name_nl`);
   consola.log(`Try running: ${chalk.bold(`silverfin get-reconciliation-id --handle ${handle}`)} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`);
   return false;
 }
 
 function missingSharedPartId(name) {
-  consola.error(`Shared part ${name}: ID is missing. Aborted`);
+  consola.error(`Shared part ${name}: ID is missing. Aborted. Please check your command for typos and check if the folder name matches the name_nl`);
   consola.info(`Try running: ${chalk.bold(`silverfin get-shared-part-id --shared-part ${name}`)} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`);
   return false;
 }
@@ -49,7 +49,7 @@ function missingExportFileId(name) {
 }
 
 function missingAccountTemplateId(name) {
-  consola.error(`Account template ${name}: ID is missing. Aborted`);
+  consola.error(`Account template ${name}: ID is missing. Aborted. Please check your command for typos and check if the folder name matches the name_nl`);
   return false;
 }
 

--- a/lib/utils/errorUtils.js
+++ b/lib/utils/errorUtils.js
@@ -44,7 +44,7 @@ function missingSharedPartId(name) {
 }
 
 function missingExportFileId(name) {
-  consola.error(`Export file ${name}: ID is missing. Aborted`);
+  consola.error(`Export file ${name}: ID is missing. Aborted. Please check your command for typos and check if the folder name matches the name_nl`);
   return false;
 }
 

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -167,7 +167,9 @@ function createConfigIfMissing(templateType, handle) {
       config.used_in = [];
       break;
     case "exportFile":
-      config.name = `${handle}`;
+      config.name_nl = `${handle}`;
+      config.name_fr = `${handle}`;
+      config.name_en = `${handle}`;
       config.file_name = "export_file.sxbrl";
       config.text = "main.liquid";
       config.encoding = "UTF-8";

--- a/lib/utils/templateUtils.js
+++ b/lib/utils/templateUtils.js
@@ -3,7 +3,7 @@ const { consola } = require("consola");
 const TEMPLATES_NAME_ATTRIBUTE = {
   reconciliationText: "handle",
   accountTemplate: "name_nl",
-  exportFile: "name",
+  exportFile: "name_nl",
   sharedPart: "name",
 };
 
@@ -67,6 +67,17 @@ function missingLiquidCode(template) {
   return false;
 }
 
+function missingNameNL(template) {
+  if (!template?.name_nl) {
+    consola.warn(
+      `Template name_nl is missing "${
+        template?.name_en || template?.name_fr || template?.name_da || template?.name_de
+      }". Skipping. NL must be enabled in "Advanced Settings" in Silverfin because the NL name is the only required field for a template name.`
+    );
+    return false;
+  }
+}
+
 module.exports = {
   TEMPLATES_NAME_ATTRIBUTE,
   TEMPLATE_TYPE_NAMES,
@@ -75,4 +86,5 @@ module.exports = {
   checkValidName,
   filterParts,
   missingLiquidCode,
+  missingNameNL,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.30.3",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.30.2",
+      "version": "1.31.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.30.3",
+  "version": "1.31.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

Used the specs here: https://gitlab.silverfin.com/development/silverfin/-/issues/24034

Couple of considerations:

- Do we want to remove the 'name' attribute from the config files as soon as someone does a 'import-export-file'? Now, we only add the 3 new locales. 

- When doing an update via 'update-export-file', some new logic was added to adjust the config file and add the missing name translations. This leads to 'new' changes after we do the update command (which can in some cases e.g. update to partners be the last action). As a result, we can end up with a situation where a fix was approved, merged with main, and when someone wants to push from main with the update command, we add the new locales. These new changes need to be put in a new PR to be reflected correctly in the repo's. Do you see any issues with this? This is a one-off of course. 

- Should we consider renaming the folder automatically to the nl naming as soon as we do any updates? 

- We have two main 'error paths':
In the update command, we still refer to the 'old' name, which is also still the folder name. This case is covered by a warning that the folder should be renamed

In the update command, we refer to the new nl name, but the folder name is still referring to the old name. We end up in the same situation as when we have a typo: Warning about ID that is missing. 

Given that this is a one-off, instead of having to write some additional logic here, could be maybe make the warning a little bit more descriptive?

So: ID is missing, aborted. Please check your command for typos and check if the folder name matches the name_nl (or something like this). 

- Do we still need the 'name' attribute in the config in the ExportFile class? 


Fixes # (link to the corresponding issue if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
