### PR TITLE
Order text properties based on their key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.45.3] (16/09/2025)
+- Fix: when creating a yaml file from an existing template, and a CustomDrop collection contains more than 10 items, we were wrongly sorting them alphabetically instead of by key id.
+
 ## [1.45.2] (12/09/2025)
 - Fix: make sure template supprots all 7 locales but not all locales get populated automatically.
 

--- a/lib/liquidTestGenerator.js
+++ b/lib/liquidTestGenerator.js
@@ -54,13 +54,8 @@ async function testGenerator(url, testName, reconciledStatus = true) {
   // Add period custom data to the test object
   const allPeriodCustoms = (await SF.getAllPeriodCustom(parameters.firmId, parameters.companyId, parameters.ledgerId)) || [];
   if (allPeriodCustoms && allPeriodCustoms.length != 0) {
-    const periodTextProperties = {};
-    for (const item of allPeriodCustoms) {
-      if (item.namespace && item.key) {
-        periodTextProperties[`${item.namespace}.${item.key}`] = item.value;
-      }
-    }
-    liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].custom = periodTextProperties;
+    const periodCustoms = Utils.processCustom(allPeriodCustoms);
+    liquidTestObject[testName].data.periods[currentPeriodData.fiscal_year.end_date].custom = periodCustoms;
   }
   process.exit;
 

--- a/lib/utils/liquidTestUtils.js
+++ b/lib/utils/liquidTestUtils.js
@@ -90,10 +90,41 @@ function exportYAML(handle, liquidTestObject) {
   );
 }
 
