### PR TITLE
feat: Introduce flag --id for update-* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.42.0] (07/08/2025)
+Now it is possible to call update commands using the `--id` option, which allows to update a specific template by its ID.
+For example: `silverfin update-reconciliation --id 12345`
+
 ## [1.41.0] (28/07/2025)
 - Add tests for the accountTemplate class
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,14 +60,15 @@ program
   .description("Update an existing reconciliation template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-h, --handle <handle>", "Specify the reconcilation to be used (mandatory)")
+  .option("-h, --handle <handle>", "Specify the reconcilation to be used")
+  .option("-i, --id <reconciliation-id>", "Specify the firm reconciliation ID to be used")
   .option("-a, --all", "Update all reconciliations")
   .option('-m, --message "<message>"', "Add a message to Silverfin's changelog (optional) | Make sure to always enclose the message in double quotes", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
-      ["handle", "all"],
+      ["handle", "id", "all"],
       options,
       firmIdDefault,
       true // Message required
@@ -75,6 +76,8 @@ program
 
     if (options.handle) {
       toolkit.publishReconciliationByHandle(settings.type, settings.envId, options.handle, options.message);
+    } else if (options.id) {
+      toolkit.publishReconciliationById(settings.type, settings.envId, options.id, options.message);
     } else if (options.all) {
       toolkit.publishAllReconciliations(settings.type, settings.envId, options.message);
     }
@@ -136,14 +139,15 @@ program
   .description("Update an existing export file template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option('-n, --name "<name>"', "Specify the export file to be used (mandatory) | Make sure to always enclose the name in double quotes")
+  .option('-n, --name "<name>"', "Specify the export file to be used | Make sure to always enclose the name in double quotes")
+  .option("-i, --id <export-file-id>", "Specify the export file ID to be used")
   .option("-a, --all", "Update all export files")
   .option('-m, --message "<message>"', "Add a message to Silverfin's changelog (optional) | Make sure to always enclose the message in double quotes", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
-      ["name", "all"],
+      ["name", "id", "all"],
       options,
       firmIdDefault,
       true // Message required
@@ -151,6 +155,8 @@ program
 
     if (options.name) {
       toolkit.publishExportFileByName(settings.type, settings.envId, options.name, options.message);
+    } else if (options.id) {
+      toolkit.publishExportFileById(settings.type, settings.envId, options.id, options.message);
     } else if (options.all) {
       toolkit.publishAllExportFiles(settings.type, settings.envId, options.message);
     }
@@ -211,14 +217,15 @@ program
   .description("Update an existing account template")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option('-n, --name "<name>"', "Specify the account template to be used (mandatory) | Make sure to always enclose the name in double quotes")
+  .option('-n, --name "<name>"', "Specify the account template to be used | Make sure to always enclose the name in double quotes")
+  .option("-i, --id <account-template-id>", "Specify the account template ID to be used")
   .option("-a, --all", "Update all account templates")
   .option('-m, --message "<message>"', "Add a message to Silverfin's changelog (optional) | Make sure to always enclose the message in double quotes", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
-      ["name", "all"],
+      ["name", "id", "all"],
       options,
       firmIdDefault,
       true // Message required
@@ -226,6 +233,8 @@ program
 
     if (options.name) {
       toolkit.publishAccountTemplateByName(settings.type, settings.envId, options.name, options.message);
+    } else if (options.id) {
+      toolkit.publishAccountTemplateById(settings.type, settings.envId, options.id, options.message);
     } else if (options.all) {
       toolkit.publishAllAccountTemplates(settings.type, settings.envId, options.message);
     }
@@ -287,14 +296,15 @@ program
   .description("Update an existing shared part")
   .option("-f, --firm <firm-id>", "Specify the firm to be used", firmIdDefault)
   .option("-p, --partner <partner-id>", "Specify the partner to be used")
-  .option("-s, --shared-part <name>", "Specify the shared part to be used (mandatory)")
+  .option("-s, --shared-part <name>", "Specify the shared part to be used")
+  .option("-i, --id <shared-part-id>", "Specify the shared part ID to be used")
   .option("-a, --all", "Update all shared parts")
   .option('-m, --message "<message>"', "Add a message to Silverfin's changelog (optional) | Make sure to always enclose the message in double quotes", undefined)
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
     cliUtils.checkPartnerSupport(options);
     const settings = runCommandChecks(
-      ["sharedPart", "all"],
+      ["sharedPart", "id", "all"],
       options,
       firmIdDefault,
       true // Message required
@@ -302,6 +312,8 @@ program
 
     if (options.sharedPart) {
       toolkit.publishSharedPartByName(settings.type, settings.envId, options.sharedPart, options.message);
+    } else if (options.id) {
+      toolkit.publishSharedPartById(settings.type, settings.envId, options.id, options.message);
     } else if (options.all) {
       toolkit.publishAllSharedParts(settings.type, settings.envId, options.message);
     }

--- a/index.js
+++ b/index.js
@@ -162,6 +162,42 @@ async function publishReconciliationByHandle(type, envId, handle, message = "Upd
   }
 }
 
+async function publishReconciliationById(type, envId, reconciliationId, message = "Updated with the Silverfin CLI") {
+  try {
+    const matchingHandle = fsUtils.findHandleByID(type, envId, "reconciliationText", reconciliationId);
+
+    if (!matchingHandle) {
+      consola.error(`No template found with reconciliation ID: ${reconciliationId} in ${type} ${envId}`);
+      return false;
+    }
+
+    consola.debug(`Updating reconciliation with ID ${reconciliationId} (handle: ${matchingHandle})...`);
+
+    const template = await ReconciliationText.read(matchingHandle);
+    if (!template) return;
+
+    // Add API-only required fields
+    template.version_comment = message;
+
+    if (type == "partner") {
+      template.version_significant_change = false;
+      delete template.is_active;
+    }
+
+    const response = await SF.updateReconciliationText(type, envId, reconciliationId, template);
+
+    if (response && response.data && response.data.handle) {
+      consola.success(`Reconciliation updated: ${response.data.handle} (ID: ${reconciliationId})`);
+      return true;
+    } else {
+      consola.error(`Reconciliation update failed for ID: ${reconciliationId} in ${type} ${envId}`);
+      return false;
+    }
+  } catch (error) {
+    errorUtils.errorHandler(error);
+  }
+}
+
 async function publishAllReconciliations(type, envId, message = "updated through the Silverfin CLI") {
   const templates = fsUtils.getAllTemplatesOfAType("reconciliationText");
   for (const handle of templates) {
@@ -319,6 +355,41 @@ async function publishExportFileByName(type, envId, name, message = "updated thr
       return true;
     } else {
       consola.error(`Export file update failed: ${name}`);
+      return false;
+    }
+  } catch (error) {
+    errorUtils.errorHandler(error);
+  }
+}
+
+async function publishExportFileById(type, envId, exportFileId, message = "Updated with the Silverfin CLI") {
+  try {
+    const matchingHandle = fsUtils.findHandleByID(type, envId, "exportFile", exportFileId);
+
+    if (!matchingHandle) {
+      consola.error(`No template found with export file ID: ${exportFileId} in ${type} ${envId}`);
+      return false;
+    }
+
+    consola.debug(`Updating export file with ID ${exportFileId} (handle: ${matchingHandle})...`);
+
+    const template = await ExportFile.read(matchingHandle);
+    if (!template) return;
+
+    // Add API-only required fields
+    template.version_comment = message;
+
+    if (type == "partner") {
+      template.version_significant_change = false;
+    }
+
+    const response = await SF.updateExportFile(type, envId, exportFileId, template);
+
+    if (response && response.data && response.data.name_nl) {
+      consola.success(`Export file updated: ${response.data.name_nl} (ID: ${exportFileId})`);
+      return true;
+    } else {
+      consola.error(`Export file update failed for ID: ${exportFileId} in ${type} ${envId}`);
       return false;
     }
   } catch (error) {
@@ -488,6 +559,47 @@ async function publishAccountTemplateByName(type, envId, name, message = "update
   }
 }
 
+async function publishAccountTemplateById(type, envId, accountTemplateId, message = "Updated with the Silverfin CLI") {
+  try {
+    const matchingHandle = fsUtils.findHandleByID(type, envId, "accountTemplate", accountTemplateId);
+
+    if (!matchingHandle) {
+      consola.error(`No template found with account template ID: ${accountTemplateId} in ${type} ${envId}`);
+      return false;
+    }
+
+    consola.debug(`Updating account template with ID ${accountTemplateId} (handle: ${matchingHandle})...`);
+
+    const template = await AccountTemplate.read(matchingHandle);
+    if (!template) return;
+
+    // Add API-only required fields
+    template.version_comment = message;
+
+    // Filter out the mapping_list_ranges that do not have this "type" and "envId"
+    template.mapping_list_ranges =
+      template.mapping_list_ranges?.filter((range) => {
+        return range.type === type && range.env_id === envId;
+      }) || [];
+
+    if (type == "partner") {
+      template.version_significant_change = false;
+    }
+
+    const response = await SF.updateAccountTemplate(type, envId, accountTemplateId, template);
+
+    if (response && response.data && response.data.name_nl) {
+      consola.success(`Account template updated: ${response.data.name_nl} (ID: ${accountTemplateId})`);
+      return true;
+    } else {
+      consola.error(`Account template update failed for ID: ${accountTemplateId} in ${type} ${envId}`);
+      return false;
+    }
+  } catch (error) {
+    errorUtils.errorHandler(error);
+  }
+}
+
 async function publishAllAccountTemplates(type, envId, message = "updated through the Silverfin CLI") {
   const templates = fsUtils.getAllTemplatesOfAType("accountTemplate");
   for (const name of templates) {
@@ -645,6 +757,41 @@ async function publishSharedPartByName(type, envId, name, message = "Updated thr
       return true;
     } else {
       consola.error(`Shared part update failed: ${name}`);
+      return false;
+    }
+  } catch (error) {
+    errorUtils.errorHandler(error);
+  }
+}
+
+async function publishSharedPartById(type, envId, sharedPartId, message = "Updated with the Silverfin CLI") {
+  try {
+    const matchingHandle = fsUtils.findHandleByID(type, envId, "sharedPart", sharedPartId);
+
+    if (!matchingHandle) {
+      consola.error(`No template found with shared part ID: ${sharedPartId} in ${type} ${envId}`);
+      return false;
+    }
+
+    consola.debug(`Updating shared part with ID ${sharedPartId} (handle: ${matchingHandle})...`);
+
+    const template = await SharedPart.read(matchingHandle);
+    if (!template) return;
+
+    // Add API-only required fields
+    template.version_comment = message;
+
+    if (type == "partner") {
+      template.version_significant_change = false;
+    }
+
+    const response = await SF.updateSharedPart(type, envId, sharedPartId, template);
+
+    if (response && response.data && response.data.name) {
+      consola.success(`Shared part updated: ${response.data.name} (ID: ${sharedPartId})`);
+      return true;
+    } else {
+      consola.error(`Shared part update failed for ID: ${sharedPartId} in ${type} ${envId}`);
       return false;
     }
   } catch (error) {
@@ -1025,6 +1172,7 @@ module.exports = {
   fetchAllReconciliations,
   fetchExistingReconciliations,
   publishReconciliationByHandle,
+  publishReconciliationById,
   publishAllReconciliations,
   newReconciliation,
   newAllReconciliations,
@@ -1033,6 +1181,7 @@ module.exports = {
   fetchAllExportFiles,
   fetchExistingExportFiles,
   publishExportFileByName,
+  publishExportFileById,
   publishAllExportFiles,
   newExportFile,
   newAllExportFiles,
@@ -1040,6 +1189,7 @@ module.exports = {
   fetchAccountTemplateById,
   fetchAllAccountTemplates,
   publishAccountTemplateByName,
+  publishAccountTemplateById,
   publishAllAccountTemplates,
   fetchExistingAccountTemplates,
   newAccountTemplate,
@@ -1049,6 +1199,7 @@ module.exports = {
   fetchAllSharedParts,
   fetchExistingSharedParts,
   publishSharedPartByName,
+  publishSharedPartById,
   publishAllSharedParts,
   newSharedPart,
   newAllSharedParts,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/toolkit.test.js
+++ b/tests/lib/toolkit.test.js
@@ -1,0 +1,466 @@
+const toolkit = require("../../index");
+const fsUtils = require("../../lib/utils/fsUtils");
+const SF = require("../../lib/api/sfApi");
+const { ReconciliationText } = require("../../lib/templates/reconciliationText");
+const { ExportFile } = require("../../lib/templates/exportFile");
+const { AccountTemplate } = require("../../lib/templates/accountTemplate");
+const { SharedPart } = require("../../lib/templates/sharedPart");
+const errorUtils = require("../../lib/utils/errorUtils");
+const consola = require("consola");
+
+jest.mock("../../lib/utils/apiUtils", () => ({
+  checkRequiredEnvVariables: jest.fn(() => true),
+}));
+
+jest.mock("../../lib/utils/fsUtils");
+jest.mock("../../lib/api/sfApi");
+jest.mock("../../lib/templates/reconciliationText");
+jest.mock("../../lib/templates/exportFile");
+jest.mock("../../lib/templates/accountTemplate");
+jest.mock("../../lib/templates/sharedPart");
+jest.mock("../../lib/utils/errorUtils");
+
+jest.mock("consola");
+consola.debug = jest.fn();
+consola.success = jest.fn();
+consola.error = jest.fn();
+
+describe("Toolkit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("publishReconciliationById", () => {
+    const mockType = "firm";
+    const mockEnvId = "100";
+    const mockReconciliationId = "12345";
+    const mockMessage = "Test update message";
+    const mockHandle = "test_handle";
+    const mockTemplate = {
+      handle: mockHandle,
+      text: "test liquid content",
+      text_parts: [],
+    };
+
+    it("should successfully update reconciliation by ID when matching template found", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ReconciliationText.read.mockResolvedValue(mockTemplate);
+      const mockResponse = {
+        data: {
+          handle: mockHandle,
+        },
+      };
+      SF.updateReconciliationText.mockResolvedValue(mockResponse);
+
+      const result = await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(fsUtils.findHandleByID).toHaveBeenCalledWith(mockType, mockEnvId, "reconciliationText", mockReconciliationId);
+      expect(ReconciliationText.read).toHaveBeenCalledWith(mockHandle);
+      expect(SF.updateReconciliationText).toHaveBeenCalledWith(mockType, mockEnvId, mockReconciliationId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no template found with matching ID", async () => {
+      fsUtils.findHandleByID.mockReturnValue(undefined);
+
+      const result = await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(require("consola").error).toHaveBeenCalledWith(`No template found with reconciliation ID: ${mockReconciliationId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle partner type correctly", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ReconciliationText.read.mockResolvedValue(mockTemplate);
+
+      const mockResponse = {
+        data: {
+          handle: mockHandle,
+        },
+      };
+      SF.updateReconciliationText.mockResolvedValue(mockResponse);
+
+      await toolkit.publishReconciliationById("partner", mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(SF.updateReconciliationText).toHaveBeenCalledWith("partner", mockEnvId, mockReconciliationId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+        version_significant_change: false,
+      });
+    });
+
+    it("should return false when template reading fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ReconciliationText.read.mockResolvedValue(null);
+
+      const result = await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return false when API call fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ReconciliationText.read.mockResolvedValue(mockTemplate);
+
+      // Mock API failure
+      SF.updateReconciliationText.mockResolvedValue(null);
+
+      const result = await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(require("consola").error).toHaveBeenCalledWith(`Reconciliation update failed for ID: ${mockReconciliationId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle exceptions gracefully", async () => {
+      const mockError = new Error("Test error");
+      fsUtils.findHandleByID.mockImplementation(() => {
+        throw mockError;
+      });
+
+      await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId, mockMessage);
+
+      expect(errorUtils.errorHandler).toHaveBeenCalledWith(mockError);
+    });
+
+    it("should use default message when none provided", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ReconciliationText.read.mockResolvedValue(mockTemplate);
+
+      const mockResponse = {
+        data: {
+          handle: mockHandle,
+        },
+      };
+      SF.updateReconciliationText.mockResolvedValue(mockResponse);
+
+      await toolkit.publishReconciliationById(mockType, mockEnvId, mockReconciliationId);
+
+      expect(SF.updateReconciliationText).toHaveBeenCalledWith(mockType, mockEnvId, mockReconciliationId, {
+        ...mockTemplate,
+        version_comment: "Updated with the Silverfin CLI",
+      });
+    });
+  });
+
+  describe("publishExportFileById", () => {
+    const mockType = "firm";
+    const mockEnvId = "100";
+    const mockExportFileId = "12345";
+    const mockMessage = "Test update message";
+    const mockHandle = "test_handle";
+    const mockTemplate = {
+      handle: mockHandle,
+      name_nl: "Test Export File",
+      text: "test liquid content",
+    };
+
+    it("should successfully update export file by ID when matching template found", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ExportFile.read.mockResolvedValue(mockTemplate);
+      const mockResponse = {
+        data: {
+          name_nl: "Test Export File",
+        },
+      };
+      SF.updateExportFile.mockResolvedValue(mockResponse);
+
+      const result = await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId, mockMessage);
+
+      expect(fsUtils.findHandleByID).toHaveBeenCalledWith(mockType, mockEnvId, "exportFile", mockExportFileId);
+      expect(ExportFile.read).toHaveBeenCalledWith(mockHandle);
+      expect(SF.updateExportFile).toHaveBeenCalledWith(mockType, mockEnvId, mockExportFileId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no template found with matching ID", async () => {
+      fsUtils.findHandleByID.mockReturnValue(undefined);
+
+      const result = await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`No template found with export file ID: ${mockExportFileId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when template reading fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ExportFile.read.mockResolvedValue(null);
+
+      const result = await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId, mockMessage);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return false when API call fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ExportFile.read.mockResolvedValue(mockTemplate);
+
+      // Mock API failure
+      SF.updateExportFile.mockResolvedValue(null);
+
+      const result = await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`Export file update failed for ID: ${mockExportFileId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle exceptions gracefully", async () => {
+      const mockError = new Error("Test error");
+      fsUtils.findHandleByID.mockImplementation(() => {
+        throw mockError;
+      });
+
+      await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId, mockMessage);
+
+      expect(errorUtils.errorHandler).toHaveBeenCalledWith(mockError);
+    });
+
+    it("should use default message when none provided", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      ExportFile.read.mockResolvedValue(mockTemplate);
+
+      const mockResponse = {
+        data: {
+          name_nl: "Test Export File",
+        },
+      };
+      SF.updateExportFile.mockResolvedValue(mockResponse);
+
+      await toolkit.publishExportFileById(mockType, mockEnvId, mockExportFileId);
+
+      expect(SF.updateExportFile).toHaveBeenCalledWith(mockType, mockEnvId, mockExportFileId, {
+        ...mockTemplate,
+        version_comment: "Updated with the Silverfin CLI",
+      });
+    });
+  });
+
+  describe("publishAccountTemplateById", () => {
+    const mockType = "firm";
+    const mockEnvId = "100";
+    const mockAccountTemplateId = "12345";
+    const mockMessage = "Test update message";
+    const mockHandle = "test_handle";
+    const mockTemplate = {
+      handle: mockHandle,
+      name_nl: "Test Account Template",
+      text: "test liquid content",
+      mapping_list_ranges: [
+        { type: "firm", env_id: "100", range: "1-10" },
+        { type: "partner", env_id: "200", range: "11-20" },
+      ],
+    };
+
+    it("should successfully update account template by ID when matching template found", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      AccountTemplate.read.mockResolvedValue(mockTemplate);
+      const mockResponse = {
+        data: {
+          name_nl: "Test Account Template",
+        },
+      };
+      SF.updateAccountTemplate.mockResolvedValue(mockResponse);
+
+      const result = await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(fsUtils.findHandleByID).toHaveBeenCalledWith(mockType, mockEnvId, "accountTemplate", mockAccountTemplateId);
+      expect(AccountTemplate.read).toHaveBeenCalledWith(mockHandle);
+      expect(SF.updateAccountTemplate).toHaveBeenCalledWith(mockType, mockEnvId, mockAccountTemplateId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+        mapping_list_ranges: [{ type: "firm", env_id: "100", range: "1-10" }],
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no template found with matching ID", async () => {
+      fsUtils.findHandleByID.mockReturnValue(undefined);
+
+      const result = await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`No template found with account template ID: ${mockAccountTemplateId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle partner type correctly", async () => {
+      const partnerEnvId = "200";
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      AccountTemplate.read.mockResolvedValue({
+        ...mockTemplate,
+        mapping_list_ranges: [
+          { type: "firm", env_id: "100", range: "1-10" },
+          { type: "partner", env_id: "200", range: "11-20" },
+        ],
+      });
+
+      const mockResponse = {
+        data: {
+          name_nl: "Test Account Template",
+        },
+      };
+      SF.updateAccountTemplate.mockResolvedValue(mockResponse);
+
+      await toolkit.publishAccountTemplateById("partner", partnerEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(SF.updateAccountTemplate).toHaveBeenCalledWith("partner", partnerEnvId, mockAccountTemplateId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+        version_significant_change: false,
+        mapping_list_ranges: [{ type: "partner", env_id: partnerEnvId, range: "11-20" }],
+      });
+    });
+
+    it("should return false when template reading fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      AccountTemplate.read.mockResolvedValue(null);
+
+      const result = await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return false when API call fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      AccountTemplate.read.mockResolvedValue(mockTemplate);
+
+      // Mock API failure
+      SF.updateAccountTemplate.mockResolvedValue(null);
+
+      const result = await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`Account template update failed for ID: ${mockAccountTemplateId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle exceptions gracefully", async () => {
+      const mockError = new Error("Test error");
+      fsUtils.findHandleByID.mockImplementation(() => {
+        throw mockError;
+      });
+
+      await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId, mockMessage);
+
+      expect(errorUtils.errorHandler).toHaveBeenCalledWith(mockError);
+    });
+
+    it("should use default message when none provided", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      AccountTemplate.read.mockResolvedValue(mockTemplate);
+
+      const mockResponse = {
+        data: {
+          name_nl: "Test Account Template",
+        },
+      };
+      SF.updateAccountTemplate.mockResolvedValue(mockResponse);
+
+      await toolkit.publishAccountTemplateById(mockType, mockEnvId, mockAccountTemplateId);
+
+      expect(SF.updateAccountTemplate).toHaveBeenCalledWith(mockType, mockEnvId, mockAccountTemplateId, {
+        ...mockTemplate,
+        version_comment: "Updated with the Silverfin CLI",
+        mapping_list_ranges: [{ type: mockType, env_id: mockEnvId, range: "1-10" }],
+      });
+    });
+  });
+
+  describe("publishSharedPartById", () => {
+    const mockType = "firm";
+    const mockEnvId = "100";
+    const mockSharedPartId = "12345";
+    const mockMessage = "Test update message";
+    const mockHandle = "test_handle";
+    const mockTemplate = {
+      handle: mockHandle,
+      name: "Test Shared Part",
+      text: "test liquid content",
+    };
+
+    it("should successfully update shared part by ID when matching template found", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      SharedPart.read.mockResolvedValue(mockTemplate);
+      const mockResponse = {
+        data: {
+          name: "Test Shared Part",
+        },
+      };
+      SF.updateSharedPart.mockResolvedValue(mockResponse);
+
+      const result = await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId, mockMessage);
+
+      expect(fsUtils.findHandleByID).toHaveBeenCalledWith(mockType, mockEnvId, "sharedPart", mockSharedPartId);
+      expect(SharedPart.read).toHaveBeenCalledWith(mockHandle);
+      expect(SF.updateSharedPart).toHaveBeenCalledWith(mockType, mockEnvId, mockSharedPartId, {
+        ...mockTemplate,
+        version_comment: mockMessage,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no template found with matching ID", async () => {
+      fsUtils.findHandleByID.mockReturnValue(undefined);
+
+      const result = await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`No template found with shared part ID: ${mockSharedPartId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when template reading fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      SharedPart.read.mockResolvedValue(null);
+
+      const result = await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId, mockMessage);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return false when API call fails", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      SharedPart.read.mockResolvedValue(mockTemplate);
+
+      // Mock API failure
+      SF.updateSharedPart.mockResolvedValue(null);
+
+      const result = await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId, mockMessage);
+
+      expect(consola.error).toHaveBeenCalledWith(`Shared part update failed for ID: ${mockSharedPartId} in ${mockType} ${mockEnvId}`);
+      expect(result).toBe(false);
+    });
+
+    it("should handle exceptions gracefully", async () => {
+      const mockError = new Error("Test error");
+      fsUtils.findHandleByID.mockImplementation(() => {
+        throw mockError;
+      });
+
+      await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId, mockMessage);
+
+      expect(errorUtils.errorHandler).toHaveBeenCalledWith(mockError);
+    });
+
+    it("should use default message when none provided", async () => {
+      fsUtils.findHandleByID.mockReturnValue(mockHandle);
+      SharedPart.read.mockResolvedValue(mockTemplate);
+
+      const mockResponse = {
+        data: {
+          name: "Test Shared Part",
+        },
+      };
+      SF.updateSharedPart.mockResolvedValue(mockResponse);
+
+      await toolkit.publishSharedPartById(mockType, mockEnvId, mockSharedPartId);
+
+      expect(SF.updateSharedPart).toHaveBeenCalledWith(mockType, mockEnvId, mockSharedPartId, {
+        ...mockTemplate,
+        version_comment: "Updated with the Silverfin CLI",
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #169 

## Description

Introduce the `--id` flag for update commands.

## Testing Instructions

Steps:

1. Run the different commands using the new --id flag and validate that templates are updated correctly.
2. Check introduced tests


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
