### PR TITLE
[Fix] add all shared parts command

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,7 +696,7 @@ async function newAllSharedParts(type, envId) {
  * @param {string} sharedPartName
  * @param {string} templateHandle
  * @param {string} templateType has to be either `reconciliationText`, `exportFile`or `accountTemplate`
- * @returns {boolean} - Returns true if the shared part was added successfully
+ * @returns {Promise<Object|boolean>} Returns the updated shared part config if successful, or false if it failed.
  */
 async function addSharedPart(type, envId, sharedPartName, templateHandle, templateType) {
   try {
@@ -804,12 +804,13 @@ async function addSharedPart(type, envId, sharedPartName, templateHandle, templa
  * @param {String} type - Options: `firm` or `partner`
  * @param {Number} envId
  * @param {boolean} force - If true, it will add the shared part to all templates, even if it's already present
+ * @returns {Promise<void>} Returns nothing. It will log the results to the console.
  */
 async function addAllSharedParts(type, envId, force = false) {
   const envConfigKey = type === "partner" ? "partner_id" : "id";
   const sharedPartsArray = fsUtils.getAllTemplatesOfAType("sharedPart");
 
-  for await (const sharedPartName of sharedPartsArray) {
+  for (const sharedPartName of sharedPartsArray) {
     const sharedPartConfig = await fsUtils.readConfig("sharedPart", sharedPartName);
 
     if (!sharedPartConfig.used_in) {
@@ -831,7 +832,7 @@ async function addAllSharedParts(type, envId, force = false) {
     }
     const existingLinks = sharedPartData.data.used_in;
 
-    for await (let template of sharedPartConfig.used_in) {
+    for (let template of sharedPartConfig.used_in) {
       template = SharedPart.checkTemplateType(template);
       if (!template.handle && !template.name) {
         consola.warn(`Shared part: ${sharedPartName}. Template stored in used_in has no handle or name. Skipping.`);
@@ -857,10 +858,7 @@ async function addAllSharedParts(type, envId, force = false) {
         }
       }
 
-      // add arbitrary delay to avoid rate limiting
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      addSharedPart(type, envId, sharedPartConfig.name, template.handle, template.type);
+      await addSharedPart(type, envId, sharedPartConfig.name, template.handle, template.type);
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -834,7 +834,7 @@ async function addAllSharedParts(type, envId, force = false) {
     for await (let template of sharedPartConfig.used_in) {
       template = SharedPart.checkTemplateType(template);
       if (!template.handle && !template.name) {
-        consola.warn(`Template stored in used_in has no handle or name. Skipping.`);
+        consola.warn(`Shared part: ${sharedPartName}. Template stored in used_in has no handle or name. Skipping.`);
         continue;
       }
 
@@ -961,7 +961,7 @@ async function getTemplateId(type, envId, templateType, handle) {
   }
 
   if (!templateText) {
-    consola.warn(`Template ${handle} wasn't found (${type})`);
+    consola.warn(`Template ${templateType} ${handle} wasn't found (${type} ${envId})`);
     return false;
   }
   const config = fsUtils.readConfig(templateType, handle);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.36.1",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.36.1",
+      "version": "1.37.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.36.1",
+  "version": "1.37.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Fixes #194 

## Description

When we add the same shared part to multiple templates, we could face a race condition when reading and writting it's config file. As a result, not all IDs may end up being stored in `used_in` section of the config file of the shared part.

## Testing Instructions

Steps:

1. Use a repository where a shared part is used in many templates.
2. Create those templates and shared parts in a new environment, or remove all corresponding IDs of the used_in section of the target shared part.
3. Run the `silverfin add-shared-part --all` command
4. Verify that all templates in `used_in` have a corresponding id


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
