### PR TITLE
Check cross-template dependencies using liquid test YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.53.0] (11/02/2026)
+We have introduced a new command `silverfin check-dependencies -h reconciliation_handle`.
+Currently, it only works for reconciliation templates and detects which templates reference the given handle in their Liquid Test data.
+
 ## [1.52.2] (11/02/2026)
 Update description of the `silverfin update-all-templates` command
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,6 +18,7 @@ const { consola } = require("consola");
 const { runCommandChecks } = require("../lib/cli/utils");
 const { CwdValidator } = require("../lib/cli/cwdValidator");
 const { AutoCompletions } = require("../lib/cli/autoCompletions");
+const fsUtils = require("../lib/utils/fsUtils");
 
 const firmIdDefault = cliUtils.loadDefaultFirmId();
 cliUtils.handleUncaughtErrors();
@@ -524,6 +525,21 @@ program
     const reconciledStatus = options.unreconciled ? false : true;
     const testName = options.test ? options.test : "test_name";
     liquidTestGenerator.testGenerator(options.url, testName, reconciledStatus);
+  });
+
+// Check Liquid Test dependencies for a reconciliation template
+program
+  .command("check-dependencies")
+  .description("List reconciliation templates whose Liquid Tests reference the given handle")
+  .requiredOption("-h, --handle <handle>", "Specify the reconciliation handle to check dependencies for")
+  .action((options) => {
+    const dependentHandles = fsUtils.checkLiquidTestDependencies(options.handle);
+    if (dependentHandles.length === 0) {
+      consola.info(`No other reconciliation templates reference "${options.handle}" in their Liquid Test data.`);
+    } else {
+      consola.info(`Templates that reference "${options.handle}" in their Liquid Test data:`);
+      dependentHandles.forEach((handle) => consola.log(`  - ${handle}`));
+    }
   });
 
 // Authorize APP

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -355,6 +355,59 @@ function listExistingRelatedLiquidFiles(firmId, handle, templateType) {
   return relatedLiquidFiles;
 }
 
