### PR TITLE
Create tests for Account Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.41.0] (28/07/2025)
+- Add tests for the accountTemplate class
+
 ## [1.40.0] (08/07/2025)
 - `stats` command now displays the amount of yaml files that have at least two unit tests defined
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -218,14 +218,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -521,9 +521,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
-      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1418,13 +1418,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.181",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.181.tgz",
-      "integrity": "sha512-+ISMj8OIQ+0qEeDj14Rt8WwcTOiqHyAB+5bnK1K7xNNLjBJ4hRCQfUkw8RWtcLbfBzDwc15ZnKH0c7SNOfwiyA==",
+      "version": "1.5.191",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
+      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2528,9 +2528,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const fsPromises = require("fs").promises;
 const path = require("path");
-const fsUtils = require("../../../lib/utils/fsUtils");
 const templateUtils = require("../../../lib/utils/templateUtils");
 const { AccountTemplate } = require("../../../lib/templates/accountTemplate");
 
@@ -40,7 +39,6 @@ describe("AccountTemplate", () => {
       text_parts: {
         part_1: "text_parts/part_1.liquid",
       },
-      name_nl: "name_nl",
       name_fr: "name_nl",
       name_en: "name_nl",
       account_range: null,
@@ -56,12 +54,11 @@ describe("AccountTemplate", () => {
         old_part: "text_parts/old_part.liquid",
         part_1: "text_parts/part_1.liquid",
       },
-      name_nl: "name_nl",
-	  name_fr: "name_fr",
-	  name_en: "name_en",
-	  account_range: null,
-	  mapping_list_ranges: [],
-	  hide_code: false,
+      name_fr: "name_fr",
+      name_en: "name_en",
+      account_range: null,
+      mapping_list_ranges: [],
+      hide_code: false,
       published: true,
     };
 
@@ -87,139 +84,136 @@ describe("AccountTemplate", () => {
       jest.resetAllMocks();
     });
 
-	it("should return false if name_nl is missing", () => {
-		const result = AccountTemplate.save("firm", 100, { id: 808080 });
-		expect(result).toBe(false);
-	});
+    it("should return false if name_nl is missing", () => {
+      const result = AccountTemplate.save("firm", 100, { id: 808080 });
+      expect(result).toBe(false);
+    });
 
-	it("should return false if the liquid code is missing", () => {
-		templateUtils.missingLiquidCode.mockReturnValue(true);
-		const result = AccountTemplate.save("firm", 100, template);
-		expect(result).toBe(false);
-		expect(templateUtils.missingLiquidCode).toHaveBeenCalledWith(template);
-	  });
+    it("should return false if the liquid code is missing", () => {
+      templateUtils.missingLiquidCode.mockReturnValue(true);
+      const result = AccountTemplate.save("firm", 100, template);
+      expect(result).toBe(false);
+      expect(templateUtils.missingLiquidCode).toHaveBeenCalledWith(template);
+    });
 
-	it("should return false if the template handle is invalid", () => {
-		templateUtils.checkValidName.mockReturnValue(false);
-		const result = AccountTemplate.save("firm", 100, template);
-		expect(result).toBe(false);
-		expect(templateUtils.checkValidName).toHaveBeenCalledWith("name_nl", "accountTemplate");
-	});
+    it("should return false if the template handle is invalid", () => {
+      templateUtils.checkValidName.mockReturnValue(false);
+      const result = AccountTemplate.save("firm", 100, template);
+      expect(result).toBe(false);
+      expect(templateUtils.checkValidName).toHaveBeenCalledWith("name_nl", "accountTemplate");
+    });
 
-  it("should create the necessary files and store template's relevant details", async () => {
-    templateUtils.missingLiquidCode.mockReturnValue(false);
-    templateUtils.checkValidName.mockReturnValue(true);
-    templateUtils.filterParts.mockReturnValue({ part_1: "Part 1 content" });
+    it("should create the necessary files and store template's relevant details", async () => {
+      templateUtils.missingLiquidCode.mockReturnValue(false);
+      templateUtils.checkValidName.mockReturnValue(true);
+      templateUtils.filterParts.mockReturnValue({ part_1: "Part 1 content" });
 
-    await AccountTemplate.save("firm", 100, template);
+      await AccountTemplate.save("firm", 100, template);
 
-    // Check folder creation
-    expect(fs.existsSync(expectedFolderPath)).toBe(true);
-    // Check main liquid file
-    expect(fs.existsSync(mainLiquidPath)).toBe(true);
-    const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
-    expect(mainLiquidContent).toBe(template.text);
-    // Check text parts liquid files
-    expect(fs.existsSync(part1LiquidPath)).toBe(true);
-    const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
-    expect(part1LiquidContent).toBe("Part 1 content");
-    // Check config file
-    expect(fs.existsSync(configPath)).toBe(true);
-    const configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
-    expect(configSaved).toEqual(configToWrite);    
-    // Check liquid test file
-    expect(fs.existsSync(testLiquidPath)).toBe(true);
-    const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
-    expect(testLiquidContent).toBe(template.tests);
+      // Check folder creation
+      expect(fs.existsSync(expectedFolderPath)).toBe(true);
+      // Check main liquid file
+      expect(fs.existsSync(mainLiquidPath)).toBe(true);
+      const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
+      expect(mainLiquidContent).toBe(template.text);
+      // Check text parts liquid files
+      expect(fs.existsSync(part1LiquidPath)).toBe(true);
+      const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
+      expect(part1LiquidContent).toBe("Part 1 content");
+      // Check config file
+      expect(fs.existsSync(configPath)).toBe(true);
+      const configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+      expect(configSaved).toEqual(configToWrite);
+      // Check liquid test file
+      expect(fs.existsSync(testLiquidPath)).toBe(true);
+      const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
+      expect(testLiquidContent).toBe(template.tests);
+    });
+
+    it("should fetch an existing template's config and update with new details", async () => {
+      templateUtils.missingLiquidCode.mockReturnValue(false);
+      templateUtils.checkValidName.mockReturnValue(true);
+      templateUtils.filterParts.mockReturnValue(textParts);
+
+      fs.mkdirSync(path.join(tempDir, "account_templates"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+      fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+
+      // Check existing config file before save
+      expect(fs.existsSync(configPath)).toBe(true);
+      let configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+      expect(configSaved).toEqual(existingConfig);
+
+      await AccountTemplate.save("firm", 100, template);
+
+      // Check config file after save
+      configToWrite.id[200] = 505050;
+      expect(fs.existsSync(configPath)).toBe(true);
+      configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+      expect(configSaved).toEqual(configToWrite);
+    });
+
+    it("should replace existing liquid files if the template already exists", async () => {
+      templateUtils.missingLiquidCode.mockReturnValue(false);
+      templateUtils.checkValidName.mockReturnValue(true);
+      templateUtils.filterParts.mockReturnValue(textParts);
+
+      fs.mkdirSync(path.join(tempDir, "account_templates"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
+      fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+      fs.writeFileSync(mainLiquidPath, "Main part: existing content");
+      fs.writeFileSync(part1LiquidPath, "Part 1: existing content");
+
+      await AccountTemplate.save("firm", 100, template);
+
+      // Check main liquid file
+      const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
+      expect(mainLiquidContent).toBe(template.text);
+      // Check text parts liquid files
+      const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
+      expect(part1LiquidContent).toBe(textParts.part_1);
+    });
+
+    it("should not replace existing liquid test files if the template already exists", async () => {
+      templateUtils.missingLiquidCode.mockReturnValue(false);
+      templateUtils.checkValidName.mockReturnValue(true);
+      templateUtils.filterParts.mockReturnValue(textParts);
+
+      const existingLiquidTest = "Existing Liquid Test";
+
+      fs.mkdirSync(path.join(tempDir, "account_templates"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "tests"));
+      fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+      fs.writeFileSync(testLiquidPath, existingLiquidTest);
+
+      await AccountTemplate.save("firm", 100, template);
+
+      // Check liquid test file
+      const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
+      expect(testLiquidContent).toBe(existingLiquidTest);
+    });
+
+    // NOTE: Do we need to modify this behavior?
+    it("should not replace or delete unspecified text_parts", async () => {
+      templateUtils.missingLiquidCode.mockReturnValue(false);
+      templateUtils.checkValidName.mockReturnValue(true);
+      templateUtils.filterParts.mockReturnValue(textParts);
+
+      const existingPartContent = "Old part: existing Part Content";
+
+      fs.mkdirSync(path.join(tempDir, "account_templates"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+      fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
+      fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+      fs.writeFileSync(oldPartLiquidPath, existingPartContent);
+
+      await AccountTemplate.save("firm", 100, template);
+
+      // Check Old Part liquid file
+      const oldPartLiquidContent = await fsPromises.readFile(oldPartLiquidPath, "utf-8");
+      expect(oldPartLiquidContent).toBe(existingPartContent);
+    });
   });
-
-  it("should fetch an existing template's config and update with new details", async () => {
-    templateUtils.missingLiquidCode.mockReturnValue(false);
-    templateUtils.checkValidName.mockReturnValue(true);
-    templateUtils.filterParts.mockReturnValue(textParts);
-
-    fs.mkdirSync(path.join(tempDir, "account_templates"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
-    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
-
-    // Check existing config file before save
-    expect(fs.existsSync(configPath)).toBe(true);
-    let configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
-    expect(configSaved).toEqual(existingConfig);
-
-    await AccountTemplate.save("firm", 100, template);
-
-    // Check config file after save
-    configToWrite.id[200] = 505050;
-    expect(fs.existsSync(configPath)).toBe(true);
-    configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
-    expect(configSaved).toEqual(configToWrite);
-
-  });
-
-  it("should replace existing liquid files if the template already exists", async () => {
-    templateUtils.missingLiquidCode.mockReturnValue(false);
-    templateUtils.checkValidName.mockReturnValue(true);
-    templateUtils.filterParts.mockReturnValue(textParts);
-
-    fs.mkdirSync(path.join(tempDir, "account_templates"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
-    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
-    fs.writeFileSync(mainLiquidPath, "Main part: existing content");
-    fs.writeFileSync(part1LiquidPath, "Part 1: existing content");
-
-    await AccountTemplate.save("firm", 100, template);
-
-    // Check main liquid file
-    const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
-    expect(mainLiquidContent).toBe(template.text);
-    // Check text parts liquid files
-    const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
-    expect(part1LiquidContent).toBe(textParts.part_1);
-  });
-
-  it("should not replace existing liquid test files if the template already exists", async () => {
-    templateUtils.missingLiquidCode.mockReturnValue(false);
-    templateUtils.checkValidName.mockReturnValue(true);
-    templateUtils.filterParts.mockReturnValue(textParts);
-
-    const existingLiquidTest = "Existing Liquid Test";
-
-    fs.mkdirSync(path.join(tempDir, "account_templates"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "tests"));
-    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
-    fs.writeFileSync(testLiquidPath, existingLiquidTest);
-
-    await AccountTemplate.save("firm", 100, template);
-
-    // Check liquid test file
-    const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
-    expect(testLiquidContent).toBe(existingLiquidTest);
-  });
-
-  // NOTE: Do we need to modify this behavior?
-  it("should not replace or delete unspecified text_parts", async () => {
-    templateUtils.missingLiquidCode.mockReturnValue(false);
-    templateUtils.checkValidName.mockReturnValue(true);
-    templateUtils.filterParts.mockReturnValue(textParts);
-
-    const existingPartContent = "Old part: existing Part Content";
-
-    fs.mkdirSync(path.join(tempDir, "account_templates"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
-    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
-    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
-    fs.writeFileSync(oldPartLiquidPath, existingPartContent);
-
-    await AccountTemplate.save("firm", 100, template);
-
-    // Check Old Part liquid file
-    const oldPartLiquidContent = await fsPromises.readFile(oldPartLiquidPath, "utf-8");
-    expect(oldPartLiquidContent).toBe(existingPartContent);
-  });
-
-});
-
 });

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const fsPromises = require("fs").promises;
+const path = require("path");
+const fsUtils = require("../../../lib/utils/fsUtils");
+const templateUtils = require("../../../lib/utils/templateUtils");
+const { AccountTemplate } = require("../../../lib/templates/accountTemplate");
+
+jest.mock("../../../lib/utils/templateUtils");
+jest.mock("consola");
+
+describe("AccountTemplate", () => {
+  describe("save", () => {
+    const testContent = "Test content as string";
+    const textParts = { part_1: "Part 1: updated content" };
+    const template = {
+      name_nl: "name_nl",
+      id: 808080,
+      text: "Main liquid content",
+      text_parts: [
+        { name: "part_1", content: "Part 1: updated content" },
+        { name: "", content: "" },
+      ],
+      tests: testContent,
+      externally_managed: true,
+    };
+    const name_nl = template.name_nl;
+    const configToWrite = {
+      id: {
+        100: 808080,
+      },
+      partner_id: {},
+      name_nl: "name_nl",
+      text: "main.liquid",
+      text_parts: {
+        part_1: "text_parts/part_1.liquid",
+      },
+	  name_nl: "name_nl",
+	  name_fr: "name_fr",
+	  name_en: "name_en",
+	  account_range: null,
+	  mapping_list_ranges: [],
+	  hide_code: true,
+      published: true,
+    };
+    const existingConfig = {
+      id: { 200: 505050 },
+      name_nl: "old_name_nl",
+      text: "main.liquid",
+      text_parts: {
+        old_part: "text_parts/old_part.liquid",
+        part_1: "text_parts/part_1.liquid",
+      },
+      name_nl: "name_nl",
+	  name_fr: "name_fr",
+	  name_en: "name_en",
+	  account_range: null,
+	  mapping_list_ranges: [],
+	  hide_code: false,
+      published: true,
+    };
+
+    const tempDir = path.join(process.cwd(), "tmp");
+    const expectedFolderPath = path.join(tempDir, "account_templates", name_nl);
+    const configPath = path.join(expectedFolderPath, "config.json");
+    const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
+    const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
+    const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
+
+    beforeEach(() => {
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(tempDir)) {
+        fs.rmdirSync(tempDir, { recursive: true });
+      }
+      jest.resetAllMocks();
+    });
+
+	it("should return false if name_nl is missing", () => {
+		const result = AccountTemplate.save("firm", 100, { id: 808080 });
+		expect(result).toBe(false);
+		expect(require("consola").warn).toHaveBeenCalledWith('Template name_nl is missing \"undefined\". Skipping. NL must be enabled in \"Advanced Settings\" in Silverfin because the NL name is the only required field for a template name.');
+	});
+
+	it("should return false if the liquid code is missing", () => {
+		templateUtils.missingLiquidCode.mockReturnValue(true);
+		const result = AccountTemplate.save("firm", 100, template);
+		expect(result).toBe(false);
+		expect(templateUtils.missingLiquidCode).toHaveBeenCalledWith(template);
+	  });
+
+	it("should return false if the template handle is invalid", () => {
+		templateUtils.checkValidName.mockReturnValue(false);
+		const result = AccountTemplate.save("firm", 100, template);
+		expect(result).toBe(false);
+		expect(templateUtils.checkValidName).toHaveBeenCalledWith("name_nl", "accountTemplate");
+	});
+
+});
+
+});

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -10,10 +10,12 @@ jest.mock("consola");
 
 describe("AccountTemplate", () => {
   describe("save", () => {
-    const testContent = "Test content as string";
+    const testContent = "# Add your Liquid Tests here";
     const textParts = { part_1: "Part 1: updated content" };
     const template = {
       name_nl: "name_nl",
+      name_en: "name_nl",
+      name_fr: "name_nl",
       id: 808080,
       text: "Main liquid content",
       text_parts: [
@@ -22,6 +24,8 @@ describe("AccountTemplate", () => {
       ],
       tests: testContent,
       externally_managed: true,
+      hide_code: true,
+      mapping_list_ranges: [],
     };
     const name_nl = template.name_nl;
     const configToWrite = {
@@ -29,17 +33,19 @@ describe("AccountTemplate", () => {
         100: 808080,
       },
       partner_id: {},
+      externally_managed: true,
       name_nl: "name_nl",
       text: "main.liquid",
+      test: "tests/name_nl_liquid_test.yml",
       text_parts: {
         part_1: "text_parts/part_1.liquid",
       },
-	  name_nl: "name_nl",
-	  name_fr: "name_fr",
-	  name_en: "name_en",
-	  account_range: null,
-	  mapping_list_ranges: [],
-	  hide_code: true,
+      name_nl: "name_nl",
+      name_fr: "name_nl",
+      name_en: "name_nl",
+      account_range: null,
+      mapping_list_ranges: [],
+      hide_code: true,
       published: true,
     };
     const existingConfig = {
@@ -65,6 +71,7 @@ describe("AccountTemplate", () => {
     const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
     const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
     const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
+    const testLiquidPath = path.join(expectedFolderPath, "tests", `${name_nl}_liquid_test.yml`);
 
     beforeEach(() => {
       if (!fs.existsSync(tempDir)) {
@@ -83,7 +90,6 @@ describe("AccountTemplate", () => {
 	it("should return false if name_nl is missing", () => {
 		const result = AccountTemplate.save("firm", 100, { id: 808080 });
 		expect(result).toBe(false);
-		expect(require("consola").warn).toHaveBeenCalledWith('Template name_nl is missing \"undefined\". Skipping. NL must be enabled in \"Advanced Settings\" in Silverfin because the NL name is the only required field for a template name.');
 	});
 
 	it("should return false if the liquid code is missing", () => {
@@ -99,6 +105,120 @@ describe("AccountTemplate", () => {
 		expect(result).toBe(false);
 		expect(templateUtils.checkValidName).toHaveBeenCalledWith("name_nl", "accountTemplate");
 	});
+
+  it("should create the necessary files and store template's relevant details", async () => {
+    templateUtils.missingLiquidCode.mockReturnValue(false);
+    templateUtils.checkValidName.mockReturnValue(true);
+    templateUtils.filterParts.mockReturnValue({ part_1: "Part 1 content" });
+
+    await AccountTemplate.save("firm", 100, template);
+
+    // Check folder creation
+    expect(fs.existsSync(expectedFolderPath)).toBe(true);
+    // Check main liquid file
+    expect(fs.existsSync(mainLiquidPath)).toBe(true);
+    const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
+    expect(mainLiquidContent).toBe(template.text);
+    // Check text parts liquid files
+    expect(fs.existsSync(part1LiquidPath)).toBe(true);
+    const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
+    expect(part1LiquidContent).toBe("Part 1 content");
+    // Check config file
+    expect(fs.existsSync(configPath)).toBe(true);
+    const configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+    expect(configSaved).toEqual(configToWrite);    
+    // Check liquid test file
+    expect(fs.existsSync(testLiquidPath)).toBe(true);
+    const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
+    expect(testLiquidContent).toBe(template.tests);
+  });
+
+  it("should fetch an existing template's config and update with new details", async () => {
+    templateUtils.missingLiquidCode.mockReturnValue(false);
+    templateUtils.checkValidName.mockReturnValue(true);
+    templateUtils.filterParts.mockReturnValue(textParts);
+
+    fs.mkdirSync(path.join(tempDir, "account_templates"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+
+    // Check existing config file before save
+    expect(fs.existsSync(configPath)).toBe(true);
+    let configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+    expect(configSaved).toEqual(existingConfig);
+
+    await AccountTemplate.save("firm", 100, template);
+
+    // Check config file after save
+    configToWrite.id[200] = 505050;
+    expect(fs.existsSync(configPath)).toBe(true);
+    configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
+    expect(configSaved).toEqual(configToWrite);
+
+  });
+
+  it("should replace existing liquid files if the template already exists", async () => {
+    templateUtils.missingLiquidCode.mockReturnValue(false);
+    templateUtils.checkValidName.mockReturnValue(true);
+    templateUtils.filterParts.mockReturnValue(textParts);
+
+    fs.mkdirSync(path.join(tempDir, "account_templates"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
+    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+    fs.writeFileSync(mainLiquidPath, "Main part: existing content");
+    fs.writeFileSync(part1LiquidPath, "Part 1: existing content");
+
+    await AccountTemplate.save("firm", 100, template);
+
+    // Check main liquid file
+    const mainLiquidContent = await fsPromises.readFile(mainLiquidPath, "utf-8");
+    expect(mainLiquidContent).toBe(template.text);
+    // Check text parts liquid files
+    const part1LiquidContent = await fsPromises.readFile(part1LiquidPath, "utf-8");
+    expect(part1LiquidContent).toBe(textParts.part_1);
+  });
+
+  it("should not replace existing liquid test files if the template already exists", async () => {
+    templateUtils.missingLiquidCode.mockReturnValue(false);
+    templateUtils.checkValidName.mockReturnValue(true);
+    templateUtils.filterParts.mockReturnValue(textParts);
+
+    const existingLiquidTest = "Existing Liquid Test";
+
+    fs.mkdirSync(path.join(tempDir, "account_templates"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "tests"));
+    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+    fs.writeFileSync(testLiquidPath, existingLiquidTest);
+
+    await AccountTemplate.save("firm", 100, template);
+
+    // Check liquid test file
+    const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
+    expect(testLiquidContent).toBe(existingLiquidTest);
+  });
+
+  // NOTE: Do we need to modify this behavior?
+  it("should not replace or delete unspecified text_parts", async () => {
+    templateUtils.missingLiquidCode.mockReturnValue(false);
+    templateUtils.checkValidName.mockReturnValue(true);
+    templateUtils.filterParts.mockReturnValue(textParts);
+
+    const existingPartContent = "Old part: existing Part Content";
+
+    fs.mkdirSync(path.join(tempDir, "account_templates"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl"));
+    fs.mkdirSync(path.join(tempDir, "account_templates", "name_nl", "text_parts"));
+    fs.writeFileSync(configPath, JSON.stringify(existingConfig));
+    fs.writeFileSync(oldPartLiquidPath, existingPartContent);
+
+    await AccountTemplate.save("firm", 100, template);
+
+    // Check Old Part liquid file
+    const oldPartLiquidContent = await fsPromises.readFile(oldPartLiquidPath, "utf-8");
+    expect(oldPartLiquidContent).toBe(existingPartContent);
+  });
 
 });
 


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

Tests were created for the AccountTemplate class (save method). The read method should still follow later on

## Testing Instructions

Steps:

1. Run npm test to cover the new tests

## Author Checklist

- [x] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