-// Format TextoProperties/Customs to an Object
+/**
+ * Format TextoProperties/Customs array to an Object
+ *
+ * Sorts the input array by namespace first, then by key within each namespace.
+ * For keys with numeric suffixes (e.g., _1, _2, ..., _10), sorts numerically rather than alphabetically.
+ *
+ * @param {Array} customArray - Array of custom objects with namespace, key, and value properties
+ * @param {string} customArray[].namespace - The namespace of the custom property
+ * @param {string} customArray[].key - The key of the custom property
+ * @param {*} customArray[].value - The value of the custom property (may have a .field property)
+ * @returns {Object} Sorted object with keys in format "namespace.key"
+ */
 function processCustom(customArray) {
+  const sortedArray = customArray.sort((a, b) => {
+    if (a.namespace !== b.namespace) {
+      return a.namespace.localeCompare(b.namespace);
+    }
+
+    const getNumericPart = (key) => {
+      const match = key.match(/_(\d+)$/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+
+    const numA = getNumericPart(a.key);
+    const numB = getNumericPart(b.key);
+
+    if (numA && numB) {
+      return numA - numB;
+    }
+
+    return a.key.localeCompare(b.key);
+  });
+
   const obj = {};
-  for (const item of customArray) {
+  for (const item of sortedArray) {
     const element = `${item.namespace}.${item.key}`;
     // Fori
     if (item.value && item.value.field) {
@@ -102,6 +133,7 @@ function processCustom(customArray) {
       obj[element] = item.value;
     }
   }
+
   return obj;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.45.2",
+      "version": "1.45.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/liquidTestGenerator.test.js
+++ b/tests/lib/liquidTestGenerator.test.js
@@ -20,7 +20,6 @@ jest.mock("../../lib/utils/liquidTestUtils", () => {
     createBaseLiquidTest: jest.fn(),
     exportYAML: jest.fn(),
     extractURL: jest.fn(),
-    processCustom: jest.fn(),
   };
 });
 
@@ -99,9 +98,6 @@ describe("liquidTestGenerator", () => {
 
     Utils.extractURL.mockReturnValue(mockParameters);
     Utils.exportYAML.mockImplementation(() => {});
-    Utils.processCustom.mockReturnValue({
-      "test_namespace.test_key": "test_value",
-    });
 
     // Mock template reading
     ReconciliationText.read.mockResolvedValue(mockReconciliationTemplate);

--- a/tests/lib/utils/liquidTestUtils.test.js
+++ b/tests/lib/utils/liquidTestUtils.test.js
@@ -1,0 +1,175 @@
+const Utils = require("../../../lib/utils/liquidTestUtils");
+
+describe("liquidTestUtils", () => {
+  describe("processCustom", () => {
+    it("should sort by namespace first", () => {
+      const input = [
+        { namespace: "zebra", key: "first", value: "z1" },
+        { namespace: "alpha", key: "second", value: "a1" },
+        { namespace: "beta", key: "third", value: "b1" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual(["alpha.second", "beta.third", "zebra.first"]);
+    });
+
+    it("should sort by key within the same namespace", () => {
+      const input = [
+        { namespace: "test", key: "zebra", value: "z1" },
+        { namespace: "test", key: "alpha", value: "a1" },
+        { namespace: "test", key: "beta", value: "b1" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual(["test.alpha", "test.beta", "test.zebra"]);
+    });
+
+    it("should handle numeric suffixes correctly", () => {
+      const input = [
+        { namespace: "test", key: "item_10", value: "10" },
+        { namespace: "test", key: "item_2", value: "2" },
+        { namespace: "test", key: "item_1", value: "1" },
+        { namespace: "test", key: "item_20", value: "20" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual(["test.item_1", "test.item_2", "test.item_10", "test.item_20"]);
+    });
+
+    it("should handle mixed keys (with and without numeric suffixes)", () => {
+      const input = [
+        { namespace: "test", key: "item_2", value: "2" },
+        { namespace: "test", key: "zebra", value: "z" },
+        { namespace: "test", key: "item_1", value: "1" },
+        { namespace: "test", key: "alpha", value: "a" },
+        { namespace: "test", key: "item_10", value: "10" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual(["test.alpha", "test.item_1", "test.item_2", "test.item_10", "test.zebra"]);
+    });
+
+    it("should handle values with field property", () => {
+      const input = [
+        { namespace: "test", key: "field1", value: { field: "field_value1" } },
+        { namespace: "test", key: "field2", value: { field: "field_value2" } },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      expect(result).toEqual({
+        "test.field1": "field_value1",
+        "test.field2": "field_value2",
+      });
+    });
+
+    it("should handle regular values without field property", () => {
+      const input = [
+        { namespace: "test", key: "simple1", value: "simple_value1" },
+        { namespace: "test", key: "simple2", value: "simple_value2" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      expect(result).toEqual({
+        "test.simple1": "simple_value1",
+        "test.simple2": "simple_value2",
+      });
+    });
+
+    it("should handle mixed value types (with and without field property)", () => {
+      const input = [
+        { namespace: "test", key: "field", value: { field: "field_value" } },
+        { namespace: "test", key: "simple", value: "simple_value" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      expect(result).toEqual({
+        "test.field": "field_value",
+        "test.simple": "simple_value",
+      });
+    });
+
+    it("should handle complex sorting scenario with multiple namespaces and numeric keys", () => {
+      const input = [
+        { namespace: "pit_integration", key: "code_1002", value: "yes" },
+        { namespace: "alpha", key: "item_10", value: "10" },
+        { namespace: "pit_integration", key: "code_1001", value: "no" },
+        { namespace: "beta", key: "simple", value: "beta_simple" },
+        { namespace: "alpha", key: "item_2", value: "2" },
+        { namespace: "alpha", key: "zebra", value: "z" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual([
+        "alpha.item_2",
+        "alpha.item_10",
+        "alpha.zebra",
+        "beta.simple",
+        "pit_integration.code_1001",
+        "pit_integration.code_1002"
+      ]);
+    });
+
+    it("should handle empty array", () => {
+      const result = Utils.processCustom([]);
+      expect(result).toEqual({});
+    });
+
+    it("should handle single item", () => {
+      const input = [{ namespace: "test", key: "single", value: "value" }];
+      const result = Utils.processCustom(input);
+      expect(result).toEqual({ "test.single": "value" });
+    });
+
+    it("should handle numeric suffixes with more than 10 items", () => {
+      const input = [
+        { namespace: "test", key: "key_14", value: "14" },
+        { namespace: "test", key: "key_3", value: "3" },
+        { namespace: "test", key: "key_1", value: "1" },
+        { namespace: "test", key: "key_11", value: "11" },
+        { namespace: "test", key: "key_2", value: "2" },
+        { namespace: "test", key: "key_10", value: "10" },
+        { namespace: "test", key: "key_12", value: "12" },
+        { namespace: "test", key: "key_5", value: "5" },
+        { namespace: "test", key: "key_9", value: "9" },
+        { namespace: "test", key: "key_13", value: "13" },
+        { namespace: "test", key: "key_4", value: "4" },
+        { namespace: "test", key: "key_8", value: "8" },
+        { namespace: "test", key: "key_6", value: "6" },
+        { namespace: "test", key: "key_7", value: "7" },
+      ];
+
+      const result = Utils.processCustom(input);
+
+      const keys = Object.keys(result);
+      expect(keys).toEqual([
+        "test.key_1",
+        "test.key_2",
+        "test.key_3",
+        "test.key_4",
+        "test.key_5",
+        "test.key_6",
+        "test.key_7",
+        "test.key_8",
+        "test.key_9",
+        "test.key_10",
+        "test.key_11",
+        "test.key_12",
+        "test.key_13",
+        "test.key_14"
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

When creating a yaml from a collection with more than 10 items in it, they are wrongly ordered.
They should be ordered based on the key index, as the order of the yaml will impact the order in which they get recreated when running the test
## Testing Instructions

Steps:

1. Create a fori loop and create more than 10 items in the collection
2. run `silverfin create-test -u ...` and validate the order of the text properties in the YAML


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
