### PR TITLE
Send Basic auth on firm OAuth token requests only when staging requires it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.56.2] (25/06/2026)
+Send the staging HTTP Basic Auth header on firm OAuth token requests only when the staging gateway actually requires it (detected via a one-time `WWW-Authenticate: Basic` probe). Fixes `silverfin authorize` and token refresh failing with "unknown client" on stagings that have HTTP basic auth disabled.
+
 ## [1.56.1] (08/06/2026)
 Increase the waiting time for the test runs to avoid timeout errors.
 

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -87,7 +87,14 @@ class AxiosFactory {
       required = /basic/i.test(response?.headers?.["www-authenticate"] || "");
     } catch (error) {
       // A Basic challenge can surface as a thrown error depending on the transport; inspect it too.
-      required = /basic/i.test(error?.response?.headers?.["www-authenticate"] || "");
+      // But a transport-level failure (timeout/DNS/TLS) has no response and is indeterminate: never
+      // cache it as "gateway disabled", or one transient blip would suppress the Basic header for the
+      // rest of the process and break every following token exchange on a gated host. Re-throw so the
+      // caller fails loudly and the next attempt re-probes.
+      if (!error?.response) {
+        throw error;
+      }
+      required = /basic/i.test(error.response.headers?.["www-authenticate"] || "");
     }
 
     this.#basicGateByHost[host] = required;

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -6,6 +6,9 @@ const pkg = require("../../package.json");
 class AxiosFactory {
   constructor() {}
 
+  // Cache of "does this staging host sit behind an HTTP Basic Auth gateway", keyed by host.
+  static #basicGateByHost = {};
+
   /**
    * Create an axios instance for a given type and environment id.
    * It will add the necessary headers and interceptors to handle the authorization, and refresh the tokens if needed.
@@ -34,37 +37,61 @@ class AxiosFactory {
   }
 
   /**
-   * Create an axios instance for a given environment id (type firm)
-   * It will add the necessary headers to handle the authorization, for example Basic Auth for staging.
-   * It won't have any token refresh mechanism, and it won't check or load the tokens from the credentials file.
-   * It is intended to be used for the authorization process, where tokens could not be available yet.
+   * Create an axios instance for a firm's OAuth token endpoint (initial authorize and token refresh).
+   * It has no token-refresh interceptor and does not read stored tokens, so it is safe to use during
+   * the authorization process when tokens are not available yet.
+   *
+   * On staging the HTTP Basic Auth header is attached ONLY when the staging gateway actually requires
+   * it (see #stagingRequiresBasicAuth). When the gateway is disabled the header is omitted, because
+   * Doorkeeper would otherwise mistake the gateway credentials for the OAuth client and reject the
+   * request with "unknown client". On production the header is never added.
    * @param {Number} envId - The environment id to create the instance for
-   * @returns {Object} - The created axios instance
+   * @returns {Promise<Object>} - The created axios instance
    */
-  static createAuthInstanceForFirm(envId) {
+  static async createTokenInstanceForFirm(envId) {
     this.BASE_URL = firmCredentials.getHost();
-    return this.#createSimpleAxiosInstanceForFirms(envId);
-  }
-
-  // PRIVATE METHODS
-
-  static #createSimpleAxiosInstanceForFirms(envId) {
-    const baseHeaders = {
-      "User-Agent": `silverfin-cli/${pkg.version}`,
-      "X-Firm-ID": envId,
-    };
 
     const axiosDetails = {
       baseURL: `${this.BASE_URL}/api/v4/f/${envId}`,
       headers: {
-        ...baseHeaders,
+        "User-Agent": `silverfin-cli/${pkg.version}`,
+        "X-Firm-ID": envId,
       },
     };
-    if (this.#isStaging()) {
+    if (await this.#stagingRequiresBasicAuth()) {
       axiosDetails.headers.Authorization = this.#basicAuthHeader();
     }
 
     return axios.create(axiosDetails);
+  }
+
+  // PRIVATE METHODS
+
+  /**
+   * Detect whether the current host sits behind an HTTP Basic Auth gateway (only staging hosts can).
+   * Such a gateway answers an unauthenticated request with `401 WWW-Authenticate: Basic`. When it is
+   * present the OAuth token request needs the Basic header to get through; when it is absent (a staging
+   * set up with "disable HTTP basic auth") the header must be omitted, or Doorkeeper reads the gateway
+   * credentials as the OAuth client and fails. The result is cached per host.
+   * @returns {Promise<Boolean>}
+   */
+  static async #stagingRequiresBasicAuth() {
+    if (!this.#isStaging()) return false;
+
+    const host = firmCredentials.getHost();
+    if (Object.hasOwn(this.#basicGateByHost, host)) return this.#basicGateByHost[host];
+
+    let required = false;
+    try {
+      const response = await axios.get(host, { validateStatus: () => true, maxRedirects: 0, timeout: 10000 });
+      required = /basic/i.test(response?.headers?.["www-authenticate"] || "");
+    } catch (error) {
+      // A Basic challenge can surface as a thrown error depending on the transport; inspect it too.
+      required = /basic/i.test(error?.response?.headers?.["www-authenticate"] || "");
+    }
+
+    this.#basicGateByHost[host] = required;
+    return required;
   }
 
   static #createAxiosInstanceForFirms(envId) {
@@ -271,8 +298,9 @@ class AxiosFactory {
         access_token: firmTokens.accessToken,
       };
 
-      // We create an instance without interceptors to avoid an infinite loop
-      const axiosInstance = this.#createSimpleAxiosInstanceForFirms(firmId);
+      // Token-only instance: no interceptors (avoids a refresh loop) and the Basic header is added
+      // only when the staging gateway requires it (otherwise Doorkeeper rejects the refresh).
+      const axiosInstance = await this.createTokenInstanceForFirm(firmId);
 
       const response = await axiosInstance.post(`${this.BASE_URL}/f/${firmId}/oauth/token`, data);
 

--- a/lib/api/silverfinAuthorizer.js
+++ b/lib/api/silverfinAuthorizer.js
@@ -55,7 +55,7 @@ class SilverfinAuthorizer {
         refresh_token: firmTokens.refreshToken,
         access_token: firmTokens.accessToken,
       };
-      const instance = AxiosFactory.createInstance("firm", firmId);
+      const instance = await AxiosFactory.createTokenInstanceForFirm(firmId);
       const response = await instance.post(`${BASE_URL}/f/${firmId}/oauth/token`, data);
 
       firmCredentials.storeNewTokenPair(firmId, response.data);
@@ -158,7 +158,7 @@ class SilverfinAuthorizer {
       const SF_API_SECRET = process.env.SF_API_SECRET;
       const url = `${this.BASE_URL}/f/${firmId}/oauth/token?client_id=${SF_API_CLIENT_ID}&client_secret=${SF_API_SECRET}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`;
 
-      const instance = AxiosFactory.createAuthInstanceForFirm(firmId);
+      const instance = await AxiosFactory.createTokenInstanceForFirm(firmId);
       const response = await instance.post(url);
 
       firmCredentials.storeNewTokenPair(firmId, response.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.56.1",
+      "version": "1.56.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -357,9 +357,12 @@ Source: `lib/api/axiosFactory.js`
 | `AxiosFactory.createInstance` (staging) | should raise an error if environment variable is not set | Verifies that using a staging host without `SF_BASIC_AUTH` set causes an error and process exit. |
 | `AxiosFactory.createInstance` (staging) | should use basic auth for firm instance in staging | Verifies that a staging firm instance uses a `Basic` `Authorization` header and passes the access token as a query parameter. |
 | `AxiosFactory.createInstance` (staging) | should use basic auth for partner instance in staging | Verifies that a staging partner instance uses a `Basic` `Authorization` header with credentials in query params. |
-| `AxiosFactory.createAuthInstanceForFirm` | should not thrown an error for missing tokens | Verifies that the auth instance is created successfully even when no tokens are stored, without logging errors or exiting. |
-| `AxiosFactory.createAuthInstanceForFirm` | should not attempt to refresh tokens | Verifies that a 401 response from an auth instance is rethrown as-is without triggering any token refresh. |
-| `AxiosFactory.createAuthInstanceForFirm` | should use basic auth for firm instance in staging | Verifies that the auth instance uses a `Basic` `Authorization` header when the host is a staging URL. |
+| `AxiosFactory.createTokenInstanceForFirm` | should not throw when there are no stored tokens | Verifies a token instance is created even when no tokens are stored, without logging errors or exiting. |
+| `AxiosFactory.createTokenInstanceForFirm` | should not attach a refresh interceptor | Verifies a 401 from a token instance is rethrown as-is without triggering a token refresh. |
+| `AxiosFactory.createTokenInstanceForFirm` | should NOT attach basic auth on production (and not probe for a gateway) | Verifies a production token instance has no Basic header and never probes for a gateway. |
+| `AxiosFactory.createTokenInstanceForFirm` | should attach basic auth on staging when the gateway requires it | Verifies a staging token instance gets a `Basic` header when the probe returns 401 with a `WWW-Authenticate: Basic` challenge. |
+| `AxiosFactory.createTokenInstanceForFirm` | should NOT attach basic auth on staging when the gateway is disabled | Verifies a staging token instance has no Basic header when the probe returns a non-Basic (302) response. |
+| `AxiosFactory.createTokenInstanceForFirm` | re-probes instead of caching a disabled gateway after an ambiguous probe failure | Verifies a transport-level probe failure (no HTTP response) is rethrown and not cached, so the next call re-probes. |
 
 ---
 

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -491,5 +491,23 @@ describe("AxiosFactory", () => {
 
       expect(axiosInstance.defaults.headers.Authorization).toBeUndefined();
     });
+
+    it("re-probes instead of caching a disabled gateway after an ambiguous (no-response) probe failure", async () => {
+      firmCredentials.getHost.mockReturnValue("https://flaky.staging.getsilverfin.com");
+
+      // First probe fails at the transport layer (no HTTP response): indeterminate, must not be cached.
+      axios.get.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+      await expect(AxiosFactory.createTokenInstanceForFirm(50000)).rejects.toThrow("ETIMEDOUT");
+
+      // Next call re-probes (the cache was not poisoned) and finds the Basic gateway.
+      axios.get.mockResolvedValueOnce({
+        status: 401,
+        headers: { "www-authenticate": 'Basic realm="Staging"' },
+      });
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(50000);
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(axiosInstance.defaults.headers.Authorization).toBe("Basic test_basic_auth");
+    });
   });
 });

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -427,14 +427,12 @@ describe("AxiosFactory", () => {
     });
   });
 
