### PR TITLE
Create test based on local liquid code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.43.0] (11/08/2025)
+- It is now possible to use the `create-test` command on files that are relying directly on partners code.
+- period.custom data is now picked up when using the `create-test` command
+
 ## [1.42.0] (07/08/2025)
 Now it is possible to call update commands using the `--id` option, which allows to update a specific template by its ID.
 For example: `silverfin update-reconciliation --id 12345`

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -493,7 +493,6 @@ async function getCompanyDrop(firmId, companyId) {
     return response;
   }
 }
-
 async function getCompanyCustom(firmId, companyId) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -506,6 +506,18 @@ async function getCompanyCustom(firmId, companyId) {
   }
 }
 
+async function getPeriodCustom(firmId, companyId, periodId) {
+  const instance = AxiosFactory.createInstance("firm", firmId);
+  try {
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/custom`);
+    apiUtils.responseSuccessHandler(response);
+    return response;
+  } catch (error) {
+    const response = await apiUtils.responseErrorHandler(error);
+    return response;
+  }
+}
+
 async function getWorkflows(firmId, companyId, periodId) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
@@ -639,6 +651,7 @@ module.exports = {
   findPeriod,
   getCompanyDrop,
   getCompanyCustom,
+  getPeriodCustom,
   getWorkflows,
   getWorkflowInformation,
   findReconciliationInWorkflow,

--- a/lib/liquidTestGenerator.js
+++ b/lib/liquidTestGenerator.js
@@ -2,6 +2,8 @@ const SF = require("./api/sfApi");
 const { firmCredentials } = require("../lib/api/firmCredentials");
 const Utils = require("./utils/liquidTestUtils");
 const { consola } = require("consola");
+const { ReconciliationText } = require("./templates/reconciliationText");
+const { SharedPart } = require("./templates/sharedPart");
 
 // MainProcess
 async function testGenerator(url, testName, reconciledStatus = true) {
@@ -62,41 +64,43 @@ async function testGenerator(url, testName, reconciledStatus = true) {
   liquidTestObject[testName].expectation.results = responseResults.data;
 
   // Get the code of the template
-  const reconciliationCode = await SF.findReconciliationTextByHandle("firm", parameters.firmId, reconciliationHandle);
-  if (!reconciliationCode) {
+  const reconciliationTextCode = await ReconciliationText.read(reconciliationHandle);
+  if (!reconciliationTextCode) {
     consola.warn(`Reconciliation "${reconciliationHandle}" wasn't found`);
     process.exit();
   }
 
   // Search for results from other reconciliations used in the liquid code (main and text_parts)
   let resultsObj;
-  resultsObj = Utils.searchForResultsFromDependenciesInLiquid(reconciliationCode, reconciliationHandle);
+  resultsObj = Utils.searchForResultsFromDependenciesInLiquid(reconciliationTextCode, reconciliationHandle);
 
   // Search for custom drops from other reconcilations used in the liquid code (main and text_parts)
   let customsObj;
-  customsObj = Utils.searchForCustomsFromDependenciesInLiquid(reconciliationCode, reconciliationHandle);
+  customsObj = Utils.searchForCustomsFromDependenciesInLiquid(reconciliationTextCode, reconciliationHandle);
 
   // Search for shared parts in the liquid code (main and text_parts)
-  const sharedPartsUsed = Utils.lookForSharedPartsInLiquid(reconciliationCode, reconciliationHandle);
+  const sharedPartsUsed = Utils.lookForSharedPartsInLiquid(reconciliationTextCode, reconciliationHandle);
   if (sharedPartsUsed && sharedPartsUsed.length != 0) {
     for (const sharedPartName of sharedPartsUsed) {
-      // Look for shared part id
-      const sharedPartResponse = await SF.findSharedPartByName("firm", parameters.firmId, sharedPartName);
-      const sharedPartId = sharedPartResponse.id;
-      // Get shared part details
-      const sharedPartDetails = await SF.readSharedPartById("firm", parameters.firmId, sharedPartId);
+      const sharedPartCode = await SharedPart.read(sharedPartName);
+      if (!sharedPartCode) {
+        consola.warn(`Shared part "${sharedPartName}" wasn't found`);
+        return;
+      }
+
       // Look for nested shared parts (in that case, add them to this same loop)
-      const nestedSharedParts = Utils.lookForSharedPartsInLiquid(sharedPartDetails.data);
+      const nestedSharedParts = Utils.lookForSharedPartsInLiquid(sharedPartCode);
       for (const nested of nestedSharedParts) {
         if (!sharedPartsUsed.includes(nested)) {
           sharedPartsUsed.push(nested);
         }
       }
+
       // Search for results from other reconciliations in shared part (we append to existing collection)
-      resultsObj = Utils.searchForResultsFromDependenciesInLiquid(sharedPartDetails.data, sharedPartDetails.data.name, resultsObj);
+      resultsObj = Utils.searchForResultsFromDependenciesInLiquid(sharedPartCode, sharedPartCode.name, resultsObj);
 
       // Search for custom drops from other reconcilations in shared parts (we append to existing collection)
-      customsObj = Utils.searchForCustomsFromDependenciesInLiquid(sharedPartDetails.data, sharedPartDetails.data.name, customsObj);
+      customsObj = Utils.searchForCustomsFromDependenciesInLiquid(sharedPartCode, sharedPartCode.name, customsObj);
     }
   }
 
@@ -163,7 +167,7 @@ async function testGenerator(url, testName, reconciledStatus = true) {
   }
 
   // Get company drop used in the liquid code (main and text_parts)
-  const companyObj = Utils.getCompanyDependencies(reconciliationCode, reconciliationHandle);
+  const companyObj = Utils.getCompanyDependencies(reconciliationTextCode, reconciliationHandle);
 
   if (companyObj.standardDropElements.length !== 0 || companyObj.customDropElements.length !== 0) {
     liquidTestObject[testName].data.company = {};

--- a/lib/liquidTestGenerator.js
+++ b/lib/liquidTestGenerator.js
@@ -51,6 +51,19 @@ async function testGenerator(url, testName, reconciledStatus = true) {
     }
   }
 
+  const responsePeriodCustom = await SF.getPeriodCustom(parameters.firmId, parameters.companyId, parameters.ledgerId);
+  const periodCustomData = responsePeriodCustom.data;
+  // Add period custom data to the test object
+  if (periodCustomData && Object.keys(periodCustomData).length > 0) {
+    const periodTextProperties = {};
+    for (const item of periodCustomData) {
+      if (item.namespace && item.key) {
+        periodTextProperties[`${item.namespace}.${item.key}`] = item.value;
+      }
+    }
+    liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].custom = periodTextProperties;
+  }
+
   // Get all the text properties (Customs from current template)
   const responseCustom = await SF.getReconciliationCustom("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, parameters.reconciliationId);
   const currentReconCustom = Utils.processCustom(responseCustom.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.42.0",
+      "version": "1.43.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1223,13 +1223,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1270,13 +1270,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1538,7 +1538,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -1601,9 +1601,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+      "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
       "dev": true,
       "funding": [
         {
@@ -1621,8 +1621,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
+        "caniuse-lite": "^1.0.30001733",
+        "electron-to-chromium": "^1.5.199",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001734",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
       "dev": true,
       "funding": [
         {
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.191",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
-      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
+      "version": "1.5.199",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.199.tgz",
+      "integrity": "sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2508,9 +2508,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -4871,9 +4871,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },
@@ -5026,9 +5026,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/liquidTestGenerator.test.js
+++ b/tests/lib/liquidTestGenerator.test.js
@@ -1,0 +1,353 @@
+// Unused imports removed - not needed for this test file
+const { testGenerator } = require("../../lib/liquidTestGenerator");
+const SF = require("../../lib/api/sfApi");
+const { firmCredentials } = require("../../lib/api/firmCredentials");
+const Utils = require("../../lib/utils/liquidTestUtils");
+const { ReconciliationText } = require("../../lib/templates/reconciliationText");
+const { SharedPart } = require("../../lib/templates/sharedPart");
+const { consola } = require("consola");
+
+// Mock all dependencies
+jest.mock("../../lib/api/sfApi");
+jest.mock("../../lib/api/firmCredentials");
+jest.mock("../../lib/utils/liquidTestUtils");
+jest.mock("../../lib/templates/reconciliationText");
+jest.mock("../../lib/templates/sharedPart");
+jest.mock("consola");
+
+describe("liquidTestGenerator", () => {
+  let mockExitSpy;
+  const mockUrl = "https://live.getsilverfin.com/f/123/456/ledgers/789/workflows/101/reconciliation_texts/202";
+  const mockTestName = "unit_1_test_1";
+  const mockParameters = {
+    firmId: "123",
+    companyId: "456",
+    ledgerId: "789",
+    workflowId: "101",
+    reconciliationId: "202",
+  };
+  const mockReconciliationHandle = "test_handle";
+  const mockPeriodData = {
+    fiscal_year: { end_date: "2024-12-31" },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock process.exit
+    mockExitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Process.exit called with code ${code}`);
+    });
+
+    // Mock Utils functions
+    Utils.createBaseLiquidTest.mockReturnValue({
+      [mockTestName]: {
+        context: { period: "2024-12-31" },
+        data: {
+          periods: {
+            replace_period_name: {
+              reconciliations: {},
+            },
+          },
+        },
+        expectation: {
+          reconciled: true,
+          results: {},
+        },
+      },
+    });
+
+    Utils.extractURL.mockReturnValue(mockParameters);
+    Utils.searchForResultsFromDependenciesInLiquid.mockReturnValue({});
+    Utils.searchForCustomsFromDependenciesInLiquid.mockReturnValue({});
+    Utils.lookForSharedPartsInLiquid.mockReturnValue([]);
+    Utils.getCompanyDependencies.mockReturnValue({
+      standardDropElements: [],
+      customDropElements: [],
+    });
+    Utils.lookForAccountsIDs.mockReturnValue([]);
+    Utils.exportYAML.mockImplementation(() => {});
+    Utils.processCustom.mockReturnValue({
+      "test_namespace.test_key": "test_value",
+    });
+
+    // Mock firmCredentials
+    firmCredentials.data = { 123: { accessToken: "mock_token" } };
+
+    // Mock SF API calls
+    SF.readReconciliationTextDetails = jest.fn().mockResolvedValue({
+      data: { handle: mockReconciliationHandle },
+    });
+    SF.findReconciliationInWorkflow = jest.fn().mockReturnValue({ starred: true });
+    SF.getPeriods = jest.fn().mockResolvedValue({
+      data: [mockPeriodData],
+    });
+    SF.findPeriod = jest.fn().mockReturnValue(mockPeriodData);
+    SF.getPeriodCustom = jest.fn().mockResolvedValue({
+      data: [
+        {
+          namespace: "pit_integration",
+          key: "code_1002",
+          value: "yes",
+          owner: { id: 100660006, type: "Ledger" },
+          documents: [],
+          updated_by_id: null,
+        },
+      ],
+    });
+    SF.getReconciliationCustom = jest.fn().mockResolvedValue({
+      data: [
+        {
+          namespace: "test_namespace",
+          key: "test_key",
+          value: "test_value",
+        },
+      ],
+    });
+    SF.getReconciliationResults = jest.fn().mockResolvedValue({
+      data: { result1: "value1", result2: "value2" },
+    });
+    SF.getCompanyDrop = jest.fn().mockResolvedValue({
+      data: { company_name: "Test Company" },
+    });
+    SF.getCompanyCustom = jest.fn().mockResolvedValue({
+      data: [],
+    });
+
+    // Mock template reading
+    ReconciliationText.read.mockResolvedValue({
+      handle: mockReconciliationHandle,
+      text: "Main liquid content",
+      text_parts: [{ name: "part1", content: "Part 1 content" }],
+    });
+
+    SharedPart.read.mockResolvedValue({
+      name: "shared_part_name",
+      text: "Shared part content",
+      text_parts: [],
+    });
+  });
+
+  afterEach(() => {
+    mockExitSpy.mockRestore();
+  });
+
+  describe("testGenerator", () => {
+    describe("template reading", () => {
+      it("should handle missing reconciliation template gracefully", async () => {
+        ReconciliationText.read.mockResolvedValue(false);
+
+        await expect(testGenerator(mockUrl, mockTestName)).rejects.toThrow("Process.exit called with code undefined");
+        expect(consola.warn).toHaveBeenCalledWith(`Reconciliation "${mockReconciliationHandle}" wasn't found`);
+      });
+
+      it("should handle missing shared part gracefully", async () => {
+        Utils.lookForSharedPartsInLiquid.mockReturnValue(["missing_shared_part"]);
+        SharedPart.read.mockResolvedValue(false);
+
+        await testGenerator(mockUrl, mockTestName);
+
+        expect(consola.warn).toHaveBeenCalledWith(`Shared part "missing_shared_part" wasn't found`);
+        // Should not exit the process, just return from function
+        expect(mockExitSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("period custom data processing", () => {
+      it("should process period custom data correctly", async () => {
+        await testGenerator(mockUrl, mockTestName);
+
+        // Verify the custom data is processed correctly
+        expect(Utils.exportYAML).toHaveBeenCalledWith(
+          mockReconciliationHandle,
+          expect.objectContaining({
+            [mockTestName]: expect.objectContaining({
+              data: expect.objectContaining({
+                periods: expect.objectContaining({
+                  "2024-12-31": expect.objectContaining({
+                    custom: {
+                      "pit_integration.code_1002": "yes",
+                    },
+                  }),
+                }),
+              }),
+            }),
+          })
+        );
+      });
+
+      it("should handle empty period custom data", async () => {
+        SF.getPeriodCustom = jest.fn().mockResolvedValue({ data: [] });
+
+        await testGenerator(mockUrl, mockTestName);
+
+        // Should not add custom data if empty
+        expect(Utils.exportYAML).toHaveBeenCalledWith(
+          mockReconciliationHandle,
+          expect.objectContaining({
+            [mockTestName]: expect.objectContaining({
+              data: expect.objectContaining({
+                periods: expect.objectContaining({
+                  "2024-12-31": expect.not.objectContaining({
+                    custom: expect.anything(),
+                  }),
+                }),
+              }),
+            }),
+          })
+        );
+      });
+
+      it("should handle period custom data with missing namespace or key", async () => {
+        SF.getPeriodCustom = jest.fn().mockResolvedValue({
+          data: [
+            { namespace: "test", key: "value", value: "should_be_included" },
+            { namespace: "", key: "value", value: "should_be_excluded" },
+            { namespace: "test", key: "", value: "should_be_excluded" },
+            { value: "should_be_excluded" },
+          ],
+        });
+
+        await testGenerator(mockUrl, mockTestName);
+
+        // Only the first item should be included
+        expect(Utils.exportYAML).toHaveBeenCalledWith(
+          mockReconciliationHandle,
+          expect.objectContaining({
+            [mockTestName]: expect.objectContaining({
+              data: expect.objectContaining({
+                periods: expect.objectContaining({
+                  "2024-12-31": expect.objectContaining({
+                    custom: {
+                      "test.value": "should_be_included",
+                    },
+                  }),
+                }),
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    describe("error handling improvements", () => {
+      it("should exit with error code 1 for authorization failures", async () => {
+        firmCredentials.data = {};
+
+        await expect(testGenerator(mockUrl, mockTestName)).rejects.toThrow("Process.exit called with code 1");
+        expect(consola.error).toHaveBeenCalledWith(`You have no authorization to access firm id ${mockParameters.firmId}`);
+      });
+
+      it("should warn and exit for missing reconciliation template", async () => {
+        ReconciliationText.read.mockResolvedValue(false);
+
+        await expect(testGenerator(mockUrl, mockTestName)).rejects.toThrow("Process.exit called with code undefined");
+        expect(consola.warn).toHaveBeenCalledWith(`Reconciliation "${mockReconciliationHandle}" wasn't found`);
+      });
+
+      it("should warn and return gracefully for missing shared parts", async () => {
+        Utils.lookForSharedPartsInLiquid.mockReturnValue(["missing_shared_part"]);
+        SharedPart.read.mockResolvedValue(false);
+
+        await testGenerator(mockUrl, mockTestName);
+
+        expect(consola.warn).toHaveBeenCalledWith(`Shared part "missing_shared_part" wasn't found`);
+        // Should not exit the process
+        expect(mockExitSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("integration with utility functions", () => {
+      it("should pass correct object structure to utility functions", async () => {
+        await testGenerator(mockUrl, mockTestName);
+
+        // Verify that the correct object structure is passed to utility functions
+        expect(Utils.searchForResultsFromDependenciesInLiquid).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: "Main liquid content",
+            text_parts: [{ name: "part1", content: "Part 1 content" }],
+          }),
+          mockReconciliationHandle
+        );
+
+        expect(Utils.searchForCustomsFromDependenciesInLiquid).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: "Main liquid content",
+            text_parts: [{ name: "part1", content: "Part 1 content" }],
+          }),
+          mockReconciliationHandle
+        );
+
+        expect(Utils.lookForSharedPartsInLiquid).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: "Main liquid content",
+            text_parts: [{ name: "part1", content: "Part 1 content" }],
+          }),
+          mockReconciliationHandle
+        );
+      });
+
+      it("should handle shared parts with nested dependencies", async () => {
+        Utils.lookForSharedPartsInLiquid
+          .mockReturnValueOnce(["shared_part_1"]) // First call for main template
+          .mockReturnValueOnce(["nested_shared_part"]); // Second call for shared part
+
+        await testGenerator(mockUrl, mockTestName);
+
+        expect(SharedPart.read).toHaveBeenCalledWith("shared_part_1");
+        expect(Utils.searchForResultsFromDependenciesInLiquid).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "shared_part_name", text: "Shared part content" }),
+          "shared_part_name",
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe("period data handling", () => {
+      it("should set current period correctly", async () => {
+        await testGenerator(mockUrl, mockTestName);
+
+        expect(Utils.exportYAML).toHaveBeenCalledWith(
+          mockReconciliationHandle,
+          expect.objectContaining({
+            [mockTestName]: expect.objectContaining({
+              context: expect.objectContaining({
+                period: "2024-12-31",
+              }),
+              data: expect.objectContaining({
+                periods: expect.objectContaining({
+                  "2024-12-31": expect.any(Object),
+                }),
+              }),
+            }),
+          })
+        );
+      });
+
+      it("should handle previous period correctly", async () => {
+        const previousPeriodData = {
+          fiscal_year: { end_date: "2023-12-31" },
+        };
+        SF.getPeriods.mockResolvedValue({
+          data: [mockPeriodData, previousPeriodData],
+        });
+
+        await testGenerator(mockUrl, mockTestName);
+
+        expect(Utils.exportYAML).toHaveBeenCalledWith(
+          mockReconciliationHandle,
+          expect.objectContaining({
+            [mockTestName]: expect.objectContaining({
+              data: expect.objectContaining({
+                periods: expect.objectContaining({
+                  "2024-12-31": expect.any(Object),
+                  "2023-12-31": null,
+                }),
+              }),
+            }),
+          })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #197 

## Description

Include a summary of the changes made

The liquid test generator function now uses the local version of the code instead of the code on firm level. This makes sure that we don't have issues with hidden template code anymore. 

Additionally, period.customs are now fetched as well

## Testing Instructions

Steps:

1. Open a random client file that uses partner templates and use the create-test functionality
2. Use a period.custom and see if it is added to the test as well
3. Check tests


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
