### PR TITLE
Implement pagination for period custom drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.45.1] (29/08/2025)
+- Fix: when fetching the Period CustomDrop, we were limited to 200 results. Implemented pagination to fetch all results.
+
 ## [1.45.0] (28/08/2025)
 - A new config file attribute `test_firm_id` was added for account templates and reconciliations texts.
 Adding it with a specific firm will make sure that this firm is used for the Github actions. 

--- a/lib/api/sfApi.js
+++ b/lib/api/sfApi.js
@@ -3,6 +3,9 @@ const { consola } = require("consola");
 const { AxiosFactory } = require("./axiosFactory");
 const { SilverfinAuthorizer } = require("./silverfinAuthorizer");
 
+const MAX_PAGES = 50;
+const PER_PAGE = 200;
+
 apiUtils.checkRequiredEnvVariables();
 
 async function authorizeFirm(firmId) {
@@ -33,7 +36,7 @@ async function readReconciliationTexts(type, envId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`reconciliations`, {
-      params: { page: page, per_page: 200 },
+      params: { page: page, per_page: PER_PAGE },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
@@ -115,7 +118,7 @@ async function readReconciliationTextDetails(type, envId, companyId, periodId, r
 async function getReconciliationCustom(type, envId, companyId, periodId, reconciliationId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
-    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`, { params: { page: page, per_page: 200 } });
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`, { params: { page: page, per_page: PER_PAGE } });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -140,7 +143,7 @@ async function readSharedParts(type, envId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`shared_parts`, {
-      params: { page: page, per_page: 200 },
+      params: { page: page, per_page: PER_PAGE },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
@@ -253,7 +256,7 @@ async function readExportFiles(type, envId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`export_files`, {
-      params: { page: page, per_page: 200 },
+      params: { page: page, per_page: PER_PAGE },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
@@ -341,7 +344,7 @@ async function readAccountTemplates(type, envId, page = 1) {
   const instance = AxiosFactory.createInstance(type, envId);
   try {
     const response = await instance.get(`account_templates`, {
-      params: { page: page, per_page: 200 },
+      params: { page: page, per_page: PER_PAGE },
     });
     apiUtils.responseSuccessHandler(response);
     return response.data;
@@ -468,7 +471,7 @@ async function getPeriods(firmId, companyId, page = 1) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
     const response = await instance.get(`/companies/${companyId}/periods`, {
-      params: { page: page, per_page: 200 },
+      params: { page: page, per_page: PER_PAGE },
     });
     apiUtils.responseSuccessHandler(response);
     return response;
@@ -505,16 +508,44 @@ async function getCompanyCustom(firmId, companyId) {
   }
 }
 
-async function getPeriodCustom(firmId, companyId, periodId) {
+async function getPeriodCustom(firmId, companyId, periodId, page = 1) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
-    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/custom`);
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/custom`, { params: { page: page, per_page: PER_PAGE } });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
     const response = await apiUtils.responseErrorHandler(error);
     return response;
   }
+}
+
+async function getAllPeriodCustom(firmId, companyId, periodId) {
+  const fetchPage = async (page) => {
+    const response = await getPeriodCustom(firmId, companyId, periodId, page);
+    if (!response || !response.data) {
+      return [];
+    }
+
+    return response.data || [];
+  };
+
+  const items = [];
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore && page <= MAX_PAGES) {
+    const pageData = await fetchPage(page);
+    items.push(...pageData);
+    hasMore = pageData.length === PER_PAGE;
+    page++;
+  }
+
+  if (page > MAX_PAGES) {
+    consola.warn(`Reached maximum page limit (${MAX_PAGES}) while fetching period custom drop data. There might be more data available.`);
+  }
+
+  return items;
 }
 
 async function getWorkflows(firmId, companyId, periodId) {
@@ -532,7 +563,7 @@ async function getWorkflows(firmId, companyId, periodId) {
 async function getWorkflowInformation(firmId, companyId, periodId, workflowId, page = 1) {
   const instance = AxiosFactory.createInstance("firm", firmId);
   try {
-    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`, { params: { page: page, per_page: 200 } });
+    const response = await instance.get(`/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`, { params: { page: page, per_page: PER_PAGE } });
     apiUtils.responseSuccessHandler(response);
     return response;
   } catch (error) {
@@ -651,6 +682,7 @@ module.exports = {
   getCompanyDrop,
   getCompanyCustom,
   getPeriodCustom,
+  getAllPeriodCustom,
   getWorkflows,
   getWorkflowInformation,
   findReconciliationInWorkflow,

--- a/lib/liquidTestGenerator.js
+++ b/lib/liquidTestGenerator.js
@@ -51,18 +51,18 @@ async function testGenerator(url, testName, reconciledStatus = true) {
     }
   }
 
-  const responsePeriodCustom = await SF.getPeriodCustom(parameters.firmId, parameters.companyId, parameters.ledgerId);
-  const periodCustomData = responsePeriodCustom.data;
   // Add period custom data to the test object
-  if (periodCustomData && Object.keys(periodCustomData).length > 0) {
+  const allPeriodCustoms = (await SF.getAllPeriodCustom(parameters.firmId, parameters.companyId, parameters.ledgerId)) || [];
+  if (allPeriodCustoms && allPeriodCustoms.length != 0) {
     const periodTextProperties = {};
-    for (const item of periodCustomData) {
+    for (const item of allPeriodCustoms) {
       if (item.namespace && item.key) {
         periodTextProperties[`${item.namespace}.${item.key}`] = item.value;
       }
     }
     liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].custom = periodTextProperties;
   }
+  process.exit;
 
   // Get all the text properties (Customs from current template)
   const responseCustom = await SF.getReconciliationCustom("firm", parameters.firmId, parameters.companyId, parameters.ledgerId, parameters.reconciliationId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.45.0",
+      "version": "1.45.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/liquidTestGenerator.test.js
+++ b/tests/lib/liquidTestGenerator.test.js
@@ -121,15 +121,13 @@ describe("liquidTestGenerator", () => {
       data: [mockPeriodData],
     });
     SF.findPeriod = jest.fn().mockReturnValue(mockPeriodData);
-    SF.getPeriodCustom = jest.fn().mockResolvedValue({
-      data: [
-        {
-          namespace: "pit_integration",
-          key: "code_1002",
-          value: "yes",
-        },
-      ],
-    });
+    SF.getAllPeriodCustom = jest.fn().mockResolvedValue([
+      {
+        namespace: "pit_integration",
+        key: "code_1002",
+        value: "yes",
+      },
+    ]);
     SF.getReconciliationCustom = jest.fn().mockResolvedValue({
       data: [
         {
@@ -236,7 +234,7 @@ describe("liquidTestGenerator", () => {
       });
 
       it("should handle empty period custom data", async () => {
-        SF.getPeriodCustom = jest.fn().mockResolvedValue({ data: [] });
+        SF.getAllPeriodCustom = jest.fn().mockResolvedValue([]);
 
         await testGenerator(mockUrl, mockTestName);
 


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

Responses from Silverfin API are limited to 200 items. Implement pagination for Period CustomDrop, used to create yaml tests in `create-test` command

## Testing Instructions

Steps:

1. Run `silverfin create-test` when the period CustomDrop has more than 200 items


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
