### PR TITLE
Fix - write file sync for readme files

### DIFF
--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -75,7 +75,7 @@ function createLiquidTestReadme(templateType, handle) {
       return;
     }
     const readmeLiquidTests = fs.readFileSync(path.resolve(__dirname, "../../resources/liquidTests/README.md"), "UTF-8");
-    fs.writeFile(readmePath, readmeLiquidTests);
+    fs.writeFileSync(readmePath, readmeLiquidTests);
     consola.debug(`Liquid testing README file created for ${handle}`);
   } catch (error) {
     logErrorLiquidTestFile(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.36.0",
+      "version": "1.36.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/templates/reconciliationTexts.test.js
+++ b/tests/lib/templates/reconciliationTexts.test.js
@@ -76,6 +76,7 @@ describe("ReconciliationText", () => {
     const configPath = path.join(expectedFolderPath, "config.json");
     const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
     const testLiquidPath = path.join(expectedFolderPath, "tests", `${handle}_liquid_test.yml`);
+    const readmePath = path.join(expectedFolderPath, "tests", "README.md");
     const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
     const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
 
@@ -134,6 +135,8 @@ describe("ReconciliationText", () => {
       expect(fs.existsSync(testLiquidPath)).toBe(true);
       const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
       expect(testLiquidContent).toBe(template.tests);
+      const readmeContent = await fsPromises.readFile(readmePath, "utf-8");
+      expect(readmeContent).toContain("Use this Readme file to add extra information about the Liquid Tests ");
       // Check config file
       expect(fs.existsSync(configPath)).toBe(true);
       const configSaved = JSON.parse(await fsPromises.readFile(configPath, "utf-8"));
@@ -191,18 +194,22 @@ describe("ReconciliationText", () => {
       templateUtils.filterParts.mockReturnValue(textParts);
 
       const existingLiquidTest = "Existing Liquid Test";
+      const existingReadmeContent = "Existing Readme content";
 
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts"));
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle"));
       fs.mkdirSync(path.join(tempDir, "reconciliation_texts", "example_handle", "tests"));
       fs.writeFileSync(configPath, JSON.stringify(existingConfig));
       fs.writeFileSync(testLiquidPath, existingLiquidTest);
+      fs.writeFileSync(readmePath, existingReadmeContent);
 
       await ReconciliationText.save("firm", 100, template);
 
       // Check liquid test file
       const testLiquidContent = await fsPromises.readFile(testLiquidPath, "utf-8");
       expect(testLiquidContent).toBe(existingLiquidTest);
+      const readmeContent = await fsPromises.readFile(readmePath, "utf-8");
+      expect(readmeContent).toBe(existingReadmeContent);
     });
 
     // NOTE: Do we need to modify this behavior?


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

After https://github.com/silverfin/silverfin-cli/pull/186, the same change was missing for the readme file. Added in the existing tests as Readme was not covered by them.

## Testing Instructions

Steps:

1. Run `silverfin import-reconciliation` in a reconciliation that does not exist yet in the repo


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