+// Find all templates with liquid test YAML files in reconciliation_texts directories
+// Only matches files whose basename ends with exactly `_liquid_test.yml`
+// Also excludes files with extra suffixes like `_TY21_liquid_test.yml`, `_TY23_liquid_test.yml`, etc.
+// Returns an array of template handles that have liquid test files
+function findTemplatesWithLiquidTests() {
+  const results = [];
+  const folderPath = path.join(process.cwd(), FOLDERS.reconciliationText);
+
+  if (!fs.existsSync(folderPath)) {
+    return results;
+  }
+
+  const templateDirs = fs.readdirSync(folderPath);
+  for (const handle of templateDirs) {
+    const templateDir = path.join(folderPath, handle);
+    const stats = fs.statSync(templateDir);
+    if (!stats.isDirectory()) {
+      continue;
+    }
+
+    const testsDir = path.join(templateDir, "tests");
+    if (!fs.existsSync(testsDir)) {
+      continue;
+    }
+
+    const testFiles = fs.readdirSync(testsDir);
+    for (const fileName of testFiles) {
+      // Match files ending with exactly `_liquid_test.yml` (no extra suffix)
+      // Pattern: any handle followed by `_liquid_test.yml`, but exclude variants with extra suffixes like `_TY21`, `_TY23`
+      const mainPattern = /^(.+)_liquid_test\.yml$/;
+      const match = fileName.match(mainPattern);
+
+      if (match) {
+        const fileHandle = match[1];
+        // Exclude files with variant suffixes (e.g., `_TY21`, `_TY23`, etc.)
+        // These patterns typically have uppercase letters followed by digits before `_liquid_test`
+        const variantPattern = /_[A-Z]{2,}\d+$/; // Matches patterns like `_TY21`, `_TY23`, `_TY2021`, etc.
+        if (variantPattern.test(fileHandle)) {
+          continue; // Skip variant files
+        }
+
+        // Add the handle to results (avoid duplicates)
+        if (!results.includes(handle)) {
+          results.push(handle);
+        }
+        break; // Found liquid test file for this template, move to next template
+      }
+    }
+  }
+
+  return results;
+}
+
 // Recursive option for fs.watch is not available in every OS (e.g. Linux)
 function recursiveInspectDirectory({ basePath, collection, pathsArray = [], typeCheck = "liquid" }) {
   collection.forEach((filePath) => {
@@ -437,6 +490,7 @@ module.exports = {
   listSharedPartsUsedInTemplate,
   listExistingFiles,
   listExistingRelatedLiquidFiles,
+  findTemplatesWithLiquidTests,
   identifyTypeAndHandle,
   getTemplateId,
   setTemplateId,

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -440,6 +440,11 @@ function checkLiquidTestDependencies(target_handle) {
   };
 
   for (const handle of allHandlesWithTests) {
+    // Skip self-reference: a template mentioning itself in its own Liquid Test data
+    // shouldn't be considered a dependency for CI purposes.
+    if (handle === target_handle) {
+      continue;
+    }
     const liquidTestPath = path.join(
       process.cwd(),
       FOLDERS.reconciliationText,

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const yaml = require("yaml");
 const { consola } = require("consola");
 
 const FOLDERS = {
@@ -408,6 +409,72 @@ function findTemplatesWithLiquidTests() {
   return results;
 }
 
+// Find all templates that have a dependency on the given handle.
+// Loops through all templates with liquid test files and checks if their YAML files
+// mention the given handle in the data subtree.
+// Currently only checks reconciliation texts (excludes account templates).
+// @param {string} target_handle - The handle to search for in other templates' test files
+// @returns {Array<string>} Array of handles that depend on the target_handle
+function checkLiquidTestDependencies(target_handle) {
+  const dependentHandles = [];
+  const allHandlesWithTests = findTemplatesWithLiquidTests();
+
+  // Recursively check if target_handle appears in the data subtree
+  const containsHandle = (obj, handle) => {
+    if (obj === null || obj === undefined) return false;
+    if (typeof obj === "string") {
+      return obj === handle;
+    }
+    if (Array.isArray(obj)) {
+      return obj.some((item) => containsHandle(item, handle));
+    }
+    if (typeof obj === "object") {
+      // Check keys
+      if (Object.keys(obj).some((key) => key === handle)) {
+        return true;
+      }
+      // Check values
+      return Object.values(obj).some((value) => containsHandle(value, handle));
+    }
+    return false;
+  };
+
+  for (const handle of allHandlesWithTests) {
+    const liquidTestPath = path.join(
+      process.cwd(),
+      FOLDERS.reconciliationText,
+      handle,
+      "tests",
+      `${handle}_liquid_test.yml`
+    );
+
+    try {
+      const testContent = fs.readFileSync(liquidTestPath, "utf-8");
+      const testYAML = yaml.parse(testContent, { maxAliasCount: 10000 });
+
+      if (!testYAML || typeof testYAML !== "object") {
+        continue;
+      }
+
+      // Check each test case's data subtree
+      for (const testCaseName of Object.keys(testYAML)) {
+        const testCase = testYAML[testCaseName];
+        if (testCase && typeof testCase === "object" && testCase.data) {
+          if (containsHandle(testCase.data, target_handle)) {
+            dependentHandles.push(handle);
+            break; // Found in this template, move to next template
+          }
+        }
+      }
+    } catch (error) {
+      // Skip templates with parsing errors or missing files
+      continue;
+    }
+  }
+
+  return dependentHandles;
+}
+
 // Recursive option for fs.watch is not available in every OS (e.g. Linux)
 function recursiveInspectDirectory({ basePath, collection, pathsArray = [], typeCheck = "liquid" }) {
   collection.forEach((filePath) => {
@@ -494,4 +561,5 @@ module.exports = {
   identifyTypeAndHandle,
   getTemplateId,
   setTemplateId,
+  checkLiquidTestDependencies,
 };

--- a/lib/utils/fsUtils.js
+++ b/lib/utils/fsUtils.js
@@ -413,13 +413,13 @@ function findTemplatesWithLiquidTests() {
 // Loops through all templates with liquid test files and checks if their YAML files
 // mention the given handle in the data subtree.
 // Currently only checks reconciliation texts (excludes account templates).
-// @param {string} target_handle - The handle to search for in other templates' test files
-// @returns {Array<string>} Array of handles that depend on the target_handle
-function checkLiquidTestDependencies(target_handle) {
+// @param {string} targetHandle - The handle to search for in other templates' test files
+// @returns {Array<string>} Array of handles that depend on the targetHandle
+function checkLiquidTestDependencies(targetHandle) {
   const dependentHandles = [];
   const allHandlesWithTests = findTemplatesWithLiquidTests();
 
-  // Recursively check if target_handle appears in the data subtree
+  // Recursively check if targetHandle appears in the data subtree
   const containsHandle = (obj, handle) => {
     if (obj === null || obj === undefined) return false;
     if (typeof obj === "string") {
@@ -442,7 +442,7 @@ function checkLiquidTestDependencies(target_handle) {
   for (const handle of allHandlesWithTests) {
     // Skip self-reference: a template mentioning itself in its own Liquid Test data
     // shouldn't be considered a dependency for CI purposes.
-    if (handle === target_handle) {
+    if (handle === targetHandle) {
       continue;
     }
     const liquidTestPath = path.join(
@@ -465,7 +465,7 @@ function checkLiquidTestDependencies(target_handle) {
       for (const testCaseName of Object.keys(testYAML)) {
         const testCase = testYAML[testCaseName];
         if (testCase && typeof testCase === "object" && testCase.data) {
-          if (containsHandle(testCase.data, target_handle)) {
+          if (containsHandle(testCase.data, targetHandle)) {
             dependentHandles.push(handle);
             break; // Found in this template, move to next template
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.52.2",
+  "version": "1.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.52.2",
+      "version": "1.53.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.52.2",
+  "version": "1.53.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/templates/accountTemplates.test.js
+++ b/tests/lib/templates/accountTemplates.test.js
@@ -65,25 +65,30 @@ describe("AccountTemplate", () => {
       test_firm_id: null,
     };
 
-    const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(tempDir, "account_templates", name_nl);
-    const configPath = path.join(expectedFolderPath, "config.json");
-    const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
-    const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
-    const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
-    const testLiquidPath = path.join(expectedFolderPath, "tests", `${name_nl}_liquid_test.yml`);
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let expectedFolderPath;
+    let configPath;
+    let mainLiquidPath;
+    let part1LiquidPath;
+    let oldPartLiquidPath;
+    let testLiquidPath;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+
+      expectedFolderPath = path.join(tempDir, "account_templates", name_nl);
+      configPath = path.join(expectedFolderPath, "config.json");
+      mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
+      part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
+      oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
+      testLiquidPath = path.join(expectedFolderPath, "tests", `${name_nl}_liquid_test.yml`);
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir, { recursive: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 

--- a/tests/lib/templates/exportFiles.test.js
+++ b/tests/lib/templates/exportFiles.test.js
@@ -66,24 +66,28 @@ describe("ExportFile", () => {
       },
     };
 
-    const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(tempDir, "export_files", name_nl);
-    const configPath = path.join(expectedFolderPath, "config.json");
-    const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
-    const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
-    const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let expectedFolderPath;
+    let configPath;
+    let mainLiquidPath;
+    let part1LiquidPath;
+    let oldPartLiquidPath;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+
+      expectedFolderPath = path.join(tempDir, "export_files", name_nl);
+      configPath = path.join(expectedFolderPath, "config.json");
+      mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
+      part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
+      oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir, { recursive: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 

--- a/tests/lib/templates/reconciliationTexts.test.js
+++ b/tests/lib/templates/reconciliationTexts.test.js
@@ -80,26 +80,32 @@ describe("ReconciliationText", () => {
       test_firm_id: null,
     };
 
-    const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(tempDir, "reconciliation_texts", handle);
-    const configPath = path.join(expectedFolderPath, "config.json");
-    const mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
-    const testLiquidPath = path.join(expectedFolderPath, "tests", `${handle}_liquid_test.yml`);
-    const readmePath = path.join(expectedFolderPath, "tests", "README.md");
-    const part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
-    const oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let expectedFolderPath;
+    let configPath;
+    let mainLiquidPath;
+    let testLiquidPath;
+    let readmePath;
+    let part1LiquidPath;
+    let oldPartLiquidPath;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+
+      expectedFolderPath = path.join(tempDir, "reconciliation_texts", handle);
+      configPath = path.join(expectedFolderPath, "config.json");
+      mainLiquidPath = path.join(expectedFolderPath, "main.liquid");
+      testLiquidPath = path.join(expectedFolderPath, "tests", `${handle}_liquid_test.yml`);
+      readmePath = path.join(expectedFolderPath, "tests", "README.md");
+      part1LiquidPath = path.join(expectedFolderPath, "text_parts", "part_1.liquid");
+      oldPartLiquidPath = path.join(expectedFolderPath, "text_parts", "old_part.liquid");
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir, { recursive: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 

--- a/tests/lib/templates/sharedParts.test.js
+++ b/tests/lib/templates/sharedParts.test.js
@@ -29,22 +29,24 @@ describe("SharedPart", () => {
       externally_managed: true,
     };
 
-    const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(tempDir, "shared_parts", name);
-    const mainLiquidPath = path.join(expectedFolderPath, `${name}.liquid`);
-    const configPath = path.join(expectedFolderPath, "config.json");
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let expectedFolderPath;
+    let mainLiquidPath;
+    let configPath;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+
+      expectedFolderPath = path.join(tempDir, "shared_parts", name);
+      mainLiquidPath = path.join(expectedFolderPath, `${name}.liquid`);
+      configPath = path.join(expectedFolderPath, "config.json");
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir, { recursive: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 
@@ -75,10 +77,11 @@ describe("SharedPart", () => {
 
   describe("read", () => {
     const name = "example_shared_part_name";
-    const tempDir = path.join(process.cwd(), "tmp");
-    const expectedFolderPath = path.join(tempDir, "shared_parts", name);
-    const mainLiquidPath = path.join(expectedFolderPath, `${name}.liquid`);
-    const configPath = path.join(expectedFolderPath, "config.json");
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let expectedFolderPath;
+    let mainLiquidPath;
+    let configPath;
 
     const configContent = {
       id: { 100: 808080 },
@@ -90,10 +93,12 @@ describe("SharedPart", () => {
     };
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+
+      expectedFolderPath = path.join(tempDir, "shared_parts", name);
+      mainLiquidPath = path.join(expectedFolderPath, `${name}.liquid`);
+      configPath = path.join(expectedFolderPath, "config.json");
 
       // Create necessary directories and files
       fs.mkdirSync(expectedFolderPath, { recursive: true });
@@ -106,9 +111,8 @@ describe("SharedPart", () => {
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir, { recursive: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 

--- a/tests/lib/utils/checkLiquidTestDependencies.test.js
+++ b/tests/lib/utils/checkLiquidTestDependencies.test.js
@@ -11,16 +11,14 @@ describe("fsUtils", () => {
     let reconciliationTextsDir;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+      reconciliationTextsDir = path.join(tempDir, "reconciliation_texts");
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 

--- a/tests/lib/utils/checkLiquidTestDependencies.test.js
+++ b/tests/lib/utils/checkLiquidTestDependencies.test.js
@@ -407,6 +407,47 @@ test_case_1:
       expect(result).not.toContain(targetHandle);
     });
 
+    it("should not include the target handle itself (self-reference)", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const selfDir = path.join(reconciliationTextsDir, targetHandle);
+      const dependentDir = path.join(reconciliationTextsDir, dependentHandle);
+
+      fs.mkdirSync(path.join(selfDir, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(dependentDir, "tests"), { recursive: true });
+
+      // Target template references itself (should be ignored)
+      fs.writeFileSync(
+        path.join(selfDir, "tests", `${targetHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      // Another template references targetHandle (should be found)
+      fs.writeFileSync(
+        path.join(dependentDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+      expect(result).not.toContain(targetHandle);
+    });
+
     it("should handle parsing errors gracefully", () => {
       const targetHandle = "target_template";
       const validHandle = "template_one";

--- a/tests/lib/utils/checkLiquidTestDependencies.test.js
+++ b/tests/lib/utils/checkLiquidTestDependencies.test.js
@@ -1,0 +1,445 @@
+const fs = require("fs");
+const path = require("path");
+const fsUtils = require("../../../lib/utils/fsUtils");
+
+jest.mock("consola");
+
+describe("fsUtils", () => {
+  describe("checkLiquidTestDependencies", () => {
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let reconciliationTextsDir;
+
+    beforeEach(() => {
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+      jest.resetAllMocks();
+    });
+
+    it("should return empty array when no templates depend on the target handle", () => {
+      const targetHandle = "target_template";
+      const handle1 = "template_one";
+      const handle2 = "template_two";
+
+      const templateDir1 = path.join(reconciliationTextsDir, handle1);
+      const templateDir2 = path.join(reconciliationTextsDir, handle2);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      // Create test files that don't reference targetHandle
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${handle1}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          other_template: {}
+`
+      );
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${handle2}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          another_template: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toEqual([]);
+    });
+
+    it("should find templates that reference target handle in data subtree as string values", () => {
+      const targetHandle = "target_template";
+      const dependentHandle1 = "template_one";
+      const dependentHandle2 = "template_two";
+      const independentHandle = "template_three";
+
+      const templateDir1 = path.join(reconciliationTextsDir, dependentHandle1);
+      const templateDir2 = path.join(reconciliationTextsDir, dependentHandle2);
+      const templateDir3 = path.join(reconciliationTextsDir, independentHandle);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir3, "tests"), { recursive: true });
+
+      // Template 1 references targetHandle as a value
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${dependentHandle1}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          some_field: ${targetHandle}
+`
+      );
+
+      // Template 2 references targetHandle as a value
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${dependentHandle2}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          nested:
+            deep: ${targetHandle}
+`
+      );
+
+      // Template 3 doesn't reference targetHandle
+      fs.writeFileSync(
+        path.join(templateDir3, "tests", `${independentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          other_template: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle1);
+      expect(result).toContain(dependentHandle2);
+      expect(result).not.toContain(independentHandle);
+    });
+
+    it("should find templates that reference target handle in data subtree as keys", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+      const independentHandle = "template_two";
+
+      const templateDir1 = path.join(reconciliationTextsDir, dependentHandle);
+      const templateDir2 = path.join(reconciliationTextsDir, independentHandle);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      // Template 1 references targetHandle as a key
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}:
+            some_field: value
+`
+      );
+
+      // Template 2 doesn't reference targetHandle
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${independentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          other_template: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+      expect(result).not.toContain(independentHandle);
+    });
+
+    it("should only scan data subtree, not context or expectation", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+      const independentHandle = "template_two";
+
+      const templateDir1 = path.join(reconciliationTextsDir, dependentHandle);
+      const templateDir2 = path.join(reconciliationTextsDir, independentHandle);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      // Template 1 has targetHandle in data (should be found)
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  context:
+    period: "2024-01-01"
+    some_field: ${targetHandle}
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+  expectation:
+    reconciled: true
+    results:
+      ${targetHandle}: some_value
+`
+      );
+
+      // Template 2 has targetHandle only in context/expectation (should NOT be found)
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${independentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  context:
+    period: "2024-01-01"
+    some_field: ${targetHandle}
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          other_template: {}
+  expectation:
+    reconciled: true
+    results:
+      ${targetHandle}: some_value
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+      expect(result).not.toContain(independentHandle);
+    });
+
+    it("should handle nested structures in data", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const templateDir = path.join(reconciliationTextsDir, dependentHandle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // Nested structure with targetHandle
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          nested:
+            deep:
+              value: ${targetHandle}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+    });
+
+    it("should handle arrays in data", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const templateDir = path.join(reconciliationTextsDir, dependentHandle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // targetHandle in arrays
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          list:
+            - ${targetHandle}
+            - other_template
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+    });
+
+    it("should only check templates with liquid test files", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_with_test";
+      const handleWithoutTest = "template_without_test";
+
+      const templateDir1 = path.join(reconciliationTextsDir, dependentHandle);
+      const templateDir2 = path.join(reconciliationTextsDir, handleWithoutTest);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(templateDir2, { recursive: true }); // No tests directory
+
+      // Template with test references targetHandle
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      // Template without test (won't be checked)
+      // Even if it had a reference, it wouldn't be found
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+      expect(result).not.toContain(handleWithoutTest);
+    });
+
+    it("should handle multiple test cases", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const templateDir = path.join(reconciliationTextsDir, dependentHandle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // Multiple test cases, targetHandle in second one
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          other_template: {}
+
+test_case_2:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+    });
+
+    it("should return unique handles even if target appears multiple times", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const templateDir = path.join(reconciliationTextsDir, dependentHandle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // Same handle appears multiple times
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+          nested:
+            ${targetHandle}: {}
+            array:
+              - ${targetHandle}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(dependentHandle);
+    });
+
+    it("should not include the target handle itself (self-reference)", () => {
+      const targetHandle = "target_template";
+      const dependentHandle = "template_one";
+
+      const selfDir = path.join(reconciliationTextsDir, targetHandle);
+      const dependentDir = path.join(reconciliationTextsDir, dependentHandle);
+
+      fs.mkdirSync(path.join(selfDir, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(dependentDir, "tests"), { recursive: true });
+
+      // Target template references itself (should be ignored)
+      fs.writeFileSync(
+        path.join(selfDir, "tests", `${targetHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      // Another template references targetHandle (should be found)
+      fs.writeFileSync(
+        path.join(dependentDir, "tests", `${dependentHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(dependentHandle);
+      expect(result).not.toContain(targetHandle);
+    });
+
+    it("should handle parsing errors gracefully", () => {
+      const targetHandle = "target_template";
+      const validHandle = "template_one";
+      const invalidHandle = "template_invalid";
+
+      const templateDir1 = path.join(reconciliationTextsDir, validHandle);
+      const templateDir2 = path.join(reconciliationTextsDir, invalidHandle);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      // Valid template with targetHandle
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${validHandle}_liquid_test.yml`),
+        `
+test_case_1:
+  data:
+    periods:
+      "2024-01-01":
+        reconciliations:
+          ${targetHandle}: {}
+`
+      );
+
+      // Invalid YAML (should be skipped)
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${invalidHandle}_liquid_test.yml`),
+        "invalid: yaml: content: ["
+      );
+
+      const result = fsUtils.checkLiquidTestDependencies(targetHandle);
+      expect(result).toContain(validHandle);
+      expect(result).not.toContain(invalidHandle);
+    });
+  });
+});

--- a/tests/lib/utils/findTemplatesWithLiquidTests.test.js
+++ b/tests/lib/utils/findTemplatesWithLiquidTests.test.js
@@ -1,0 +1,196 @@
+const fs = require("fs");
+const path = require("path");
+const fsUtils = require("../../../lib/utils/fsUtils");
+
+jest.mock("consola");
+
+describe("fsUtils", () => {
+  describe("findTemplatesWithLiquidTests", () => {
+    const tempDir = path.join(process.cwd(), "tmp");
+    const reconciliationTextsDir = path.join(tempDir, "reconciliation_texts");
+
+    beforeEach(() => {
+      if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir, { recursive: true });
+      }
+      process.chdir(tempDir);
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+      jest.resetAllMocks();
+    });
+
+    it("should return empty array when reconciliation_texts directory does not exist", () => {
+      const result = fsUtils.findTemplatesWithLiquidTests();
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when no test files exist", () => {
+      const templateDir = path.join(reconciliationTextsDir, "test_template");
+      fs.mkdirSync(templateDir, { recursive: true });
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+      expect(result).toEqual([]);
+    });
+
+    it("should find templates with liquid test files", () => {
+      const handle1 = "template_one";
+      const handle2 = "template_two";
+      const templateDir1 = path.join(reconciliationTextsDir, handle1);
+      const templateDir2 = path.join(reconciliationTextsDir, handle2);
+
+      // Create directories and test files
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${handle1}_liquid_test.yml`),
+        "test: content"
+      );
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${handle2}_liquid_test.yml`),
+        "test: content"
+      );
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(expect.arrayContaining([handle1, handle2]));
+    });
+
+    it("should exclude variant files with TY suffix (e.g., _TY21, _TY23)", () => {
+      const handle = "test_template";
+      const templateDir = path.join(reconciliationTextsDir, handle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // Create main test file
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_liquid_test.yml`),
+        "test: content"
+      );
+
+      // Create variant files (should be excluded)
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_TY21_liquid_test.yml`),
+        "test: variant content"
+      );
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_TY23_liquid_test.yml`),
+        "test: variant content"
+      );
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(handle);
+    });
+
+    it("should exclude variant files with other uppercase suffix patterns", () => {
+      const handle = "test_template";
+      const templateDir = path.join(reconciliationTextsDir, handle);
+      fs.mkdirSync(path.join(templateDir, "tests"), { recursive: true });
+
+      // Create main test file
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_liquid_test.yml`),
+        "test: content"
+      );
+
+      // Create variant files with different patterns (should be excluded)
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_TY2021_liquid_test.yml`),
+        "test: variant content"
+      );
+      fs.writeFileSync(
+        path.join(templateDir, "tests", `${handle}_AB123_liquid_test.yml`),
+        "test: variant content"
+      );
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(handle);
+    });
+
+    it("should only search in reconciliation_texts, not account_templates", () => {
+      const reconciliationHandle = "reconciliation_template";
+      const accountTemplateName = "account_template_name_nl"; // Account templates use name_nl, not handle
+      const reconciliationDir = path.join(reconciliationTextsDir, reconciliationHandle);
+      const accountTemplatesDir = path.join(tempDir, "account_templates", accountTemplateName);
+
+      fs.mkdirSync(path.join(reconciliationDir, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(accountTemplatesDir, "tests"), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(reconciliationDir, "tests", `${reconciliationHandle}_liquid_test.yml`),
+        "test: content"
+      );
+      // Account templates use name_nl for the test file name
+      fs.writeFileSync(
+        path.join(accountTemplatesDir, "tests", `${accountTemplateName}_liquid_test.yml`),
+        "test: content"
+      );
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(reconciliationHandle);
+      expect(result).not.toContain(accountTemplateName);
+    });
+
+    it("should skip directories without tests folder", () => {
+      const handle = "template_no_tests";
+      const templateDir = path.join(reconciliationTextsDir, handle);
+      fs.mkdirSync(templateDir, { recursive: true });
+      // No tests directory created
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+      expect(result).toEqual([]);
+    });
+
+    it("should skip non-directory files in reconciliation_texts", () => {
+      fs.mkdirSync(reconciliationTextsDir, { recursive: true });
+      const filePath = path.join(reconciliationTextsDir, "not_a_directory.txt");
+      fs.writeFileSync(filePath, "not a directory");
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+      expect(result).toEqual([]);
+    });
+
+    it("should handle multiple templates with mixed main and variant files", () => {
+      const handle1 = "template_one";
+      const handle2 = "template_two";
+      const templateDir1 = path.join(reconciliationTextsDir, handle1);
+      const templateDir2 = path.join(reconciliationTextsDir, handle2);
+
+      fs.mkdirSync(path.join(templateDir1, "tests"), { recursive: true });
+      fs.mkdirSync(path.join(templateDir2, "tests"), { recursive: true });
+
+      // Template 1: main test file + variants
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${handle1}_liquid_test.yml`),
+        "test: content"
+      );
+      fs.writeFileSync(
+        path.join(templateDir1, "tests", `${handle1}_TY21_liquid_test.yml`),
+        "test: variant"
+      );
+
+      // Template 2: only main test file
+      fs.writeFileSync(
+        path.join(templateDir2, "tests", `${handle2}_liquid_test.yml`),
+        "test: content"
+      );
+
+      const result = fsUtils.findTemplatesWithLiquidTests();
+
+      expect(result).toHaveLength(2);
+      expect(result.sort()).toEqual([handle1, handle2].sort());
+    });
+  });
+});
+

--- a/tests/lib/utils/findTemplatesWithLiquidTests.test.js
+++ b/tests/lib/utils/findTemplatesWithLiquidTests.test.js
@@ -6,20 +6,19 @@ jest.mock("consola");
 
 describe("fsUtils", () => {
   describe("findTemplatesWithLiquidTests", () => {
-    const tempDir = path.join(process.cwd(), "tmp");
-    const reconciliationTextsDir = path.join(tempDir, "reconciliation_texts");
+    const repoRoot = path.resolve(__dirname, "../../..");
+    let tempDir;
+    let reconciliationTextsDir;
 
     beforeEach(() => {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
+      tempDir = fs.mkdtempSync(path.join(repoRoot, "tmp-"));
       process.chdir(tempDir);
+      reconciliationTextsDir = path.join(tempDir, "reconciliation_texts");
     });
 
     afterEach(() => {
-      if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      process.chdir(repoRoot);
+      if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
       jest.resetAllMocks();
     });
 


### PR DESCRIPTION
## Description

We have introduced a new command `silverfin check-dependencies`.
Currently, it only works for reconciliation templates and detects which templates reference the given handle in their Liquid Test data.

## Testing Instructions

Steps:

1. Run `silverfin check-dependencies -h reconciliation_handle`

## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced are covered by tests of acceptable quality
