### PR TITLE
Run multiple handles in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.52.0] (12/01/2026)
+This update improves test execution performance when running tests with status checks across multiple template handles. 
+Tests are now run in parallel for multiple handles when using the `--status` flag, significantly reducing the overall execution time. Previously, tests with status checks for multiple handles would run sequentially, but now they leverage parallel processing for better efficiency. This change only affects the `silverfin run-test` command when both multiple handles and the status flag are used together.
+
 ## [1.51.0] (08/01/2026)
 
 This update should have no user impact whatsoever.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -467,24 +467,20 @@ program
 
     const templateType = options.handle ? "reconciliationText" : "accountTemplate";
     const templateName = options.handle ? options.handle : options.accountTemplate;
-
-    // Normalize to array for uniform handling (Commander returns array for variadic, string otherwise)
-    const templateNames = Array.isArray(templateName) ? templateName : [templateName];
-
     // Block multiple handles/templates without --status
-    if (templateNames.length > 1 && !options.status) {
+    if (templateName.length > 1 && !options.status) {
       consola.error("Multiple handles/templates are only allowed when used with the --status flag");
       process.exit(1);
     }
 
     if (options.status) {
       // Status mode: allow multiple, pass array of template names
-      await liquidTestRunner.runTestsStatusOnly(options.firm, templateType, templateNames, options.test);
+      await liquidTestRunner.runTestsStatusOnly(options.firm, templateType, templateName, options.test);
       return;
     }
 
     // Non-status mode: always run a single template, pass string handle/name
-    const singleTemplateName = templateNames[0];
+    const singleTemplateName = templateName[0];
 
     if (options.previewOnly && !options.htmlInput && !options.htmlPreview) {
       consola.info(`When using "--preview-only" you need to specify at least one of the following options: "--html-input", "--html-preview"`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -467,6 +467,12 @@ program
 
     const templateType = options.handle ? "reconciliationText" : "accountTemplate";
     const templateName = options.handle ? options.handle : options.accountTemplate;
+
+    if (!templateName || templateName.length === 0) {
+      consola.error("You need to provide at least one handle or account template name");
+      process.exit(1);
+    }
+
     // Block multiple handles/templates without --status
     if (templateName.length > 1 && !options.status) {
       consola.error("Multiple handles/templates are only allowed when used with the --status flag");

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -468,21 +468,30 @@ program
     const templateType = options.handle ? "reconciliationText" : "accountTemplate";
     const templateName = options.handle ? options.handle : options.accountTemplate;
 
-    // Check if multiple handles are provided without --status flag
-    if (templateName.length > 1 && !options.status) {
-      consola.error("Multiple handles are only allowed when used with the --status flag");
+    // Normalize to array for uniform handling (Commander returns array for variadic, string otherwise)
+    const templateNames = Array.isArray(templateName) ? templateName : [templateName];
+
+    // Block multiple handles/templates without --status
+    if (templateNames.length > 1 && !options.status) {
+      consola.error("Multiple handles/templates are only allowed when used with the --status flag");
       process.exit(1);
     }
 
     if (options.status) {
-      await liquidTestRunner.runTestsStatusOnly(options.firm, templateType, templateName, options.test);
-    } else {
-      if (options.previewOnly && !options.htmlInput && !options.htmlPreview) {
-        consola.info(`When using "--preview-only" you need to specify at least one of the following options: "--html-input", "--html-preview"`);
-        process.exit(1);
-      }
-      await liquidTestRunner.runTestsWithOutput(options.firm, templateType, templateName, options.test, options.previewOnly, options.htmlInput, options.htmlPreview);
+      // Status mode: allow multiple, pass array of template names
+      await liquidTestRunner.runTestsStatusOnly(options.firm, templateType, templateNames, options.test);
+      return;
     }
+
+    // Non-status mode: always run a single template, pass string handle/name
+    const singleTemplateName = templateNames[0];
+
+    if (options.previewOnly && !options.htmlInput && !options.htmlPreview) {
+      consola.info(`When using "--preview-only" you need to specify at least one of the following options: "--html-input", "--html-preview"`);
+      process.exit(1);
+    }
+
+    await liquidTestRunner.runTestsWithOutput(options.firm, templateType, singleTemplateName, options.test, options.previewOnly, options.htmlInput, options.htmlPreview);
   });
 
 // Create Liquid Test

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -466,7 +466,12 @@ program
     }
 
     const templateType = options.handle ? "reconciliationText" : "accountTemplate";
-    const templateName = options.handle ? options.handle : options.accountTemplate;
+    let templateName = options.handle ? options.handle : options.accountTemplate;
+
+    // Support pipe-separated values: if single string contains pipes, split it
+    if (templateName.length === 1 && typeof templateName[0] === 'string' && templateName[0].includes('|')) {
+      templateName = templateName[0].split('|').map(name => name.trim()).filter(name => name.length > 0);
+    }
 
     if (!templateName || templateName.length === 0) {
       consola.error("You need to provide at least one handle or account template name");

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -427,27 +427,54 @@ async function runTestsStatusOnly(firmId, templateType, handle, testName = "") {
     process.exit(1);
   }
 
-  let status = "FAILED";
-  const testResult = await runTests(firmId, templateType, handle, testName, false, "none");
+  // handle can be an array (multiple handles/templates) or a string (single handle/template)
+  const handles = Array.isArray(handle) ? handle : [handle];
 
-  if (!testResult) {
-    status = "PASSED";
-    consola.success(status);
-    return status;
-  }
+  const runSingleHandle = async (singleHandle) => {
+    let status = "FAILED";
+    const failedTestNames = [];
+    const testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none");
 
-  const testRun = testResult?.testRun;
-
-  if (testRun && testRun?.status === "completed") {
-    const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
-    if (errorsPresent === false) {
+    if (!testResult) {
       status = "PASSED";
-      consola.success(status);
-      return status;
+    } else {
+      const testRun = testResult?.testRun;
+
+      if (testRun && testRun?.status === "completed") {
+        const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
+        if (errorsPresent === false) {
+          status = "PASSED";
+        } else {
+          // Extract failed test names
+          const testNames = Object.keys(testRun.tests).sort();
+          testNames.forEach((testName) => {
+            const testErrorsPresent = checkTestErrorsPresent(testName, testRun.tests);
+            if (testErrorsPresent) {
+              failedTestNames.push(testName);
+            }
+          });
+        }
+      }
     }
-  }
-  consola.error(status);
-  return status;
+
+    if (status === "PASSED") {
+      consola.success(`${singleHandle}: ${status}`);
+    } else {
+      consola.error(`${singleHandle}: ${status}`);
+      // Display failed test names
+      failedTestNames.forEach((testName) => {
+        consola.log(`  ${testName}: FAILED`);
+      });
+    }
+
+    return { handle: singleHandle, status, failedTestNames };
+  };
+
+  const results = await Promise.all(handles.map(runSingleHandle));
+
+  const overallStatus = results.every((result) => result.status === "PASSED") ? "PASSED" : "FAILED";
+
+  return overallStatus;
 }
 
 module.exports = {

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -421,14 +421,11 @@ async function runTestsWithOutput(firmId, templateType, handle, testName = "", p
 
 // RETURN (AND LOG) ONLY PASSED OR FAILED
 // CAN BE USED BY GITHUB ACTIONS
-async function runTestsStatusOnly(firmId, templateType, handle, testName = "") {
+async function runTestsStatusOnly(firmId, templateType, handles, testName = "") {
   if (templateType !== "reconciliationText" && templateType !== "accountTemplate") {
     consola.error(`Template type is missing or invalid`);
     process.exit(1);
   }
-
-  // handle can be an array (multiple handles/templates) or a string (single handle/template)
-  const handles = Array.isArray(handle) ? handle : [handle];
 
   const runSingleHandle = async (singleHandle) => {
     let status = "FAILED";
@@ -458,9 +455,9 @@ async function runTestsStatusOnly(firmId, templateType, handle, testName = "") {
     }
 
     if (status === "PASSED") {
-      consola.success(`${singleHandle}: ${status}`);
+      consola.log(`${singleHandle}: ${status}`);
     } else {
-      consola.error(`${singleHandle}: ${status}`);
+      consola.log(`${singleHandle}: ${status}`);
       // Display failed test names
       failedTestNames.forEach((testName) => {
         consola.log(`  ${testName}: FAILED`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.51.0",
+      "version": "1.52.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "version": "25.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
+      "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1561,9 +1561,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001762",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.47.0",
+  "version": "1.50.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.50.0",
+  "version": "1.48.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

Multiple handles/AT's can now be passed to the run-test command:

e.g. `silverfin run-test -f 200619 -h be_pit_wages_salaries_part_2 be_pit_wages_salaries --status`
or  `silverfin run-test -f 14400 -h 'Dubieuze debiteuren' 'Erelonen' --status`


Note that I only allowed/activated it for the status flag since this will cover our usecase for now (Github actions). 
This can be expanded later on if required.

Had some issues with the handle flag being rendered as an array in case there was only 1 element/handle, but some checks solved this issue. 

Reporting is done per handle (and if differences, we show the units/tests as well). 

QQ: in general, this is quicker than running them one by one, but in some cases, the API seems to be very slow. Is there a way in which we can avoid that? 

## Testing Instructions

Steps:

1. Run tests with multiple handles
2. Run tests with one handle
3. Run test without staus flag


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
