### PR TITLE
`stats`: count yaml files with at least two tests defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.40.0] (08/07/2025)
+- `stats` command now displays the amount of yaml files that have at least two unit tests defined
+
 ## [1.39.0] (07/07/2025)
 - Add tests for the exportFile class
 

--- a/lib/cli/stats.js
+++ b/lib/cli/stats.js
@@ -73,12 +73,14 @@ async function yamlFilesActivity(sinceDate) {
 
 // Count how many YAML files are stored. We base on the presence of a non empty file
 // Count how many unit tests are stored. We base on the presence of a title for each unit test
+// Count how many YAML files have at least two unit tests
 async function countYamlFiles(templateType) {
   const files = fsUtils.listExistingFiles("yml");
   const FOLDER = fsUtils.FOLDERS[templateType];
   const YAML_EXPRESSION = `.*${FOLDER}/.*/tests/.*_liquid_test.*.y(a)?ml`;
   const re = new RegExp(YAML_EXPRESSION, "g");
   let countFiles = 0;
+  let countFilesWithAtLeastTwoTests = 0;
   let countTests = 0;
   for (const file of files) {
     const found = file.match(re);
@@ -93,6 +95,10 @@ async function countYamlFiles(templateType) {
           });
           const unitTestsCount = Object.keys(yamlContent).length || 0;
           countTests += unitTestsCount;
+
+          if (unitTestsCount >= 2) {
+            countFilesWithAtLeastTwoTests += 1;
+          }
         } catch (e) {
           // Error while parsing the YAML file
           // consola.log(e);
@@ -100,7 +106,7 @@ async function countYamlFiles(templateType) {
       }
     }
   }
-  return { files: countFiles, tests: countTests };
+  return { files: countFiles, tests: countTests, filesWithAtLeastTwoTests: countFilesWithAtLeastTwoTests };
 }
 
 // Return an array with non empty template names of a given type
