### PR TITLE
Implement test firm id in Github actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ config.json
 .DS_Store
 
 # Template directories
-reconciliation_texts
+# reconciliation_texts
 shared_parts
 account_templates
 permanent_texts

--- a/lib/templates/accountTemplate.js
+++ b/lib/templates/accountTemplate.js
@@ -4,7 +4,7 @@ const templateUtils = require("../utils/templateUtils");
 const { consola } = require("consola");
 
 class AccountTemplate {
-  static CONFIG_ITEMS = ["name_en", "name_fr", "name_nl", "externally_managed", "account_range", "mapping_list_ranges", "published", "hide_code"];
+  static CONFIG_ITEMS = ["name_en", "name_fr", "name_nl", "externally_managed", "account_range", "mapping_list_ranges", "published", "hide_code", "test_firm_id"];
   static TEMPLATE_TYPE = "accountTemplate";
   static TEMPLATE_FOLDER = fsUtils.FOLDERS[this.TEMPLATE_TYPE];
   constructor() {}

--- a/lib/templates/reconciliationText.js
+++ b/lib/templates/reconciliationText.js
@@ -21,6 +21,7 @@ class ReconciliationText {
     "hide_code",
     "use_full_width",
     "downloadable_as_docx",
+    "test_firm_id",
   ];
   static RECONCILIATION_TYPE_OPTIONS = ["reconciliation_not_necessary", "can_be_reconciled_without_data", "only_reconciled_with_data"];
   static EXTERNALLY_MANAGED_ITEMS = ["downloadable_as_docx"];

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -173,6 +173,7 @@ function createConfigIfMissing(templateType, handle) {
       config.downloadable_as_docx = false;
       config.text = "main.liquid";
       config.text_parts = {};
+      config.test_firm_id = null;
       break;
     case "sharedPart":
       config.name = `${handle}`;
@@ -197,6 +198,7 @@ function createConfigIfMissing(templateType, handle) {
       config.mapping_list_ranges = [];
       config.text = "main.liquid";
       config.text_parts = {};
+      config.test_firm_id = null;
       break;
   }
   writeConfig(templateType, handle, config);

--- a/reconciliation_texts/test_handle/main.liquid
+++ b/reconciliation_texts/test_handle/main.liquid
@@ -1,0 +1,1 @@
+{% comment %} MAIN PART {% endcomment %}

--- a/reconciliation_texts/test_handle/test_handle.liquid
+++ b/reconciliation_texts/test_handle/test_handle.liquid
@@ -1,0 +1,1 @@
+{% comment %} MAIN PART {% endcomment %}

--- a/reconciliation_texts/test_handle/tests/README.md
+++ b/reconciliation_texts/test_handle/tests/README.md
@@ -1,0 +1,5 @@
+# Liquid Testing
+
+## [Template name]
+
+> Use this Readme file to add extra information about the Liquid Tests that can be performed

--- a/reconciliation_texts/test_handle/tests/test_handle_liquid_test.yml
+++ b/reconciliation_texts/test_handle/tests/test_handle_liquid_test.yml
@@ -1,0 +1,1 @@
+# Add your Liquid Tests here

--- a/reconciliation_texts/test_handle/text_parts/part_1.liquid
+++ b/reconciliation_texts/test_handle/text_parts/part_1.liquid
@@ -1,0 +1,1 @@
+{% comment %} PART 1 {% endcomment %}

--- a/run_tests.yml
+++ b/run_tests.yml
@@ -1,0 +1,215 @@
+name: run-liquid-tests
+run-name: Run liquid tests of updated reconciliations and reconciliations that use updated shared parts
+on: 
+  workflow_call:
+
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+jobs:
+  check-auth:
+    uses: ./.github/workflows/check_auth.yml
+    secrets: inherit
+
+  check-changed-templates:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_templates: ${{ steps.templates_changed.outputs.changed_templates }}
+    steps:
+      - name: Checkout Repository - Fetch all history for all tags and branches
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed liquid files
+        id: changed-files
+        uses: tj-actions/changed-files@v41
+        with:
+          since_last_remote_commit: false
+          dir_names: false
+          ref: 'main'
+          files: |
+            **/**.{liquid,yml,yaml,json}
+      - name: Filter templates changed
+        id: templates_changed
+        run: |
+          pattern="(?:reconciliation_texts|shared_parts)/([^/]+)/"
+          changed_files="${{ steps.changed-files.outputs.all_changed_files }}"
+          if [ -n "$changed_files" ]; then
+            filtered_names=($(printf "%s\n" "$changed_files" | grep -oP "$pattern" || true))
+            if [ $? -ne 0 ]; then
+              echo "No files match the pattern"
+              changed_templates=()
+            else
+              # Remove the trailing "/" from the extracted names
+              filtered_names=("${filtered_names[@]%/}")
+              # Remove duplicates
+              changed_templates=($(printf "%s\n" "${filtered_names[@]}" | sort -u))
+            fi
+          else
+            echo "No changed files"
+            changed_templates=()
+          fi
+          # Store outputs
+          if [ ${#changed_templates[@]} -eq 0 ]; then
+            echo "changed_templates=[]" >> $GITHUB_OUTPUT
+          else
+            echo "changed_templates=${changed_templates[*]}" >> $GITHUB_OUTPUT
+            # Print the templates names
+            for name in "${changed_templates[@]}"; do
+              echo "$name"
+            done
+          fi
+          exit 0
+
+  test-templates:
+    runs-on: ubuntu-latest
+    env:
+      SF_API_CLIENT_ID: "${{ secrets.SF_API_CLIENT_ID }}"
+      SF_API_SECRET: "${{ secrets.SF_API_SECRET }}"
+      CHANGED_TEMPLATES: "${{ needs.check-changed-templates.outputs.changed_templates }}"
+    if: ${{ needs.check-changed-templates.outputs.changed_templates != '[]' }}
+    needs: [check-auth, check-changed-templates]
+    steps:
+      - name: Checkout Repository - Fetch all history for all tags and branches
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node v18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Load Silverfin config file from secrets
+        run: |
+          mkdir -p $HOME/.silverfin/
+          touch $HOME/.silverfin/config.json
+          echo '${{ secrets.CONFIG_JSON }}' > $HOME/.silverfin/config.json
+      - name: Add silverfin-cli package latest version
+        run: |
+          npm install https://github.com/silverfin/silverfin-cli.git
+          VERSION=$(./node_modules/silverfin-cli/bin/cli.js -V)
+          echo "CLI version: ${VERSION}"
+      - name: Run liquid tests for updated templates
+        run: |
+          declare -a ERRORS
+          for CURRENT_DIR in ${{ env.CHANGED_TEMPLATES }}; do
+            echo "Checking ${CURRENT_DIR}"
+            while [[ "${CURRENT_DIR}" != "." ]]; do
+              if [[ -e "${CURRENT_DIR}/config.json" ]]; then
+                HANDLE=$(cat ${CURRENT_DIR}/config.json | jq -r ".handle // .name")
+                
+                # Check if test_firm_id is present in config
+                TEST_FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".test_firm_id // empty")
+
+                if [[ -n "$TEST_FIRM_ID" ]]; then
+                  # Check if test_firm_id exists in the .id object
+                  AVAILABLE_FIRM_IDS=$(cat ${CURRENT_DIR}/config.json | jq -r ".id | keys[]" 2>/dev/null || echo "")
+                  
+                  if [[ "$AVAILABLE_FIRM_IDS" == *"$TEST_FIRM_ID"* ]]; then
+                    FIRM_ID="$TEST_FIRM_ID"
+                    echo "Using configured test_firm_id: ${FIRM_ID}"
+                  else
+                    echo "Warning: test_firm_id '${TEST_FIRM_ID}' not found in .id object, falling back to default"
+                    FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
+                  fi
+                else
+                  # No test_firm_id configured, use default
+                  FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
+                fi
+                if [[ "${CURRENT_DIR}" == *reconciliation_texts* ]]; then
+                  # FETCH THE NEWEST VERSION OF THE TOKENS FROM THE SECRETS, IN CASE THEY WERE UPDATED BY THE INITIATION OF A CONCURRENT WORKFLOW
+                  echo '${{ secrets.CONFIG_JSON }}' > $HOME/.silverfin/config.json
+                  # RUN TEST
+                  echo "Running tests for ${HANDLE} in firm ${FIRM_ID}"
+                  FORMATTED_OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --handle "${HANDLE}" --firm "${FIRM_ID}")
+                  OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --handle "${HANDLE}" --firm "${FIRM_ID}" --status 2>&1)
+                  # CHECK OUTPUT
+                  if [[ "$OUTPUT" =~ "PASSED" ]]; then
+                    echo "${HANDLE}: passed"
+                  elif [[ "$OUTPUT" =~ "FAILED" ]]; then
+                    echo "${HANDLE}: failed"
+                    echo "Details of test run: ${FORMATTED_OUTPUT}"
+                    ERRORS+=("${HANDLE}")
+                  else
+                    echo "${HANDLE}: other errors: ${OUTPUT}"
+                    ERRORS+=("${OUTPUT}")
+                  fi
+                fi
+                break
+              else
+                echo "Config file not found in ${CURRENT_DIR}"
+                CURRENT_DIR="$(dirname "${CURRENT_DIR}")"
+              fi
+            done
+          done
+          # CHECK ERRORS PRESENT
+          if [ ${#ERRORS[@]} -eq 0 ]; then
+              echo "All tests have passed"
+          else
+              echo "Errors: ${ERRORS[@]}, please run the tests locally to fix the errors"
+              exit 1
+          fi
+     
+      # - name: Get changed files in the shared_parts folder
+      #   id: changed-files-shared-parts
+      #   uses: tj-actions/changed-files@v35
+      #   with:
+      #     since_last_remote_commit: false
+      #     dir_names: true
+      #     files: "shared_parts"
+      # - name: List all changed files in the shared_parts folder
+      #   run: |
+      #     for file in ${{ steps.changed-files-shared-parts.outputs.all_changed_files }}; do
+      #       echo "$file was changed"
+      #     done
+      # - name: Run liquid tests for reconciliations that use updated shared parts
+      #   run: |
+      #     declare -a ERRORS
+      #     for CURRENT_DIR in ${{ steps.changed-files-shared-parts.outputs.all_changed_files }}; do
+      #       echo "Checking ${CURRENT_DIR}"
+      #       while [[ "${CURRENT_DIR}" != "." ]]; do
+      #         if [[ -e "${CURRENT_DIR}/config.json" ]]; then
+      #           JSON=$(cat ${CURRENT_DIR}/config.json)
+      #           HANDLES=$(echo "$JSON" | jq -r '.used_in[].handle')
+      #           # LOOP THROUGH EACH RECONCILIATION
+      #           for HANDLE in $HANDLES; do
+      #             # CHECK IF RECONCILIATION CONFIG IS IMPORTED
+      #             if [[ -f "./reconciliation_texts/${HANDLE}/config.json" ]]; then
+      #               # RUN THE TEST FOR THE FIRST FIRM ID IN THE RECONCILIATION CONFIG
+      #               FIRM_ID=$(cat ./reconciliation_texts/${HANDLE}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
+      #               # RUN TEST
+      #               echo "Running tests for ${HANDLE} in firm ${FIRM_ID}"
+      #               FORMATTED_OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --handle "${HANDLE}" --firm "${FIRM_ID}")
+      #               OUTPUT=$(node ./node_modules/silverfin-cli/bin/cli.js run-test --handle "${HANDLE}" --firm "${FIRM_ID}" --status 2>&1)
+      #               # CHECK OUTPUT
+      #               if [[ "$OUTPUT" =~ "PASSED" ]]; then
+      #                 echo "${HANDLE}: passed"
+      #               elif [[ "$OUTPUT" =~ "FAILED" ]]; then
+      #                 echo "${HANDLE}: failed"
+      #                 echo "Details of test run: ${FORMATTED_OUTPUT}"
+      #                 ERRORS+=("${HANDLE}")
+      #               else
+      #                 echo "${HANDLE}: other errors: ${OUTPUT}"
+      #                 ERRORS+=("${OUTPUT}")
+      #               fi
+      #             fi
+      #           done
+      #           break
+      #         else
+      #           echo "Config file not found in ${CURRENT_DIR}"
+      #           CURRENT_DIR="$(dirname "${CURRENT_DIR}")"
+      #         fi
+      #       done
+      #     done
+      #     # CHECK ERRORS PRESENT
+      #     if [ ${#ERRORS[@]} -eq 0 ]; then
+      #         echo "All tests have passed"
+      #     else
+      #         echo "Errors: ${ERRORS[@]}, please run the tests locally to fix the errors"
+      #         exit 1
+      #     fi

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -25,6 +25,7 @@ describe("AccountTemplate", () => {
       externally_managed: true,
       hide_code: true,
       mapping_list_ranges: [],
+      test_firm_id: null,
     };
     const name_nl = template.name_nl;
     const configToWrite = {
@@ -45,6 +46,7 @@ describe("AccountTemplate", () => {
       mapping_list_ranges: [],
       hide_code: true,
       published: true,
+      test_firm_id: null,
     };
     const existingConfig = {
       id: { 200: 505050 },
@@ -60,6 +62,7 @@ describe("AccountTemplate", () => {
       mapping_list_ranges: [],
       hide_code: false,
       published: true,
+      test_firm_id: null,
     };
 
     const tempDir = path.join(process.cwd(), "tmp");

--- a/tests/lib/templates/reconciliationTexts.test.js
+++ b/tests/lib/templates/reconciliationTexts.test.js
@@ -47,6 +47,7 @@ describe("ReconciliationText", () => {
       reconciliation_type: "only_reconciled_with_data",
       use_full_width: true,
       virtual_account_number: "",
+      test_firm_id: null,
     };
     const existingConfig = {
       id: { 200: 505050 },
@@ -69,6 +70,7 @@ describe("ReconciliationText", () => {
       reconciliation_type: "only_reconciled_with_data",
       use_full_width: true,
       virtual_account_number: "",
+      test_firm_id: null,
     };
 
     const tempDir = path.join(process.cwd(), "tmp");


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

Include a summary of the changes made

- Introduced a new config item -> test_firm_id for reconciliations and account templates.
- If completed, the GH action will use that firm, if not (or if not present in the firm id linked to that template), we use the first id in the config file. 

## Testing Instructions

Steps:

Testing is a bit tricky since we need 2 repo's at the same time (market repo + cli repo). Why is why:
- I added a test reconciliation to CLI
- Moved the GH action code to CLI
- Logic can be mocked by running the following bash script:

```
# Test the logic with the real config file
CURRENT_DIR="reconciliation_texts/test_handle"
TEST_FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".test_firm_id // empty")

if [[ -n "$TEST_FIRM_ID" ]]; then
  # Check if test_firm_id exists in the .id object
  AVAILABLE_FIRM_IDS=$(cat ${CURRENT_DIR}/config.json | jq -r ".id | keys[]" 2>/dev/null || echo "")
  
  if [[ "$AVAILABLE_FIRM_IDS" == *"$TEST_FIRM_ID"* ]]; then
    FIRM_ID="$TEST_FIRM_ID"
    echo "Using configured test_firm_id: ${FIRM_ID}"
  else
    echo "Warning: test_firm_id '${TEST_FIRM_ID}' not found in .id object, falling back to default"
    FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
  fi
else
  # No test_firm_id configured, use default
  FIRM_ID=$(cat ${CURRENT_DIR}/config.json | jq -r ".id" | jq "keys_unsorted" | jq "first" | tr -d '"')
fi

echo "Final FIRM_ID: $FIRM_ID"
```

If OK, I will undo all these temporary changes and implement it for BE market

## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
