### PR TITLE
Validate cwd when running Silverfin CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ const SF = require("../lib/api/sfApi");
 const path = require("path");
 const { consola } = require("consola");
 const { runCommandChecks } = require("../lib/cli/utils");
+const { CwdValidator } = require("../lib/cli/cwdValidator");
 
 const firmIdDefault = cliUtils.loadDefaultFirmId();
 cliUtils.handleUncaughtErrors();
@@ -650,6 +651,7 @@ if (pkg.repository && pkg.repository.url) {
 // Initiate CLI
 (async function () {
   await CliUpdater.checkVersions();
+  CwdValidator.run();
   cliUtils.logCurrentHost();
   await program.parseAsync();
 })();

--- a/lib/cli/cwdValidator.js
+++ b/lib/cli/cwdValidator.js
@@ -1,0 +1,33 @@
+const { consola } = require("consola");
+const path = require("path");
+const fs = require("fs");
+const fsUtils = require("../utils/fsUtils");
+
+class CwdValidator {
+  static run() {
+    const currentDirectory = process.cwd();
+    const warningMessage = `Please, double check that you are executing "silverfin" CLI in the correct directory. Your current directory is "${currentDirectory}".`;
+    const gitDirPresent = fs.existsSync(path.join(currentDirectory, `.git`));
+
+    if (gitDirPresent) {
+      return;
+    }
+
+    let folderIdentified = false;
+    const folders = Object.values(fsUtils.FOLDERS);
+    for (const folder of folders) {
+      const re = new RegExp(folder);
+
+      if (re.test(currentDirectory)) {
+        folderIdentified = true;
+        consola.warn(`${warningMessage} You are running "silverfin" from the "${folder}" directory, this could have unexpected consequences.`);
+      }
+    }
+
+    if (!folderIdentified) {
+      consola.warn(warningMessage);
+    }
+  }
+}
+
+module.exports = { CwdValidator };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/cli/cwdValidator.spec.js
+++ b/tests/lib/cli/cwdValidator.spec.js
@@ -1,0 +1,64 @@
+const { CwdValidator } = require("../../../lib/cli/cwdValidator");
+const { consola } = require("consola");
+const fs = require("fs");
+const path = require("path");
+
+jest.mock("consola", () => ({
+  consola: {
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock("fs");
+
+const originalCwd = process.cwd;
+
+describe("CwdValidator", () => {
+  describe("run", () => {
+    let mockCurrentDir;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockCurrentDir = "/test/dir";
+      process.cwd = jest.fn().mockReturnValue(mockCurrentDir);
+      fs.existsSync.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      process.cwd = originalCwd;
+    });
+
+    it("should not display a warning if .git directory exists", () => {
+      fs.existsSync.mockReturnValue(true); // .git exists
+
+      CwdValidator.run();
+
+      expect(fs.existsSync).toHaveBeenCalledWith(path.join(mockCurrentDir, ".git"));
+      expect(consola.warn).not.toHaveBeenCalled();
+    });
+
+    it("should warn about known directories", () => {
+      fs.existsSync.mockReturnValue(false);
+      const mockCurrentDir = "/test/dir/reconciliation_texts/handle";
+      process.cwd = jest.fn().mockReturnValue(mockCurrentDir);
+
+      CwdValidator.run();
+
+      expect(fs.existsSync).toHaveBeenCalledWith(path.join(mockCurrentDir, ".git"));
+      expect(consola.warn).toHaveBeenCalledWith(
+        `Please, double check that you are executing "silverfin" CLI in the correct directory. Your current directory is "${mockCurrentDir}". You are running "silverfin" from the "reconciliation_texts" directory, this could have unexpected consequences.`
+      );
+    });
+
+    it("should display a warning if .git directory does not exist", () => {
+      fs.existsSync.mockReturnValue(false);
+
+      CwdValidator.run();
+
+      expect(fs.existsSync).toHaveBeenCalledWith(path.join(mockCurrentDir, ".git"));
+      expect(consola.warn).toHaveBeenCalledWith(
+        `Please, double check that you are executing "silverfin" CLI in the correct directory. Your current directory is "${mockCurrentDir}".`
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,9 +862,9 @@ binary-extensions@^2.0.0:
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.12"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Description

We want to identify if the program was called from a different place than the root directory of the repository.

If we identify any of the known folders in the path, it means that we are not set in the root, and we will warn it (eventually, we could set the cwd to the root path)

Also, we don't find a git repository we would warn it as well as it may be another sign of a wrong execution

Fixes #71 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