@@ -160,6 +166,8 @@ async function getTemplatesSummary() {
       yamlFiles: 0,
       yamlFilesPerc: 0,
       unitTests: 0,
+      yamlFilesWithAtLeastTwoTests: 0,
+      yamlFilesWithAtLeastTwoTestsPerc: 0,
     },
     sharedParts: {
       total: 0,
@@ -178,6 +186,8 @@ async function getTemplatesSummary() {
       yamlFiles: 0,
       yamlFilesPerc: 0,
       unitTests: 0,
+      yamlFilesWithAtLeastTwoTests: 0,
+      yamlFilesWithAtLeastTwoTestsPerc: 0,
     },
     all: {
       total: 0,
@@ -186,6 +196,8 @@ async function getTemplatesSummary() {
       yamlFiles: 0,
       yamlFilesPerc: 0,
       unitTests: 0,
+      yamlFilesWithAtLeastTwoTests: 0,
+      yamlFilesWithAtLeastTwoTestsPerc: 0,
     },
   };
 
@@ -199,6 +211,8 @@ async function getTemplatesSummary() {
   summary.reconciliations.yamlFiles = reconciliationsTests.files;
   summary.reconciliations.yamlFilesPerc = percentageRoundTwo(summary.reconciliations.yamlFiles, summary.reconciliations.total);
   summary.reconciliations.unitTests = reconciliationsTests.tests;
+  summary.reconciliations.yamlFilesWithAtLeastTwoTests = reconciliationsTests.filesWithAtLeastTwoTests;
+  summary.reconciliations.yamlFilesWithAtLeastTwoTestsPerc = percentageRoundTwo(summary.reconciliations.yamlFilesWithAtLeastTwoTests, summary.reconciliations.total);
 
   // Shared Parts
   const sharedPartsNonEmpty = await listNonEmptyTemplates("sharedPart");
@@ -224,6 +238,8 @@ async function getTemplatesSummary() {
   summary.accountTemplates.yamlFiles = accountTemplatesTests.files;
   summary.accountTemplates.yamlFilesPerc = percentageRoundTwo(summary.accountTemplates.yamlFiles, summary.accountTemplates.total);
   summary.accountTemplates.unitTests = accountTemplatesTests.tests;
+  summary.accountTemplates.yamlFilesWithAtLeastTwoTests = accountTemplatesTests.filesWithAtLeastTwoTests;
+  summary.accountTemplates.yamlFilesWithAtLeastTwoTestsPerc = percentageRoundTwo(summary.accountTemplates.yamlFilesWithAtLeastTwoTests, summary.accountTemplates.total);
 
   // All
   summary.all.total = summary.reconciliations.total + summary.sharedParts.total + summary.exportFiles.total + summary.accountTemplates.total;
@@ -233,6 +249,8 @@ async function getTemplatesSummary() {
   summary.all.yamlFiles = summary.reconciliations.yamlFiles + summary.accountTemplates.yamlFiles;
   summary.all.yamlFilesPerc = percentageRoundTwo(summary.all.yamlFiles, summary.reconciliations.total + summary.accountTemplates.total);
   summary.all.unitTests = summary.reconciliations.unitTests + summary.accountTemplates.unitTests;
+  summary.all.yamlFilesWithAtLeastTwoTests = summary.reconciliations.yamlFilesWithAtLeastTwoTests + summary.accountTemplates.yamlFilesWithAtLeastTwoTests;
+  summary.all.yamlFilesWithAtLeastTwoTestsPerc = percentageRoundTwo(summary.all.yamlFilesWithAtLeastTwoTests, summary.reconciliations.total + summary.accountTemplates.total);
 
   return summary;
 }
@@ -260,12 +278,18 @@ function displayOverview(sinceDate, today, templateSummary, yamlSummary) {
   consola.log(`Externally Managed: ${templateSummary.reconciliations.externallyManaged} (${templateSummary.reconciliations.externallyManagedPerc}%)`);
   consola.log(`YAML files: ${templateSummary.reconciliations.yamlFiles} (${templateSummary.reconciliations.yamlFilesPerc}%)`);
   consola.log(`Unit Tests: ${templateSummary.reconciliations.unitTests}`);
+  consola.log(
+    `YAML files with at least two unit tests: ${templateSummary.reconciliations.yamlFilesWithAtLeastTwoTests} (${templateSummary.reconciliations.yamlFilesWithAtLeastTwoTestsPerc}%)`
+  );
   consola.log("");
   consola.log(`${chalk.bold("Account Templates:")}`);
   consola.log(`Templates: ${templateSummary.accountTemplates.total}`);
   consola.log(`Externally Managed: ${templateSummary.accountTemplates.externallyManaged} (${templateSummary.accountTemplates.externallyManagedPerc}%)`);
   consola.log(`YAML files: ${templateSummary.accountTemplates.yamlFiles} (${templateSummary.accountTemplates.yamlFilesPerc}%)`);
   consola.log(`Unit Tests: ${templateSummary.accountTemplates.unitTests}`);
+  consola.log(
+    `YAML files with at least two unit tests: ${templateSummary.accountTemplates.yamlFilesWithAtLeastTwoTests} (${templateSummary.accountTemplates.yamlFilesWithAtLeastTwoTestsPerc}%)`
+  );
   consola.log("");
   consola.log(`${chalk.bold("Shared Parts:")}`);
   consola.log(`Templates: ${templateSummary.sharedParts.total}`);
@@ -280,6 +304,7 @@ function displayOverview(sinceDate, today, templateSummary, yamlSummary) {
   consola.log(`Externally Managed: ${templateSummary.all.externallyManaged} (${templateSummary.all.externallyManagedPerc}%)`);
   consola.log(`YAML files: ${templateSummary.all.yamlFiles} (${templateSummary.all.yamlFilesPerc}%)`);
   consola.log(`Unit Tests: ${templateSummary.all.unitTests}`);
+  consola.log(`YAML files with at least two unit tests: ${templateSummary.all.yamlFilesWithAtLeastTwoTests} (${templateSummary.all.yamlFilesWithAtLeastTwoTestsPerc}%)`);
   consola.log("");
   consola.log("------------------------------------");
 }
@@ -315,6 +340,10 @@ function createRow(sinceDate, today, templateSummary, yamlSummary) {
     templateSummary.all.yamlFilesPerc,
     templateSummary.reconciliations.yamlFilesPerc,
     templateSummary.accountTemplates.yamlFilesPerc,
+    templateSummary.reconciliations.yamlFilesWithAtLeastTwoTests,
+    templateSummary.reconciliations.yamlFilesWithAtLeastTwoTestsPerc,
+    templateSummary.accountTemplates.yamlFilesWithAtLeastTwoTests,
+    templateSummary.accountTemplates.yamlFilesWithAtLeastTwoTestsPerc,
   ];
   const row = `\r\n${rowContent.join(";")}`;
   return row;
@@ -351,6 +380,10 @@ function saveOverviewToFile(row) {
     "All - yaml files (%)",
     "Reconciliations - yaml files (%)",
     "Account Templates - yaml files (%)",
+    "Reconciliations - yaml files with at least two tests",
+    "Reconciliations - yaml files with at least two tests (%)",
+    "Account Templates - yaml files with at least two tests",
+    "Account Templates - yaml files with at least two tests (%)",
   ];
   const ROW_HEADER = `${COLUMNS.join(";")}`;
   const CSV_PATH = `./stats/overview.csv`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

So far we consider a yaml file as "valid" if it has at least one test in it. As there may be situations where only one case (an empty state case) is defined, now we also want to visualize and track for metrics, how many liquid test files have at least two unit tests defined.

## Testing Instructions

Steps:

Run `silverfin stats` command in your repository and validate that new count is included


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
