### PR TITLE
Create an empty yml file for new account templates

### DIFF
--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -70,6 +70,9 @@ class AccountTemplate {
     if (!this.#validateFolderName(name, templateConfig)) return false;
     const template = this.#filterConfigItems(templateConfig);
 
+    // Liquid tests
+    templateConfig = this.#createLiquidTest(name, templateConfig);
+
     // Liquid
     this.#createMainLiquid(name);
     template.text = this.#readMainLiquid(name, templateConfig);
@@ -174,6 +177,15 @@ class AccountTemplate {
       text_parts: configTextParts,
       mapping_list_ranges: updatedMappingRanges,
     };
+  }
+
+  static #createLiquidTest(name, templateConfig) {
+    const testContent = "# Add your Liquid Tests here";
+    fsUtils.createLiquidTestFiles(this.TEMPLATE_TYPE, name, testContent);
+    if (!templateConfig.test) {
+      templateConfig.test = `tests/${name}_liquid_test.yml`;
+    }
+    return templateConfig;
   }
 
   static #filterConfigItems(templateConfig) {

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -216,4 +216,83 @@ describe("AccountTemplate", () => {
       expect(oldPartLiquidContent).toBe(existingPartContent);
     });
   });
+
+  describe("read", () => {
+    const name = "test_account_template";
+    const tempDir = path.join(process.cwd(), "tmp");
+    const templateDir = path.join(tempDir, "account_templates", name);
+    const configPath = path.join(templateDir, "config.json");
+    const mainLiquidPath = path.join(templateDir, "main.liquid");
+    const testLiquidPath = path.join(templateDir, "tests", `${name}_liquid_test.yml`);
+    const part1LiquidPath = path.join(templateDir, "text_parts", "part_1.liquid");
+
+    const configContent = {
+      id: { 100: 808080 },
+      name_en: "test_account_template",
+      name_nl: "test_account_template",
+      name_fr: "test_account_template",
+      text: "main.liquid",
+      text_parts: {
+        part_1: "text_parts/part_1.liquid",
+      },
+      externally_managed: true,
+      account_range: null,
+      mapping_list_ranges: [],
+      hide_code: true,
+      published: true,
+    };
+
+    beforeEach(() => {
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+      process.chdir(tempDir);
+
+      // Create necessary directories and files
+      fs.mkdirSync(templateDir, { recursive: true });
+      fs.mkdirSync(path.join(templateDir, "text_parts"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify(configContent));
+      fs.writeFileSync(mainLiquidPath, "Main liquid content");
+      fs.writeFileSync(part1LiquidPath, "Part 1 content");
+      fs.writeFileSync(testLiquidPath, "# Add your Liquid Tests here");
+
+      // Mock valid name check
+      templateUtils.checkValidName.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(tempDir)) {
+        fs.rmdirSync(tempDir, { recursive: true });
+      }
+      jest.resetAllMocks();
+    });
+
+    it("should read and process the account template correctly", () => {
+      const result = AccountTemplate.read(name);
+
+      expect(result).toEqual({
+        name_en: "test_account_template",
+        name_nl: "test_account_template",
+        name_fr: "test_account_template",
+        externally_managed: true,
+        account_range: null,
+        mapping_list_ranges: [],
+        hide_code: true,
+        published: true,
+        text: "Main liquid content",
+        text_parts: [{ name: "part_1", content: "Part 1 content" }],
+      });
+    });
+
+    it("should create liquid test file if it's missing", async () => {
+      await fsPromises.unlink(testLiquidPath);
+
+      AccountTemplate.read(name);
+
+      expect(fs.existsSync(testLiquidPath)).toBe(true);
+      const content = await fsPromises.readFile(testLiquidPath, "utf-8");
+      expect(content).toBe("# Add your Liquid Tests here");
+    });
+  });
 });


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

https://github.com/orgs/silverfin/projects/4/views/1?pane=issue&itemId=123104622&issue=silverfin%7Csilverfin-cli%7C210 

## Description

Include a summary of the changes made

Command create-account-template didn't create an empty .yml file (which is done for the reconciliations). This has now been aligned. 

## Testing Instructions

Steps:

1. Create a new account template via CLI


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
