### PR TITLE
Improve run-test --status output for CI (error reasons + no spinner noise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.56.3] (03/07/2026)
+Improve `run-test --status` output for CI: surface the underlying error message when a run ends in `test_error`/`internal_error` (previously reported as a bare `FAILED` with no reason), and suppress the progress spinner when stdout is not a TTY (it flooded CI logs with hundreds of "Running tests.." frames).
+
 ## [1.56.2] (25/06/2026)
 Send the staging HTTP Basic Auth header on firm OAuth token requests only when the staging gateway actually requires it (detected via a one-time `WWW-Authenticate: Basic` probe). Fixes `silverfin authorize` and token refresh failing with "unknown client" on stagings that have HTTP basic auth disabled.
 

--- a/lib/cli/spinner.js
+++ b/lib/cli/spinner.js
@@ -18,6 +18,12 @@ class Spinner {
   spin(text = "Doing some work...") {
     if (this.running) return;
 
+    // The animation relies on cursor/line controls that only work on an
+    // interactive terminal. In a non-TTY environment (e.g. GitHub Actions) each
+    // frame is appended instead of overwritten, flooding the log with hundreds of
+    // "Running tests.." lines. Skip the spinner entirely when stdout is not a TTY.
+    if (!stdout.isTTY) return;
+
     this.running = true;
     // Remove the cursor so we can see the effect
     Spinner.#removeCursor();

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -597,16 +597,20 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
 
   const runSingleHandle = async (singleHandle) => {
     let status = "FAILED";
+    // When a run fails without completing (test_error / internal_error / no
+    // response) there are no per-test results to report. Capture a short reason so
+    // --status output (consumed by CI) explains *why* a template failed instead of
+    // printing a bare FAILED that is indistinguishable from a real assertion failure.
+    let failureReason = "";
     const failedTestNames = [];
     const testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none", pattern);
 
     if (!testResult) {
-      status = "FAILED";
-      consola.error(`Error running tests for ${singleHandle}`);
+      failureReason = "Error running tests (no response from the platform)";
     } else {
       const testRun = testResult?.testRun;
 
-      if (testRun && testRun?.status === "completed") {
+      if (testRun?.status === "completed") {
         const errorsPresent = checkAllTestsErrorsPresent(testRun.tests);
         if (errorsPresent === false) {
           status = "PASSED";
@@ -620,20 +624,28 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
             }
           });
         }
+      } else if (testRun?.status === "test_error") {
+        failureReason = testRun.error_message || "Ran into an error and couldn't complete the test run";
+      } else if (testRun?.status === "internal_error") {
+        failureReason = "Internal error. Try to run the test again or contact support if the issue persists.";
+      } else {
+        failureReason = `Test run did not complete (status: ${testRun?.status ?? "unknown"})`;
       }
     }
 
-    if (status === "PASSED") {
-      consola.log(`${singleHandle}: ${status}`);
-    } else {
-      consola.log(`${singleHandle}: ${status}`);
-      // Display failed test names
+    consola.log(`${singleHandle}: ${status}`);
+    if (status !== "PASSED") {
+      // Indented detail lines. The GitHub Actions parser only reads the top-level
+      // "<name>: PASSED|FAILED" line and skips indented lines, so these are safe.
       failedTestNames.forEach((testName) => {
         consola.log(`  ${testName}: FAILED`);
       });
+      if (failureReason) {
+        consola.log(`  ${failureReason}`);
+      }
     }
 
-    return { handle: singleHandle, status, failedTestNames };
+    return { handle: singleHandle, status, failedTestNames, failureReason };
   };
 
   const results = await Promise.all(handles.map(runSingleHandle));

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -627,7 +627,7 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
       } else if (testRun?.status === "test_error") {
         failureReason = testRun.error_message || "Ran into an error and couldn't complete the test run";
       } else if (testRun?.status === "internal_error") {
-        failureReason = "Internal error. Try to run the test again or contact support if the issue persists.";
+        failureReason = testRun.error_message || "Internal error. Try to run the test again or contact support if the issue persists.";
       } else {
         failureReason = `Test run did not complete (status: ${testRun?.status ?? "unknown"})`;
       }

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -641,7 +641,9 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
         consola.log(`  ${testName}: FAILED`);
       });
       if (failureReason) {
-        consola.log(`  ${failureReason}`);
+        // Collapse newlines so a multi-line error_message stays on the single
+        // indented line and can't be misread as a new top-level result.
+        consola.log(`  ${failureReason.replace(/\r?\n/g, " ")}`);
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.56.2",
+      "version": "1.56.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -869,6 +869,7 @@ Source: `lib/liquidTestRunner.js`
 | `runTestsStatusOnly` | should return FAILED when test result is null (runTests returned nothing) | Verifies that `"FAILED"` is returned when `runTests` returns nothing (e.g. missing config). |
 | `runTestsStatusOnly` | should surface the error message when a run errors out instead of completing | Verifies that a `test_error` run returns `"FAILED"` and logs the underlying `error_message` as an indented detail line. |
 | `runTestsStatusOnly` | should collapse newlines in the error message onto a single indented line | Verifies that a multi-line `error_message` is collapsed to spaces so it stays on one indented line and can't be misparsed as a new top-level result. |
+| `runTestsStatusOnly` | should surface a specific error message for internal_error when present | Verifies that an `internal_error` run prefers the platform's `error_message` over the generic fallback text. |
 | `runTestsStatusOnly` | should handle multiple handles and return FAILED if any fail | Verifies that `"FAILED"` is returned when at least one handle in a multi-handle run fails. |
 
 ---

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -867,6 +867,7 @@ Source: `lib/liquidTestRunner.js`
 | `runTestsStatusOnly` | should return PASSED when all handles pass | Verifies that `"PASSED"` is returned and logged when all supplied handles have passing test runs. |
 | `runTestsStatusOnly` | should return FAILED when a handle fails | Verifies that `"FAILED"` is returned and logged when a test run reports failures. |
 | `runTestsStatusOnly` | should return FAILED when test result is null (runTests returned nothing) | Verifies that `"FAILED"` is returned when `runTests` returns nothing (e.g. missing config). |
+| `runTestsStatusOnly` | should surface the error message when a run errors out instead of completing | Verifies that a `test_error` run returns `"FAILED"` and logs the underlying `error_message` as an indented detail line. |
 | `runTestsStatusOnly` | should handle multiple handles and return FAILED if any fail | Verifies that `"FAILED"` is returned when at least one handle in a multi-handle run fails. |
 
 ---

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -868,6 +868,7 @@ Source: `lib/liquidTestRunner.js`
 | `runTestsStatusOnly` | should return FAILED when a handle fails | Verifies that `"FAILED"` is returned and logged when a test run reports failures. |
 | `runTestsStatusOnly` | should return FAILED when test result is null (runTests returned nothing) | Verifies that `"FAILED"` is returned when `runTests` returns nothing (e.g. missing config). |
 | `runTestsStatusOnly` | should surface the error message when a run errors out instead of completing | Verifies that a `test_error` run returns `"FAILED"` and logs the underlying `error_message` as an indented detail line. |
+| `runTestsStatusOnly` | should collapse newlines in the error message onto a single indented line | Verifies that a multi-line `error_message` is collapsed to spaces so it stays on one indented line and can't be misparsed as a new top-level result. |
 | `runTestsStatusOnly` | should handle multiple handles and return FAILED if any fail | Verifies that `"FAILED"` is returned when at least one handle in a multi-handle run fails. |
 
 ---

--- a/tests/lib/liquidTestRunner.test.js
+++ b/tests/lib/liquidTestRunner.test.js
@@ -487,6 +487,29 @@ describe("runTestsStatusOnly", () => {
     expect(consola.log).toHaveBeenCalledWith("  line 1 line 2 line 3");
   });
 
+  it("should surface a specific error message for internal_error when present", async () => {
+    const handle = "reconciliation_text_1";
+    setupFsUtilsMocks(handle);
+
+    const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+
+    ReconciliationText.read.mockReturnValue({ handle, text: "x", text_parts: [] });
+
+    SF.createTestRun = jest.fn().mockResolvedValue({ data: 14 });
+    SF.readTestRun = jest.fn().mockResolvedValue({
+      data: { status: "internal_error", tests: {}, error_message: "Backend timeout" },
+    });
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handle]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Backend timeout"));
+  });
+
   it("should handle multiple handles and return FAILED if any fail", async () => {
     const handlePass = "reconciliation_text_1";
     const handleFail = "reconciliation_text_2";

--- a/tests/lib/liquidTestRunner.test.js
+++ b/tests/lib/liquidTestRunner.test.js
@@ -441,6 +441,30 @@ describe("runTestsStatusOnly", () => {
     expect(overallStatus).toBe("FAILED");
   });
 
+  it("should surface the error message when a run errors out instead of completing", async () => {
+    const handle = "reconciliation_text_1";
+    setupFsUtilsMocks(handle);
+
+    const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+
+    ReconciliationText.read.mockReturnValue({ handle, text: "x", text_parts: [] });
+
+    SF.createTestRun = jest.fn().mockResolvedValue({ data: 12 });
+    SF.readTestRun = jest.fn().mockResolvedValue({
+      data: { status: "test_error", tests: {}, error_message: "Liquid syntax error on line 3" },
+    });
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handle]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(`${handle}: FAILED`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Liquid syntax error on line 3"));
+  });
+
   it("should handle multiple handles and return FAILED if any fail", async () => {
     const handlePass = "reconciliation_text_1";
     const handleFail = "reconciliation_text_2";

--- a/tests/lib/liquidTestRunner.test.js
+++ b/tests/lib/liquidTestRunner.test.js
@@ -465,6 +465,28 @@ describe("runTestsStatusOnly", () => {
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Liquid syntax error on line 3"));
   });
 
+  it("should collapse newlines in the error message onto a single indented line", async () => {
+    const handle = "reconciliation_text_1";
+    setupFsUtilsMocks(handle);
+
+    const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+
+    ReconciliationText.read.mockReturnValue({ handle, text: "x", text_parts: [] });
+
+    SF.createTestRun = jest.fn().mockResolvedValue({ data: 13 });
+    SF.readTestRun = jest.fn().mockResolvedValue({
+      data: { status: "test_error", tests: {}, error_message: "line 1\nline 2\r\nline 3" },
+    });
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handle]);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(consola.log).toHaveBeenCalledWith("  line 1 line 2 line 3");
+  });
+
   it("should handle multiple handles and return FAILED if any fail", async () => {
     const handlePass = "reconciliation_text_1";
     const handleFail = "reconciliation_text_2";


### PR DESCRIPTION
## What

Two focused improvements to `run-test --status` (the mode consumed by the `bso_github_actions` parallel test workflow):

1. **Surface the failure reason for non-completed runs.** When a run ends in `test_error` / `internal_error` (a liquid/compile error, or a transient platform error under concurrent load) the CLI reported a bare `<name>: FAILED` with no explanation — indistinguishable from a genuine assertion failure. `runTestsStatusOnly` now captures `testRun.error_message` (plus a generic message for `internal_error`, no-response, and other non-`completed` statuses) and prints it as an **indented** detail line.

2. **Suppress the spinner in non-TTY environments.** The custom spinner animates via `readline` cursor/line controls that only work on an interactive terminal. In CI (`stdout.isTTY` falsy) every frame was *appended* rather than overwritten, flooding GitHub Actions logs with hundreds of `Running tests..` lines. `spin()` now no-ops when stdout is not a TTY.

## Why

Surfaced while validating the parallel-test workflow (bso_github_actions #27). Two reconciliations failed in CI with a bare `FAILED` and no detail; run locally they **passed** — they had hit a `test_error` under the concurrent `Promise.all` batch, not a real assertion failure. In `--status` mode there was no way to tell the two apart. This change makes the distinction visible in the CI log.

## Safety / compatibility

- The reason lines are **indented**, and the bso workflow's status parser (`grep -oE '\[log\] [^[:space:]].*: (PASSED|FAILED)...'`) only reads the top-level `<name>: PASSED|FAILED` line and skips indented lines — so this is purely additive and does not change how the workflow parses results.
- `runSingleHandle` return shape is unchanged except for an added `failureReason` field.

## Tests

- New unit test: `runTestsStatusOnly` surfaces `error_message` on a `test_error` run.
- Full suite green (563 passed). `TESTS.md` index updated.
- Version bumped to `1.56.3` with a matching CHANGELOG entry (for `check-cli-version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)