-  describe("Create auth instance for firm", () => {
-    const mockHost = "https://test-api.com";
-
-    it("should not thrown an error for missing tokens", () => {
-      firmCredentials.getHost.mockReturnValue(mockHost);
+  describe("Create token instance for firm", () => {
+    it("should not throw when there are no stored tokens", async () => {
+      firmCredentials.getHost.mockReturnValue("https://test-api.com");
       firmCredentials.getTokenPair.mockReturnValue(null);
 
-      const axiosInstance = AxiosFactory.createAuthInstanceForFirm(123);
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(123);
 
       expect(axiosInstance).toBeDefined();
       expect(axios.create).toHaveBeenCalled();
@@ -443,10 +441,10 @@ describe("AxiosFactory", () => {
       expect(exitSpy).not.toHaveBeenCalled();
     });
 
-    it("should not attempt to refresh tokens", async () => {
-      firmCredentials.getHost.mockReturnValue(mockHost);
+    it("should not attach a refresh interceptor", async () => {
+      firmCredentials.getHost.mockReturnValue("https://test-api.com");
 
-      const axiosInstance = AxiosFactory.createAuthInstanceForFirm(123);
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(123);
 
       expect(axiosInstance).toBeDefined();
       expect(axios.create).toHaveBeenCalled();
@@ -463,17 +461,35 @@ describe("AxiosFactory", () => {
       expect(axiosInstance.post).not.toHaveBeenCalled();
     });
 
-    it("should use basic auth for firm instance in staging", () => {
-      const mockHost = "https://test-api.staging.getsilverfin.com";
-      const firmId = 50000;
-      firmCredentials.getHost.mockReturnValue(mockHost);
+    it("should NOT attach basic auth on production (and not probe for a gateway)", async () => {
+      firmCredentials.getHost.mockReturnValue("https://test-api.com");
 
-      const axiosInstance = AxiosFactory.createAuthInstanceForFirm(firmId);
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(123);
 
-      expect(axiosInstance).toBeDefined();
-      expect(axiosInstance.defaults.baseURL).toBe(`https://test-api.staging.getsilverfin.com/api/v4/f/50000`);
+      expect(axiosInstance.defaults.headers.Authorization).toBeUndefined();
+      expect(axios.get).not.toHaveBeenCalled();
+    });
 
+    it("should attach basic auth on staging when the gateway requires it", async () => {
+      firmCredentials.getHost.mockReturnValue("https://gated.staging.getsilverfin.com");
+      axios.get.mockResolvedValue({
+        status: 401,
+        headers: { "www-authenticate": 'Basic realm="Staging"' },
+      });
+
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(50000);
+
+      expect(axiosInstance.defaults.baseURL).toBe("https://gated.staging.getsilverfin.com/api/v4/f/50000");
       expect(axiosInstance.defaults.headers.Authorization).toBe("Basic test_basic_auth");
+    });
+
+    it("should NOT attach basic auth on staging when the gateway is disabled", async () => {
+      firmCredentials.getHost.mockReturnValue("https://open.staging.getsilverfin.com");
+      axios.get.mockResolvedValue({ status: 302, headers: {} });
+
+      const axiosInstance = await AxiosFactory.createTokenInstanceForFirm(50000);
+
+      expect(axiosInstance.defaults.headers.Authorization).toBeUndefined();
     });
   });
 });

--- a/tests/lib/api/silverfinAuthorizer.test.js
+++ b/tests/lib/api/silverfinAuthorizer.test.js
@@ -76,7 +76,7 @@ describe("SilverfinAuthorizer", () => {
     mockAxiosInstance.post.mockResolvedValue(mockTokenResponse);
     mockAxiosInstance.get.mockResolvedValue(mockFirmResponse);
     AxiosFactory.createInstance.mockReturnValue(mockAxiosInstance);
-    AxiosFactory.createTokenInstanceForFirm.mockReturnValue(mockAxiosInstance);
+    AxiosFactory.createTokenInstanceForFirm.mockResolvedValue(mockAxiosInstance);
 
     // Mock process.exit
     exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {

--- a/tests/lib/api/silverfinAuthorizer.test.js
+++ b/tests/lib/api/silverfinAuthorizer.test.js
@@ -23,7 +23,7 @@ jest.mock("../../../lib/api/firmCredentials", () => ({
 jest.mock("../../../lib/api/axiosFactory", () => ({
   AxiosFactory: {
     createInstance: jest.fn(),
-    createAuthInstanceForFirm: jest.fn(),
+    createTokenInstanceForFirm: jest.fn(),
   },
 }));
 
@@ -76,7 +76,7 @@ describe("SilverfinAuthorizer", () => {
     mockAxiosInstance.post.mockResolvedValue(mockTokenResponse);
     mockAxiosInstance.get.mockResolvedValue(mockFirmResponse);
     AxiosFactory.createInstance.mockReturnValue(mockAxiosInstance);
-    AxiosFactory.createAuthInstanceForFirm.mockReturnValue(mockAxiosInstance);
+    AxiosFactory.createTokenInstanceForFirm.mockReturnValue(mockAxiosInstance);
 
     // Mock process.exit
     exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
@@ -97,7 +97,7 @@ describe("SilverfinAuthorizer", () => {
 
       expect(open).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/authorize"));
 
-      expect(AxiosFactory.createAuthInstanceForFirm).toHaveBeenCalledWith(mockFirmId);
+      expect(AxiosFactory.createTokenInstanceForFirm).toHaveBeenCalledWith(mockFirmId);
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.stringContaining("api.test.com/f/123/oauth/token"));
 
@@ -134,7 +134,7 @@ describe("SilverfinAuthorizer", () => {
 
       expect(open).not.toHaveBeenCalled();
 
-      expect(AxiosFactory.createAuthInstanceForFirm).not.toHaveBeenCalled();
+      expect(AxiosFactory.createTokenInstanceForFirm).not.toHaveBeenCalled();
       expect(AxiosFactory.createInstance).not.toHaveBeenCalled();
 
       expect(firmCredentials.storeNewTokenPair).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

On staging, the CLI attaches the `SF_BASIC_AUTH` HTTP Basic header to every firm request, including the OAuth `/token` POSTs (initial `authorize`, manual `refreshFirm`, and the automatic 401-refresh interceptor).

When a staging environment has its Basic Auth gateway **disabled** (e.g. set up with the "disable HTTP basic auth" option), that header breaks authentication: Doorkeeper treats the gateway credentials as the OAuth client, finds no matching client, and responds `401 "Client authentication failed ... unknown client"`. As a result `silverfin authorize` and token refresh fail on such stagings.

Confirmed empirically: the same `/oauth/token` request, with the same `client_id`/`client_secret`, succeeds when the Basic header is omitted.

## Fix

Add `AxiosFactory.createTokenInstanceForFirm()`, which builds the token-endpoint axios instance and attaches the Basic header **only when the staging gateway actually requires it** — detected by a one-time, per-host probe for a `WWW-Authenticate: Basic` challenge (an unauthenticated request to a Basic-protected host returns `401 WWW-Authenticate: Basic`).

- Gateway **disabled** → no Basic header → token request authenticates via `client_id`/`client_secret`, as Doorkeeper expects.
- Gateway **enabled** → Basic header attached, so the request still passes the gateway.
- **Production** → never probed; the header is never added (behaviour unchanged).

All three firm `/oauth/token` paths now route through this method (initial authorize, `refreshFirm`, and the 401-refresh interceptor). Staging **data** calls keep the Basic header; production behaviour is unchanged.

## Tests

Updated `tests/lib/api/axiosFactory.test.js` and `tests/lib/api/silverfinAuthorizer.test.js`, including new coverage for gateway-present vs gateway-disabled staging. All api-layer tests pass (91/91).
