### PR TITLE
Raise error when it fails to fetch the access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.54.2] (13/05/2026)
+Fix error reporting in `silverfin authorize`, `refresh-token`, and the partner-key refresh: previously some failures (notably network-layer errors with no HTTP response) crashed with `Cannot read properties of undefined (reading 'status')` or exited silently — they now print the underlying error so the cause is visible.
+
 ## [1.54.1] (14/04/2026)
 Increase the waiting time for the test runs to avoid timeout errors.
 

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -70,6 +70,9 @@ class SilverfinAuthorizer {
           description ? `\nError description: ${description}` : "",
           "\nError refreshing the tokens. Try running the authentication process again"
         );
+      } else {
+        consola.error("Error refreshing the tokens. Try running the authentication process again");
+        consola.error(error);
       }
       process.exit(1);
     }
@@ -100,6 +103,9 @@ class SilverfinAuthorizer {
     } catch (error) {
       if (error.response) {
         consola.error(`Response Status: ${error.response.status} (${error.response.statusText}). An error occurred trying to refresh the partner API key`);
+      } else {
+        consola.error("An error occurred trying to refresh the partner API key");
+        consola.error(error);
       }
       process.exit(1);
     }
@@ -159,8 +165,15 @@ class SilverfinAuthorizer {
 
       return true;
     } catch (error) {
-      consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
-      consola.error(`Error description: ${JSON.stringify(error.response.data.error_description)}`);
+      if (error.response) {
+        consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
+        if (error.response.data?.error_description) {
+          consola.error(`Error description: ${JSON.stringify(error.response.data.error_description)}`);
+        }
+      } else {
+        consola.error("Failed to obtain the firm access token");
+        consola.error(error);
+      }
       process.exit(1);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.54.1",
+      "version": "1.54.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Fixes # (link to the corresponding issue if applicable)

## Description

Raise error when it fails to fetch the access token and there is no `error.response` most likely due to network issues. This will help us debug where the issue comes from in these cases

## Testing Instructions

Steps:

1. ...
2. ...
3. ...


## Author Checklist

- [ ] Skip bumping the CLI version

## Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced are covered by tests of acceptable quality
