### PR TITLE
Expand run-sampler --compact: results register, vanished-output grouping, scope tier, visual-only tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.59.0] (05/08/2026)
+Expand `silverfin run-sampler --compact`
+
 ## [1.58.0] (31/07/2026)
 Added the `company-data-copier` command, which triggers the platform Data Copier to copy a source company's data (account values incl. adjustments, text properties, people/company drop and configuration) into a brand-new company in a destination development firm. Intended for BSO developers to reproduce a client's situation in a dev firm without touching the production firm. Only *data* is copied, not template *code* — templates must already exist in the destination firm to be populated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [1.59.0] (05/08/2026)
-Expand `silverfin run-sampler --compact`
+Expand `silverfin run-sampler --compact`: diff the `results` register, group vanished output per template instead of listing every entry, add a scope-change tier (dependencies/rollforward/required keys) and a visual-only tier for `view.html` changes the data diff can't see, and truncate/cap long output. Also adds `run-sampler --from-zip <path>` to build the compact diff from an already-downloaded `results.zip`.
 
 ## [1.58.0] (31/07/2026)
 Added the `company-data-copier` command, which triggers the platform Data Copier to copy a source company's data (account values incl. adjustments, text properties, people/company drop and configuration) into a brand-new company in a destination development firm. Intended for BSO developers to reproduce a client's situation in a dev firm without touching the production firm. Only *data* is copied, not template *code* — templates must already exist in the destination firm to be populated.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -530,14 +530,31 @@ program
       "accountTemplate",
       "sharedPart",
       "firmIds",
+      "fromZip",
+    ])
+  )
+  .addOption(
+    new Option("--from-zip <path>", "Build the compact diff from an already-downloaded results.zip - no sampler run, no network call").conflicts([
+      "handle",
+      "accountTemplate",
+      "sharedPart",
+      "firmIds",
+      "id",
     ])
   )
   .option("--no-open", "Do not download/open the report locally; only print its URL (default in CI)")
-  .option("--compact", "Download the result and print a compact named_results diff (grouped by template) to stdout - review-friendly and safe in CI")
+  .option("--compact", "Download the result and print a compact diff (named_results/results, dependencies, vanished renders, visual-only changes) grouped by template - review-friendly and safe in CI")
   .action(async (options) => {
     // Commander sets options.open = false when --no-open is passed.
     // In CI, never open regardless of the flag.
     const runnerOptions = { openReport: options.open && !process.env.CI, compact: options.compact || false };
+
+    // A local zip needs no partner API access at all - it's pure offline
+    // re-analysis of a result someone already has on disk.
+    if (options.fromZip) {
+      await new LiquidSamplerRunner(options.partner, runnerOptions).printCompactDiffFromZip(options.fromZip);
+      return;
+    }
 
     // If an existing sampler ID is provided, fetch and display results
     if (options.id) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -519,7 +519,7 @@ program
 program
   .command("run-sampler", { hidden: true})
   .description("Run Liquid Sampler for partner templates (reconciliation texts, account detail templates, and/or shared parts)")
-  .requiredOption("-p, --partner <partner-id>", "Specify the partner to be used")
+  .option("-p, --partner <partner-id>", "Specify the partner to be used (required unless --from-zip is used)")
   .option("-h, --handle <handles...>", "Specify reconciliation text handle(s) - can specify multiple")
   .option("-at, --account-template <names...>", "Specify account detail template name(s) - can specify multiple")
   .option("-s, --shared-part <names...>", "Specify shared part name(s) - can specify multiple")
@@ -554,6 +554,13 @@ program
     if (options.fromZip) {
       await new LiquidSamplerRunner(options.partner, runnerOptions).printCompactDiffFromZip(options.fromZip);
       return;
+    }
+
+    // Every other path talks to the partner/sampler API, so -p/--partner is
+    // required there - it's just not required for --from-zip's offline path.
+    if (!options.partner) {
+      consola.error("You need to specify a partner using -p or --partner");
+      process.exit(1);
     }
 
     // If an existing sampler ID is provided, fetch and display results

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -546,7 +546,7 @@ program
   .option("--compact", "Download the result and print a compact diff (named_results/results, dependencies, vanished renders, visual-only changes) grouped by template - review-friendly and safe in CI")
   .option(
     "--add-diffs-folder",
-    "With --from-zip: add a diffs/ folder to the zip containing before/after pairs only for the entries the compact diff flagged (data/scope/vanished-output/visual-only changes), instead of every sampled entry"
+    "With --from-zip: add a diffs/ folder to the zip containing before/after pairs for the entries the compact diff flagged (data/scope/vanished-output/visual-only changes) whose renders actually differ, instead of every sampled entry"
   )
   .action(async (options) => {
     // Commander sets options.open = false when --no-open is passed.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -544,15 +544,28 @@ program
   )
   .option("--no-open", "Do not download/open the report locally; only print its URL (default in CI)")
   .option("--compact", "Download the result and print a compact diff (named_results/results, dependencies, vanished renders, visual-only changes) grouped by template - review-friendly and safe in CI")
+  .option(
+    "--add-diffs-folder",
+    "With --from-zip: add a diffs/ folder to the zip containing before/after pairs only for the entries the compact diff flagged (data/scope/vanished-output/visual-only changes), instead of every sampled entry"
+  )
   .action(async (options) => {
     // Commander sets options.open = false when --no-open is passed.
     // In CI, never open regardless of the flag.
     const runnerOptions = { openReport: options.open && !process.env.CI, compact: options.compact || false };
 
+    if (options.addDiffsFolder && !options.fromZip) {
+      consola.error("--add-diffs-folder requires --from-zip <path>");
+      process.exit(1);
+    }
+
     // A local zip needs no partner API access at all - it's pure offline
     // re-analysis of a result someone already has on disk.
     if (options.fromZip) {
-      await new LiquidSamplerRunner(options.partner, runnerOptions).printCompactDiffFromZip(options.fromZip);
+      const runner = new LiquidSamplerRunner(options.partner, runnerOptions);
+      await runner.printCompactDiffFromZip(options.fromZip);
+      if (options.addDiffsFolder) {
+        runner.addDiffsFolderToZip(options.fromZip);
+      }
       return;
     }
 

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -5,20 +5,28 @@ const YAML = require("yaml");
 /**
  * Extract a compact, LLM/review-friendly view of a Liquid Sampler result.
  *
- * A sampler `results.zip` is huge (the rendered HTML report alone is ~470K tokens
- * at scale, and the raw per-entry output is ~150 MB). The only signal a reviewer
- * usually needs first is the DATA diff: how each template's `named_results`
- * changed. That lives in `registers.json` for every sampled entry, before/after.
+ * A sampler `results.zip` is huge (the rendered HTML report alone can be tens of
+ * MB, and the raw per-entry output is ~150 MB at scale). This module builds
+ * several small, targeted signals instead of a raw diff:
  *
- * This module reads an already-EXTRACTED results directory (the layout inside
- * results.zip) and returns just the `named_results` changes, grouped by template
- * and deduped by identical change, so the whole thing is ~900 tokens instead of
- * hundreds of thousands. It never touches the rendered HTML.
+ *  - `templates`      - the `named_results`/`results` DATA diff, deduped by
+ *                       identical change and capped so one broken/verbose
+ *                       template can't blow up the whole summary.
+ *  - `collapsedEntries` - entries whose rendered output vanished entirely
+ *                       between phases (a strong broken-template signal that
+ *                       would otherwise show up as dozens of individual
+ *                       "value -> undefined" lines).
+ *  - `scopeTemplates` - `dependencies` / `rollforward_params` /
+ *                       `required_keys_missing` changes: what the template
+ *                       depends on, not what it renders.
+ *  - `visualOnlyEntries` - entries where `view.html` changed but the DATA
+ *                       (named_results/results) didn't - a rendering-only
+ *                       regression the data diff can't see.
  *
  * Expected directory layout (inside results.zip):
  *   <dir>/sample_entry_ids.yml
- *   <dir>/output/account_entries/<id>/{before,after}/registers.json
- *   <dir>/output/reconciliation_entries/<id>/{before,after}/registers.json
+ *   <dir>/output/account_entries/<id>/{before,after}/{registers.json,view.html}
+ *   <dir>/output/reconciliation_entries/<id>/{before,after}/{registers.json,view.html}
  */
 
 const ENTRY_KINDS = ["account_entries", "reconciliation_entries"];
@@ -27,15 +35,35 @@ const ENTRY_KINDS = ["account_entries", "reconciliation_entries"];
 // that distinctly from an explicit JSON `null`.
 const ABSENT = Symbol("absent");
 
+// Individual before/after values longer than this are elided - long free-text
+// fields (accounting-policy paragraphs, notes) are the single biggest driver of
+// oversized summaries, and the full text rarely helps a reviewer decide
+// "is this intended?" faster than a preview does.
+const MAX_VALUE_CHARS = 100;
+// Detail lines shown per template before collapsing the rest into "+N more".
+const MAX_CHANGES_SHOWN = 8;
+// Named-results/results keys that flip from a value to `undefined` in a single
+// entry, at or above this count, are treated as "the render broke" rather than
+// as that many independent findings.
+const COLLAPSE_MIN_LOST_KEYS = 3;
+// Items shown before eliding a set-diff (dependencies/rollforward params/etc.)
+const MAX_SET_ITEMS_SHOWN = 3;
+// Field-level notes shown per visual-only entry before eliding the rest.
+const MAX_VISUAL_CHANGES_SHOWN = 6;
+
 /**
  * Render a named_results value for display. Distinguishes an absent key
- * (template no longer emits it) from an explicit null.
+ * (template no longer emits it) from an explicit null, and elides long values.
  * @param {*} value
  * @returns {string}
  */
 function renderValue(value) {
   if (value === ABSENT) return "undefined";
-  return JSON.stringify(value);
+  const rendered = JSON.stringify(value);
+  if (rendered.length > MAX_VALUE_CHARS) {
+    return `${rendered.slice(0, MAX_VALUE_CHARS)}…(${rendered.length} chars)`;
+  }
+  return rendered;
 }
 
 /**
@@ -72,23 +100,30 @@ function readEntryLabels(resultsDir) {
 }
 
 /**
- * Read the named_results object from a registers.json file.
+ * Read and validate a registers.json file.
  * @param {string} filePath
- * @returns {Object|null} the named_results object, or null if unreadable
+ * @returns {Object|null} the parsed registers object, or null if unreadable
  */
-function readNamedResults(filePath) {
+function readRegisters(filePath) {
   try {
     const registers = JSON.parse(fs.readFileSync(filePath, "utf8"));
     // A valid registers.json is always an object. Anything else (a bare
     // string/number, an array, or a truncated-to-null file) means the file
-    // is unreadable, not that named_results happens to be absent.
+    // is unreadable, not that its contents happen to be absent.
     if (!registers || typeof registers !== "object" || Array.isArray(registers)) return null;
-
-    const named = registers.named_results;
-    return named && typeof named === "object" ? named : {};
+    return registers;
   } catch {
     return null;
   }
+}
+
+/**
+ * @param {Object} registers - a parsed registers.json
+ * @returns {Object} the named_results object, defaulting to {} when absent
+ */
+function namedResultsOf(registers) {
+  const named = registers.named_results;
+  return named && typeof named === "object" ? named : {};
 }
 
 /**
@@ -131,22 +166,410 @@ function diffNamedResults(before, after) {
 }
 
 /**
- * Walk an extracted results directory and build the compact named_results diff.
+ * Whether a `results` array is a plain 0/1 flag vector (the common shape for
+ * reconciliation-check indicators) rather than raw numeric values.
+ * @param {Array} arr
+ * @returns {boolean}
+ */
+function isFlagArray(arr) {
+  return Array.isArray(arr) && arr.length > 0 && arr.every((v) => v === "0.0" || v === "1.0" || v === "0" || v === "1");
+}
+
+/**
+ * Format a `results` register value for display. Flag-shaped arrays (every
+ * element 0/1) render as a triggered-count, since that's the reviewable
+ * signal (e.g. "how many unreconciled indicators fired"); anything else
+ * (raw numeric values from other template kinds) falls back to the plain
+ * rendered value.
+ * @param {*} value
+ * @returns {string}
+ */
+function formatResultsValue(value) {
+  if (value == null) return "undefined";
+  if (isFlagArray(value)) {
+    const triggered = value.filter((v) => v === "1.0" || v === "1").length;
+    return `${triggered}/${value.length} triggered`;
+  }
+  return renderValue(value);
+}
+
+/**
+ * Diff the `results` register (Liquid's unnamed results array) between
+ * phases. Unlike named_results this is a single un-keyed value per entry, so
+ * it's either unchanged or it's one change - never one per array element.
+ * @param {*} before
+ * @param {*} after
+ * @returns {{before: string, after: string}|null}
+ */
+function diffResultsRegister(before, after) {
+  const b = before == null ? null : before;
+  const a = after == null ? null : after;
+  if (JSON.stringify(b) === JSON.stringify(a)) return null;
+  return { before: formatResultsValue(before), after: formatResultsValue(after) };
+}
+
+/**
+ * Set-diff two arrays of strings.
+ * @param {Array<string>} beforeArr
+ * @param {Array<string>} afterArr
+ * @returns {{added: Array<string>, removed: Array<string>}|null} null if identical
+ */
+function diffStringSet(beforeArr, afterArr) {
+  const before = new Set(beforeArr || []);
+  const after = new Set(afterArr || []);
+  const added = [...after].filter((x) => !before.has(x)).sort();
+  const removed = [...before].filter((x) => !after.has(x)).sort();
+  if (added.length === 0 && removed.length === 0) return null;
+  return { added, removed };
+}
+
+/**
+ * @param {Array<string>} items
+ * @returns {string} up to MAX_SET_ITEMS_SHOWN items, then "+N more"
+ */
+function previewList(items, max = MAX_SET_ITEMS_SHOWN) {
+  if (items.length <= max) return items.join(", ");
+  return `${items.slice(0, max).join(", ")} +${items.length - max} more`;
+}
+
+/**
+ * @param {number} n
+ * @param {string} unit - singular form, e.g. "handle"
+ * @returns {string}
+ */
+function pluralize(n, unit) {
+  return `${unit}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Render an added/removed set-diff as a compact one-line summary, e.g.
+ * "−1 ledger (10028311), +2 handles (overview_notes, office_info)".
+ * @param {Array<string>} added
+ * @param {Array<string>} removed
+ * @param {string} unit
+ * @returns {string}
+ */
+function formatSetSummary(added, removed, unit) {
+  const parts = [];
+  if (removed.length) parts.push(`−${removed.length} ${pluralize(removed.length, unit)} (${previewList(removed)})`);
+  if (added.length) parts.push(`+${added.length} ${pluralize(added.length, unit)} (${previewList(added)})`);
+  return parts.join(", ");
+}
+
+/**
+ * @param {Object} deps - a `dependencies` register value
+ * @returns {Object<string, Array<string>>} handle names keyed by ledger id
+ */
+function dependencyHandlesPerLedger(deps) {
+  return (deps && deps.reconciliations && deps.reconciliations.handles_per_ledger) || {};
+}
+
+/**
+ * @param {Object} deps - a `dependencies` register value
+ * @returns {Array<string>} every ledger id the template touches, from either
+ *   the flat `ledgers` list or the handles-per-ledger map
+ */
+function dependencyLedgers(deps) {
+  if (!deps) return [];
+  const handlesPerLedger = dependencyHandlesPerLedger(deps);
+  return [...new Set([...(deps.ledgers || []).map(String), ...Object.keys(handlesPerLedger)])];
+}
+
+/**
+ * @param {Object} deps - a `dependencies` register value
+ * @returns {Array<string>} every distinct handle name depended on, across all ledgers
+ */
+function dependencyHandles(deps) {
+  if (!deps) return [];
+  return [...new Set(Object.values(dependencyHandlesPerLedger(deps)).flat())];
+}
+
+/**
+ * Diff a template's `dependencies` register (which ledgers/handles/account
+ * ranges/company attributes it reads) - its SCOPE, not its rendered data.
+ * Returned as one line per category (rather than one joined string) since a
+ * template can touch all four at once and a semicolon-packed single line
+ * gets unreadable fast.
+ * @param {Object} before
+ * @param {Object} after
+ * @returns {Array<string>|null} one summary line per changed category, or null if unchanged
+ */
+function diffDependencies(before, after) {
+  const parts = [];
+
+  const ledgerDiff = diffStringSet(dependencyLedgers(before), dependencyLedgers(after));
+  if (ledgerDiff) parts.push(formatSetSummary(ledgerDiff.added, ledgerDiff.removed, "ledger"));
+
+  const handleDiff = diffStringSet(dependencyHandles(before), dependencyHandles(after));
+  if (handleDiff) parts.push(formatSetSummary(handleDiff.added, handleDiff.removed, "handle"));
+
+  const rangeDiff = diffStringSet((before && before.account_ranges) || [], (after && after.account_ranges) || []);
+  if (rangeDiff) parts.push(formatSetSummary(rangeDiff.added, rangeDiff.removed, "account range"));
+
+  const beforeAttr = !!(before && before.company && before.company.attributes);
+  const afterAttr = !!(after && after.company && after.company.attributes);
+  if (beforeAttr !== afterAttr) parts.push(`company.attributes: ${beforeAttr} → ${afterAttr}`);
+
+  return parts.length ? parts : null;
+}
+
+/**
+ * Diff a template's `rollforward_params` register by declared param name
+ * (the `value` is usually null/a placeholder, so the name is the signal).
+ * @param {Array<Object>} before
+ * @param {Array<Object>} after
+ * @returns {string|null}
+ */
+function diffRollforwardParams(before, after) {
+  const names = (list) => (Array.isArray(list) ? list : []).map((p) => p && p.name).filter(Boolean);
+  const diff = diffStringSet(names(before), names(after));
+  if (!diff) return null;
+  return formatSetSummary(diff.added, diff.removed, "param");
+}
+
+/**
+ * Diff a template's `required_keys_missing` register.
+ * @param {Array<string>} before
+ * @param {Array<string>} after
+ * @returns {string|null}
+ */
+function diffRequiredKeysMissing(before, after) {
+  const diff = diffStringSet(before, after);
+  if (!diff) return null;
+  return formatSetSummary(diff.added, diff.removed, "key");
+}
+
+/**
+ * Diff the "scope" registers (what the template depends on / requires), as
+ * distinct from the "data" registers (what it renders). Kept as its own tier
+ * so a dependency change never gets mistaken for a data regression.
+ * @param {Object} before - a parsed registers.json
+ * @param {Object} after - a parsed registers.json
+ * @returns {Array<{key: string, summary?: string, subLines?: Array<string>}>}
+ */
+function diffScope(before, after) {
+  const changes = [];
+  const dependencies = diffDependencies(before.dependencies, after.dependencies);
+  if (dependencies) changes.push({ key: "dependencies", subLines: dependencies });
+
+  const rollforwardParams = diffRollforwardParams(before.rollforward_params, after.rollforward_params);
+  if (rollforwardParams) changes.push({ key: "rollforward_params", summary: rollforwardParams });
+
+  const requiredKeysMissing = diffRequiredKeysMissing(before.required_keys_missing, after.required_keys_missing);
+  if (requiredKeysMissing) changes.push({ key: "required_keys_missing", summary: requiredKeysMissing });
+
+  return changes;
+}
+
+/**
+ * @param {string} resultsDir
+ * @param {string} kind
+ * @param {string} entryId
+ * @param {"before"|"after"} phase
+ * @returns {string} path to that entry's view.html for the given phase
+ */
+function viewHtmlPath(resultsDir, kind, entryId, phase) {
+  return path.join(resultsDir, "output", kind, entryId, phase, "view.html");
+}
+
+const HTML_ENTITIES = { "&nbsp;": " ", "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'" };
+
+/**
+ * Minimal entity decoding - just the handful that show up in rendered form markup.
+ * @param {string} text
+ * @returns {string}
+ */
+function decodeEntities(text) {
+  return text.replace(/&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;/g, (m) => HTML_ENTITIES[m]);
+}
+
+/**
+ * @param {string} attrs - a tag's raw attribute string
+ * @param {string} name
+ * @returns {string|null} the attribute's value, or null if absent
+ */
+function getAttr(attrs, name) {
+  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`));
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract every form field in a rendered view.html that's anchored by
+ * `data-name` (Silverfin's stable per-field identifier), keyed by that name.
+ * Fields without a `data-name` (static markup, wrapper divs) aren't
+ * individually addressable, so they fall outside this map entirely - a
+ * change confined to those falls back to the generic note in
+ * describeVisualChange.
+ * @param {string} html
+ * @returns {Map<string, {tag: string, value: string|null, placeholder: string|null}>}
+ */
+function extractNamedFields(html) {
+  const fields = new Map();
+
+  for (const m of html.matchAll(/<textarea\b([^>]*)>([\s\S]*?)<\/textarea>/g)) {
+    const name = getAttr(m[1], "data-name");
+    if (!name) continue;
+    fields.set(name, { tag: "textarea", value: decodeEntities(m[2].trim()), placeholder: getAttr(m[1], "placeholder") });
+  }
+  for (const m of html.matchAll(/<input\b([^>]*?)\/?>/g)) {
+    const name = getAttr(m[1], "data-name");
+    if (!name) continue;
+    fields.set(name, { tag: "input", value: getAttr(m[1], "value"), placeholder: getAttr(m[1], "placeholder") });
+  }
+  for (const m of html.matchAll(/<select\b([^>]*)>([\s\S]*?)<\/select>/g)) {
+    const name = getAttr(m[1], "data-name");
+    if (!name) continue;
+    const selected = m[2].match(/<option\b[^>]*\bselected\b[^>]*>([^<]*)</);
+    fields.set(name, { tag: "select", value: selected ? decodeEntities(selected[1].trim()) : null, placeholder: null });
+  }
+  return fields;
+}
+
+/**
+ * Describe what visually changed between two view.html renders, at the
+ * granularity of individual named form fields - added/removed fields, and
+ * value/placeholder changes on fields present in both. Falls back to a
+ * generic note when the diff isn't explained by any anchored field (e.g. a
+ * layout/wrapper change with no `data-name` of its own).
+ * @param {string} beforeHtml
+ * @param {string} afterHtml
+ * @returns {Array<string>}
+ */
+function describeVisualChange(beforeHtml, afterHtml) {
+  const before = extractNamedFields(beforeHtml);
+  const after = extractNamedFields(afterHtml);
+  const notes = [];
+
+  for (const name of [...new Set([...before.keys(), ...after.keys()])].sort()) {
+    const b = before.get(name);
+    const a = after.get(name);
+    if (b && !a) {
+      notes.push(`field \`${name}\` removed`);
+      continue;
+    }
+    if (!b && a) {
+      notes.push(`field \`${name}\` added`);
+      continue;
+    }
+    if (b.value !== a.value) {
+      notes.push(`field \`${name}\` value: ${renderValue(b.value)} → ${renderValue(a.value)}`);
+    }
+    if ((b.placeholder || "") !== (a.placeholder || "")) {
+      notes.push(`field \`${name}\` placeholder: ${renderValue(b.placeholder || "")} → ${renderValue(a.placeholder || "")}`);
+    }
+  }
+
+  if (notes.length === 0) {
+    notes.push("layout/markup changed with no anchored field explaining it - compare the two view.html files directly");
+  }
+  return notes;
+}
+
+/**
+ * Compare an entry's rendered view.html between phases and describe what
+ * changed. Returns null when either file is missing (view.html wasn't
+ * extracted, or this run predates it) or when they're identical, so callers
+ * can skip the tier entirely rather than false-flagging.
+ * @param {string} resultsDir
+ * @param {string} kind
+ * @param {string} entryId
+ * @returns {{changes: Array<string>}|null}
+ */
+function describeViewHtmlDiff(resultsDir, kind, entryId) {
+  const beforePath = viewHtmlPath(resultsDir, kind, entryId, "before");
+  const afterPath = viewHtmlPath(resultsDir, kind, entryId, "after");
+  if (!fs.existsSync(beforePath) || !fs.existsSync(afterPath)) return null;
+  const beforeHtml = fs.readFileSync(beforePath, "utf8");
+  const afterHtml = fs.readFileSync(afterPath, "utf8");
+  if (beforeHtml === afterHtml) return null;
+  return { changes: describeVisualChange(beforeHtml, afterHtml) };
+}
+
+/**
+ * Add a set of changes to a per-template bucket, deduping identical changes
+ * across entries (with a count) and tracking one example entry to link back
+ * to for a reviewer.
+ * @param {Map} byTemplate
+ * @param {string} kind
+ * @param {string} label
+ * @param {string} entryKey - "kind/entryId"
+ * @param {Array<{key: string, before?: string, after?: string, summary?: string, subLines?: Array<string>}>} changes
+ * @param {string|null} url
+ */
+function addChangesToTemplate(byTemplate, kind, label, entryKey, changes, url) {
+  const templateKey = JSON.stringify([kind, label]);
+  if (!byTemplate.has(templateKey)) {
+    byTemplate.set(templateKey, {
+      label,
+      entryIds: new Set(),
+      changeCounts: new Map(),
+      exampleUrl: url,
+      exampleEntryKey: entryKey,
+    });
+  }
+  const bucket = byTemplate.get(templateKey);
+  bucket.entryIds.add(entryKey);
+  for (const change of changes) {
+    const dedupKey = changeDedupKey(change);
+    const existing = bucket.changeCounts.get(dedupKey);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      bucket.changeCounts.set(dedupKey, { ...change, count: 1 });
+    }
+  }
+}
+
+/**
+ * A stable string key identifying a change's shape, for cross-entry dedup.
+ * @param {{key: string, before?: string, after?: string, summary?: string, subLines?: Array<string>}} change
+ * @returns {string}
+ */
+function changeDedupKey(change) {
+  if (change.subLines !== undefined) return `${change.key}\x00${change.subLines.join("\x01")}`;
+  if (change.summary !== undefined) return `${change.key}\x00${change.summary}`;
+  return `${change.key}\x00${change.before}\x00${change.after}`;
+}
+
+/**
+ * Convert a byTemplate bucket map into a sorted, plain-object array.
+ * @param {Map} byTemplate
+ * @returns {Array<{label: string, entriesChanged: number, exampleUrl: string|null, exampleEntryKey: string, changes: Array}>}
+ */
+function toTemplatesArray(byTemplate) {
+  const templates = [...byTemplate.entries()]
+    .map(([, bucket]) => ({
+      label: bucket.label,
+      entriesChanged: bucket.entryIds.size,
+      exampleUrl: bucket.exampleUrl,
+      exampleEntryKey: bucket.exampleEntryKey,
+      // Most-repeated change first, then alphabetically by key for stability.
+      changes: [...bucket.changeCounts.values()].sort((x, y) => y.count - x.count || x.key.localeCompare(y.key)),
+    }))
+    .sort((x, y) => y.entriesChanged - x.entriesChanged || x.label.localeCompare(y.label));
+
+  return templates;
+}
+
+/**
+ * Walk an extracted results directory and build every compact-diff tier.
  * @param {string} resultsDir - Path to the extracted results directory
  * @returns {{
- *   summary: {templatesChanged: number, entriesChanged: number, entriesSampled: number, entriesSkipped: number},
- *   templates: Array<{label: string, entriesChanged: number, changes: Array<{key: string, before: string, after: string, count: number}>}>
+ *   summary: {templatesChanged: number, entriesChanged: number, entriesSampled: number, entriesSkipped: number, collapsedCount: number, visualOnlyCount: number},
+ *   templates: Array,
+ *   scopeTemplates: Array,
+ *   collapsedTemplates: Array,
+ *   visualOnlyEntries: Array<{kind: string, entryId: string, label: string, url: string|null, changes: Array<string>}>
  * }}
  */
 function extractCompact(resultsDir) {
   const labelMap = readEntryLabels(resultsDir);
   const outputDir = path.join(resultsDir, "output");
 
-  // JSON.stringify([kind, label]) -> { label, entryIds: Set, changeCounts: Map<"key\0before\0after", {key,before,after,count}> }
-  // Keyed by kind as well as label because the same label string could
-  // (however unlikely) apply to both an account and a reconciliation
-  // template - merging those would combine unrelated entries/changes.
   const byTemplate = new Map();
+  const scopeByTemplate = new Map();
+  const collapsedByTemplate = new Map();
+  const visualOnlyEntries = [];
   let entriesSampled = 0;
   let entriesSkipped = 0;
 
@@ -158,9 +581,9 @@ function extractCompact(resultsDir) {
       const entryDir = path.join(kindDir, entryId);
       if (!fs.statSync(entryDir).isDirectory()) continue;
 
-      const before = readNamedResults(path.join(entryDir, "before", "registers.json"));
-      const after = readNamedResults(path.join(entryDir, "after", "registers.json"));
-      if (before === null || after === null) {
+      const beforeRegisters = readRegisters(path.join(entryDir, "before", "registers.json"));
+      const afterRegisters = readRegisters(path.join(entryDir, "after", "registers.json"));
+      if (beforeRegisters === null || afterRegisters === null) {
         // registers.json missing/malformed - this entry was never actually
         // compared, so it shouldn't count toward "sampled".
         entriesSkipped += 1;
@@ -168,41 +591,54 @@ function extractCompact(resultsDir) {
       }
       entriesSampled += 1;
 
-      const changes = diffNamedResults(before, after);
-      if (changes.length === 0) continue;
-
       const entryKey = `${kind}/${entryId}`;
       const label = (labelMap[entryKey] && labelMap[entryKey].label) || entryId;
-      const templateKey = JSON.stringify([kind, label]);
-      if (!byTemplate.has(templateKey)) {
-        byTemplate.set(templateKey, { label, entryIds: new Set(), changeCounts: new Map() });
+      const url = (labelMap[entryKey] && labelMap[entryKey].url) || null;
+
+      const beforeNamed = namedResultsOf(beforeRegisters);
+      const afterNamed = namedResultsOf(afterRegisters);
+      const namedChanges = diffNamedResults(beforeNamed, afterNamed);
+
+      const resultsChange = diffResultsRegister(beforeRegisters.results, afterRegisters.results);
+      const dataChanges = resultsChange ? [...namedChanges, { key: "results", ...resultsChange }] : namedChanges;
+
+      // A template that broke mid-render loses many named_results/results
+      // keys at once - that's ONE finding ("output vanished"), not N.
+      const vanishedCount = dataChanges.filter((c) => c.after === "undefined").length;
+      const hadContentBefore = Object.keys(beforeNamed).length > 0 || beforeRegisters.results != null;
+      const isCollapse = hadContentBefore && vanishedCount === dataChanges.length && vanishedCount >= COLLAPSE_MIN_LOST_KEYS;
+
+      if (isCollapse) {
+        // Grouped and deduped the same way as data/scope changes, so a
+        // template that broke across dozens of sampled companies collapses
+        // into one section entry instead of one line per entry.
+        addChangesToTemplate(collapsedByTemplate, kind, label, entryKey, [{ key: "output vanished", summary: `${vanishedCount} value(s) lost` }], url);
+      } else if (dataChanges.length > 0) {
+        addChangesToTemplate(byTemplate, kind, label, entryKey, dataChanges, url);
       }
-      const bucket = byTemplate.get(templateKey);
-      bucket.entryIds.add(entryKey);
-      for (const change of changes) {
-        const dedupKey = `${change.key}\x00${change.before}\x00${change.after}`;
-        const existing = bucket.changeCounts.get(dedupKey);
-        if (existing) {
-          existing.count += 1;
-        } else {
-          bucket.changeCounts.set(dedupKey, { ...change, count: 1 });
+
+      const scopeChanges = diffScope(beforeRegisters, afterRegisters);
+      if (scopeChanges.length > 0) {
+        addChangesToTemplate(scopeByTemplate, kind, label, entryKey, scopeChanges, url);
+      }
+
+      // The visual-only tier only adds information when the data tier found
+      // nothing to explain a view.html change - otherwise it's just a noisier
+      // restatement of a finding already surfaced above.
+      if (!isCollapse && dataChanges.length === 0) {
+        const visualDiff = describeViewHtmlDiff(resultsDir, kind, entryId);
+        if (visualDiff) {
+          visualOnlyEntries.push({ kind, entryId, label, url, changes: visualDiff.changes });
         }
       }
     }
   }
 
-  const templates = [...byTemplate.entries()]
-    .map(([, bucket]) => ({
-      label: bucket.label,
-      entriesChanged: bucket.entryIds.size,
-      // Most-repeated change first, then alphabetically by key for stability.
-      changes: [...bucket.changeCounts.values()].sort(
-        (x, y) => y.count - x.count || x.key.localeCompare(y.key),
-      ),
-    }))
-    .sort((x, y) => y.entriesChanged - x.entriesChanged || x.label.localeCompare(y.label));
-
+  const templates = toTemplatesArray(byTemplate);
+  const scopeTemplates = toTemplatesArray(scopeByTemplate);
+  const collapsedTemplates = toTemplatesArray(collapsedByTemplate);
   const entriesChanged = templates.reduce((sum, t) => sum + t.entriesChanged, 0);
+  const collapsedCount = collapsedTemplates.reduce((sum, t) => sum + t.entriesChanged, 0);
 
   return {
     summary: {
@@ -210,49 +646,154 @@ function extractCompact(resultsDir) {
       entriesChanged,
       entriesSampled,
       entriesSkipped,
+      collapsedCount,
+      visualOnlyCount: visualOnlyEntries.length,
     },
     templates,
+    scopeTemplates,
+    collapsedTemplates,
+    visualOnlyEntries,
   };
 }
 
 /**
- * Format the compact diff as Markdown, suitable for stdout or a PR comment.
+ * A markdown link to an example entry: the live app URL when known, else a
+ * relative path into the results directory so a reviewer with the zip open
+ * locally still has somewhere to look.
+ * @param {string|null} url
+ * @param {string} entryKey - "kind/entryId"
+ * @returns {string}
+ */
+function exampleRef(url, entryKey) {
+  return url ? `([example](${url}))` : `(\`output/${entryKey}/\`)`;
+}
+
+/**
+ * @param {number} n
+ * @param {string} word - singular form, e.g. "entry"
+ * @returns {string} "entry" or "entries"/"words" as appropriate
+ */
+function pluralizeWord(n, word) {
+  if (n === 1) return word;
+  return word.endsWith("y") ? `${word.slice(0, -1)}ies` : `${word}s`;
+}
+
+/**
+ * Render a capped list of `{key, before, after}`, `{key, summary}`, or
+ * `{key, subLines}` change lines, disclosing how many were elided rather
+ * than silently dropping them. `subLines` (e.g. a `dependencies` change with
+ * one line per category: ledgers/handles/account ranges) renders as a nested
+ * list under the change's key instead of one semicolon-packed line.
+ * @param {Array<Object>} changes
+ * @returns {Array<string>}
+ */
+function formatChangeLines(changes) {
+  const lines = [];
+  for (const change of changes.slice(0, MAX_CHANGES_SHOWN)) {
+    const times = change.count > 1 ? `[${change.count}×] ` : "";
+    if (change.subLines !== undefined) {
+      lines.push(`- ${times}\`${change.key}\`:`);
+      for (const sub of change.subLines) lines.push(`  - ${sub}`);
+      continue;
+    }
+    const body = change.summary !== undefined ? change.summary : `\`${change.before}\` → \`${change.after}\``;
+    lines.push(`- ${times}\`${change.key}\`: ${body}`);
+  }
+  if (changes.length > MAX_CHANGES_SHOWN) {
+    lines.push(`- … +${changes.length - MAX_CHANGES_SHOWN} more change${changes.length - MAX_CHANGES_SHOWN === 1 ? "" : "s"}`);
+  }
+  return lines;
+}
+
+/**
+ * Format the full compact diff as Markdown, suitable for stdout or a PR
+ * comment. Sections only appear when they have content, and every finding
+ * points at a concrete file or URL to follow up on.
  * @param {ReturnType<typeof extractCompact>} data
  * @returns {string}
  */
 function formatCompact(data) {
-  const { summary, templates } = data;
+  const summary = data.summary || {};
+  const templates = data.templates || [];
+  const scopeTemplates = data.scopeTemplates || [];
+  const collapsedTemplates = data.collapsedTemplates || [];
+  const visualOnlyEntries = data.visualOnlyEntries || [];
   const lines = [];
-  lines.push("## 🧪 Sampler compact diff (named_results)");
+
+  lines.push("## 🧪 Sampler compact diff");
   lines.push("");
 
-  const skippedNote =
-    summary.entriesSkipped > 0
-      ? `, ${summary.entriesSkipped} skipped (unreadable registers.json)`
-      : "";
+  const nothingChanged = templates.length === 0 && scopeTemplates.length === 0 && collapsedTemplates.length === 0 && visualOnlyEntries.length === 0;
+  const skippedNote = summary.entriesSkipped > 0 ? `, ${summary.entriesSkipped} skipped (unreadable registers.json)` : "";
 
-  if (templates.length === 0) {
-    lines.push(
-      `No \`named_results\` changes across ${summary.entriesSampled} sampled entr${summary.entriesSampled === 1 ? "y" : "ies"}${skippedNote}.`,
-    );
+  if (nothingChanged) {
+    lines.push(`No changes detected across ${summary.entriesSampled} sampled ${pluralizeWord(summary.entriesSampled, "entry")}${skippedNote}.`);
     return lines.join("\n");
   }
 
-  lines.push(
-    `**${summary.templatesChanged}** template(s) changed across **${summary.entriesChanged}** ` +
-      `entr${summary.entriesChanged === 1 ? "y" : "ies"} (${summary.entriesSampled} sampled${skippedNote}).`,
-  );
+  const headline = [`**${summary.templatesChanged}** template(s) changed across **${summary.entriesChanged}** ${pluralizeWord(summary.entriesChanged, "entry")}`];
+  headline.push(`(${summary.entriesSampled} sampled${skippedNote})`);
+  lines.push(headline.join(" "));
+
+  if (collapsedTemplates.length > 0) {
+    lines.push("");
+    lines.push(`### ⚠️ Output vanished (${summary.collapsedCount} ${pluralizeWord(summary.collapsedCount, "entry")} across ${collapsedTemplates.length} template(s))`);
+    lines.push("Rendered output that existed before is completely gone after - check for a broken include/tag, not a data change.");
+    for (const template of collapsedTemplates) {
+      lines.push("");
+      const ref = exampleRef(template.exampleUrl, template.exampleEntryKey);
+      lines.push(`**${template.label}** — ${template.entriesChanged} ${pluralizeWord(template.entriesChanged, "entry")} collapsed ${ref}`);
+      lines.push(...formatChangeLines(template.changes));
+    }
+  }
 
   for (const template of templates) {
     lines.push("");
-    lines.push(`### ${template.label} — ${template.entriesChanged} entr${template.entriesChanged === 1 ? "y" : "ies"} changed`);
-    for (const change of template.changes) {
-      const times = change.count > 1 ? `[${change.count}×] ` : "";
-      lines.push(`- ${times}\`${change.key}\`: \`${change.before}\` → \`${change.after}\``);
+    const ref = exampleRef(template.exampleUrl, template.exampleEntryKey);
+    lines.push(`### ${template.label} — ${template.entriesChanged} ${pluralizeWord(template.entriesChanged, "entry")} changed ${ref}`);
+    lines.push(...formatChangeLines(template.changes));
+  }
+
+  if (scopeTemplates.length > 0) {
+    lines.push("");
+    lines.push("### 🔧 Scope/dependency changes");
+    lines.push("What each template depends on/requires changed - not its rendered data.");
+    for (const template of scopeTemplates) {
+      lines.push("");
+      const ref = exampleRef(template.exampleUrl, template.exampleEntryKey);
+      lines.push(`**${template.label}** — ${template.entriesChanged} ${pluralizeWord(template.entriesChanged, "entry")} ${ref}`);
+      lines.push(...formatChangeLines(template.changes));
+    }
+  }
+
+  if (visualOnlyEntries.length > 0) {
+    lines.push("");
+    lines.push(`### 👁️ Visual-only changes (${visualOnlyEntries.length} ${pluralizeWord(visualOnlyEntries.length, "entry")}, data unchanged)`);
+    lines.push("`view.html` differs even though named_results/results didn't - a markup/layout change the data diff can't see.");
+    for (const entry of visualOnlyEntries) {
+      lines.push("");
+      const entryKey = `${entry.kind}/${entry.entryId}`;
+      const ref = entry.url ? `[open in app](${entry.url}) · ` : "";
+      lines.push(`**${entry.label}** — ${ref}\`output/${entryKey}/{before,after}/view.html\``);
+      for (const note of entry.changes.slice(0, MAX_VISUAL_CHANGES_SHOWN)) {
+        lines.push(`- ${note}`);
+      }
+      if (entry.changes.length > MAX_VISUAL_CHANGES_SHOWN) {
+        const hidden = entry.changes.length - MAX_VISUAL_CHANGES_SHOWN;
+        lines.push(`- … +${hidden} more change${hidden === 1 ? "" : "s"}`);
+      }
     }
   }
 
   return lines.join("\n");
 }
 
-module.exports = { extractCompact, formatCompact, diffNamedResults, readEntryLabels };
+module.exports = {
+  extractCompact,
+  formatCompact,
+  diffNamedResults,
+  diffResultsRegister,
+  diffScope,
+  describeVisualChange,
+  readEntryLabels,
+};

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const YAML = require("yaml");
 
 /**
@@ -54,6 +55,16 @@ const MAX_VISUAL_CHANGES_SHOWN = 6;
 /**
  * Render a named_results value for display. Distinguishes an absent key
  * (template no longer emits it) from an explicit null, and elides long values.
+ *
+ * A truncated value's suffix includes both the full length and a short
+ * content hash, not just the length - two distinct long values that happen
+ * to share the same first `MAX_VALUE_CHARS` characters AND the same total
+ * length would otherwise render identically. That matters beyond display:
+ * this rendered string doubles as the cross-entry dedup key in
+ * `changeDedupKey`, so an identical-looking truncation would silently
+ * collapse two different values into one deduped change with an inflated
+ * count - exactly what this module's truncation is meant to avoid eliding
+ * silently.
  * @param {*} value
  * @returns {string}
  */
@@ -61,7 +72,8 @@ function renderValue(value) {
   if (value === ABSENT) return "undefined";
   const rendered = JSON.stringify(value);
   if (rendered.length > MAX_VALUE_CHARS) {
-    return `${rendered.slice(0, MAX_VALUE_CHARS)}…(${rendered.length} chars)`;
+    const hash = crypto.createHash("sha1").update(rendered).digest("hex").slice(0, 8);
+    return `${rendered.slice(0, MAX_VALUE_CHARS)}…(${rendered.length} chars, #${hash})`;
   }
   return rendered;
 }
@@ -180,12 +192,17 @@ function isFlagArray(arr) {
  * element 0/1) render as a triggered-count, since that's the reviewable
  * signal (e.g. "how many unreconciled indicators fired"); anything else
  * (raw numeric values from other template kinds) falls back to the plain
- * rendered value.
+ * rendered value. An absent register (`undefined`, the key was never there)
+ * and an explicit JSON `null` are rendered distinctly, since the latter can
+ * be a legitimate value and shouldn't be indistinguishable from - and
+ * miscounted alongside - a genuinely vanished register (see the "output
+ * vanished" collapse heuristic in extractCompact).
  * @param {*} value
  * @returns {string}
  */
 function formatResultsValue(value) {
-  if (value == null) return "undefined";
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
   if (isFlagArray(value)) {
     const triggered = value.filter((v) => v === "1.0" || v === "1").length;
     return `${triggered}/${value.length} triggered`;
@@ -197,6 +214,11 @@ function formatResultsValue(value) {
  * Diff the `results` register (Liquid's unnamed results array) between
  * phases. Unlike named_results this is a single un-keyed value per entry, so
  * it's either unchanged or it's one change - never one per array element.
+ * An absent register and an explicit `null` are treated as equivalent for
+ * the "did anything change" check (both mean "no results"), but the raw
+ * before/after values (not a null-normalized copy) are passed to
+ * formatResultsValue so a genuine change still displays "null" vs
+ * "undefined" distinctly rather than collapsing both to "undefined".
  * @param {*} before
  * @param {*} after
  * @returns {{before: string, after: string}|null}
@@ -209,14 +231,16 @@ function diffResultsRegister(before, after) {
 }
 
 /**
- * Set-diff two arrays of strings.
+ * Set-diff two arrays of strings. Non-array inputs (a malformed register
+ * value - a stray string/number/object instead of an array) are treated as
+ * empty rather than thrown on, so one bad entry can't abort the whole diff.
  * @param {Array<string>} beforeArr
  * @param {Array<string>} afterArr
  * @returns {{added: Array<string>, removed: Array<string>}|null} null if identical
  */
 function diffStringSet(beforeArr, afterArr) {
-  const before = new Set(beforeArr || []);
-  const after = new Set(afterArr || []);
+  const before = new Set(Array.isArray(beforeArr) ? beforeArr : []);
+  const after = new Set(Array.isArray(afterArr) ? afterArr : []);
   const added = [...after].filter((x) => !before.has(x)).sort();
   const removed = [...before].filter((x) => !after.has(x)).sort();
   if (added.length === 0 && removed.length === 0) return null;
@@ -265,6 +289,16 @@ function dependencyHandlesPerLedger(deps) {
 }
 
 /**
+ * @param {*} value
+ * @returns {Array} value if it's an array, else [] - a malformed register
+ *   value (a stray string/number/object instead of an array) shouldn't throw
+ *   and abort the whole sampler run's diff, just be treated as empty.
+ */
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
  * @param {Object} deps - a `dependencies` register value
  * @returns {Array<string>} every ledger id the template touches, from either
  *   the flat `ledgers` list or the handles-per-ledger map
@@ -272,7 +306,7 @@ function dependencyHandlesPerLedger(deps) {
 function dependencyLedgers(deps) {
   if (!deps) return [];
   const handlesPerLedger = dependencyHandlesPerLedger(deps);
-  return [...new Set([...(deps.ledgers || []).map(String), ...Object.keys(handlesPerLedger)])];
+  return [...new Set([...asArray(deps.ledgers).map(String), ...Object.keys(handlesPerLedger)])];
 }
 
 /**
@@ -303,7 +337,7 @@ function diffDependencies(before, after) {
   const handleDiff = diffStringSet(dependencyHandles(before), dependencyHandles(after));
   if (handleDiff) parts.push(formatSetSummary(handleDiff.added, handleDiff.removed, "handle"));
 
-  const rangeDiff = diffStringSet((before && before.account_ranges) || [], (after && after.account_ranges) || []);
+  const rangeDiff = diffStringSet(asArray(before && before.account_ranges), asArray(after && after.account_ranges));
   if (rangeDiff) parts.push(formatSetSummary(rangeDiff.added, rangeDiff.removed, "account range"));
 
   const beforeAttr = !!(before && before.company && before.company.attributes);
@@ -414,7 +448,10 @@ function extractNamedFields(html) {
   for (const m of html.matchAll(/<input\b([^>]*?)\/?>/g)) {
     const name = getAttr(m[1], "data-name");
     if (!name) continue;
-    fields.set(name, { tag: "input", value: getAttr(m[1], "value"), placeholder: getAttr(m[1], "placeholder") });
+    const rawValue = getAttr(m[1], "value");
+    // Decoded for consistency with the textarea/select branches above - an
+    // entity-encoded input value (e.g. `&amp;`) should render decoded here too.
+    fields.set(name, { tag: "input", value: rawValue === null ? null : decodeEntities(rawValue), placeholder: getAttr(m[1], "placeholder") });
   }
   for (const m of html.matchAll(/<select\b([^>]*)>([\s\S]*?)<\/select>/g)) {
     const name = getAttr(m[1], "data-name");
@@ -660,12 +697,19 @@ function extractCompact(resultsDir) {
  * A markdown link to an example entry: the live app URL when known, else a
  * relative path into the results directory so a reviewer with the zip open
  * locally still has somewhere to look.
+ *
+ * `url` comes from `sample_entry_ids.yml`, which with `--from-zip` is no
+ * longer guaranteed to originate from Silverfin's own sampler backend - it's
+ * whatever local zip the caller points at. It's validated as an http(s) URL
+ * before being interpolated into Markdown link syntax, since this compact
+ * diff is often posted verbatim as a PR/CI comment.
  * @param {string|null} url
  * @param {string} entryKey - "kind/entryId"
  * @returns {string}
  */
 function exampleRef(url, entryKey) {
-  return url ? `([example](${url}))` : `(\`output/${entryKey}/\`)`;
+  const safeUrl = typeof url === "string" && /^https?:\/\//.test(url) ? url : null;
+  return safeUrl ? `([example](${safeUrl}))` : `(\`output/${entryKey}/\`)`;
 }
 
 /**
@@ -731,9 +775,18 @@ function formatCompact(data) {
     return lines.join("\n");
   }
 
-  const headline = [`**${summary.templatesChanged}** template(s) changed across **${summary.entriesChanged}** ${pluralizeWord(summary.entriesChanged, "entry")}`];
-  headline.push(`(${summary.entriesSampled} sampled${skippedNote})`);
-  lines.push(headline.join(" "));
+  // Worded as data-diff (named_results/results) specific, and only shown as
+  // a "N template(s) changed" count when that tier actually has findings -
+  // otherwise a run whose only changes are in the collapsed/scope/visual
+  // tiers would print a contradictory "0 template(s) changed across 0
+  // entries" line directly above sections that clearly do report changes.
+  if (templates.length > 0) {
+    const headline = [`**${summary.templatesChanged}** template(s) changed across **${summary.entriesChanged}** ${pluralizeWord(summary.entriesChanged, "entry")} in named_results/results`];
+    headline.push(`(${summary.entriesSampled} sampled${skippedNote})`);
+    lines.push(headline.join(" "));
+  } else {
+    lines.push(`No named_results/results changes (${summary.entriesSampled} sampled${skippedNote}) - see other tiers below.`);
+  }
 
   if (collapsedTemplates.length > 0) {
     lines.push("");

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -694,21 +694,47 @@ function extractCompact(resultsDir) {
 }
 
 /**
- * A markdown link to an example entry: the live app URL when known, else a
- * relative path into the results directory so a reviewer with the zip open
- * locally still has somewhere to look.
+ * Validate a URL before it's interpolated into Markdown link syntax.
  *
- * `url` comes from `sample_entry_ids.yml`, which with `--from-zip` is no
- * longer guaranteed to originate from Silverfin's own sampler backend - it's
- * whatever local zip the caller points at. It's validated as an http(s) URL
- * before being interpolated into Markdown link syntax, since this compact
- * diff is often posted verbatim as a PR/CI comment.
+ * `url` values in this module come from `sample_entry_ids.yml`, which with
+ * `--from-zip` is no longer guaranteed to originate from Silverfin's own
+ * sampler backend - it's whatever local zip the caller points at. Checking
+ * only the scheme isn't enough: a value like
+ * `https://trusted.example/a) [injected](https://attacker)` still passes an
+ * `^https?://` check but closes the generated `(...)` link early and injects
+ * arbitrary Markdown - relevant since this diff is often posted verbatim as
+ * a PR/CI comment. Parentheses (the link-destination terminator),
+ * whitespace, angle brackets, and control characters are all rejected
+ * outright rather than escaped, since a real Silverfin app URL never needs
+ * any of them.
+ * @param {*} url
+ * @returns {string|null} the URL if it's safe to interpolate, else null
+ */
+function sanitizeUrl(url) {
+  if (typeof url !== "string") return null;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (/[()\s<>]/.test(url)) return null;
+  // eslint-disable-next-line no-control-regex -- deliberately scanning for control chars (e.g. line breaks) that could break out of Markdown link syntax.
+  if (/[\x00-\x1f]/.test(url)) return null;
+  return url;
+}
+
+/**
+ * A markdown link to an example entry: the live app URL when known and
+ * safe to link to, else a relative path into the results directory so a
+ * reviewer with the zip open locally still has somewhere to look.
  * @param {string|null} url
  * @param {string} entryKey - "kind/entryId"
  * @returns {string}
  */
 function exampleRef(url, entryKey) {
-  const safeUrl = typeof url === "string" && /^https?:\/\//.test(url) ? url : null;
+  const safeUrl = sanitizeUrl(url);
   return safeUrl ? `([example](${safeUrl}))` : `(\`output/${entryKey}/\`)`;
 }
 
@@ -826,7 +852,8 @@ function formatCompact(data) {
     for (const entry of visualOnlyEntries) {
       lines.push("");
       const entryKey = `${entry.kind}/${entry.entryId}`;
-      const ref = entry.url ? `[open in app](${entry.url}) · ` : "";
+      const safeUrl = sanitizeUrl(entry.url);
+      const ref = safeUrl ? `[open in app](${safeUrl}) · ` : "";
       lines.push(`**${entry.label}** — ${ref}\`output/${entryKey}/{before,after}/view.html\``);
       for (const note of entry.changes.slice(0, MAX_VISUAL_CHANGES_SHOWN)) {
         lines.push(`- ${note}`);

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -207,35 +207,58 @@ function normalizeFlag(v) {
  * miscounted alongside - a genuinely vanished register (see the "output
  * vanished" collapse heuristic in extractCompact).
  *
- * `other` is the paired before/after value, used only to catch the case
- * where two same-length flag vectors have the same triggered count but
- * different indices firing (e.g. ["1.0","0.0"] -> ["0.0","1.0"]) - without
- * it, both sides render as the identical "N/M triggered" string, which both
- * reads as a no-op to a reviewer and collapses distinct changes into one
- * cross-entry dedup bucket (changeDedupKey hashes this rendered string).
+ * `suffix` (from describeFlagFlipSuffix) is appended verbatim so a
+ * same-triggered-count reorder doesn't render as an identical no-op string
+ * on both sides of the diff.
  * @param {*} value
- * @param {*} [other]
+ * @param {string} [suffix]
  * @returns {string}
  */
-function formatResultsValue(value, other) {
+function formatResultsValue(value, suffix = "") {
   if (value === undefined) return "undefined";
   if (value === null) return "null";
   if (isFlagArray(value)) {
-    const triggered = value.filter((v) => v === "1.0" || v === "1").length;
-    let suffix = "";
-    if (Array.isArray(other) && isFlagArray(other) && other.length === value.length) {
-      const otherTriggered = other.filter((v) => v === "1.0" || v === "1").length;
-      const flipped = [];
-      for (let i = 0; i < value.length; i += 1) {
-        if (normalizeFlag(value[i]) !== normalizeFlag(other[i])) flipped.push(i);
-      }
-      if (triggered === otherTriggered && flipped.length > 0) {
-        suffix = ` (indices ${flipped.join(",")} flipped)`;
-      }
-    }
+    const triggered = value.filter((v) => normalizeFlag(v) === "1").length;
     return `${triggered}/${value.length} triggered${suffix}`;
   }
   return renderValue(value);
+}
+
+/**
+ * Describe a same-triggered-count flag-array reorder by which indices
+ * turned on vs off, e.g. "(0 off, 1 on)" - not just which indices differ.
+ * Naming direction (not just position) matters: two entries with opposite
+ * reorders (["1.0","0.0"]->["0.0","1.0"] vs ["0.0","1.0"]->["1.0","0.0"])
+ * touch the same index set, so a position-only suffix renders identically
+ * for both and they'd still collapse into one deduped change via
+ * changeDedupKey (which hashes this rendered string). Naming the direction
+ * of each flip makes the two cases render - and dedup - distinctly.
+ *
+ * The detail list is capped like `renderValue`'s truncation, with a content
+ * hash (not just a count) covering the elided flips - a plain "+N more"
+ * would let two different long vectors that agree on the first few flipped
+ * indices collapse into the same dedup key again.
+ * @param {Array<string>} before
+ * @param {Array<string>} after
+ * @returns {string} e.g. " (0 off, 1 on)", or "" if not a same-count reorder
+ */
+function describeFlagFlipSuffix(before, after) {
+  if (!isFlagArray(before) || !isFlagArray(after) || before.length !== after.length) return "";
+  const beforeTriggered = before.filter((v) => normalizeFlag(v) === "1").length;
+  const afterTriggered = after.filter((v) => normalizeFlag(v) === "1").length;
+  if (beforeTriggered !== afterTriggered) return "";
+
+  const flips = [];
+  for (let i = 0; i < before.length; i += 1) {
+    const b = normalizeFlag(before[i]);
+    const a = normalizeFlag(after[i]);
+    if (b !== a) flips.push(`${i} ${a === "1" ? "on" : "off"}`);
+  }
+  if (flips.length === 0) return "";
+
+  if (flips.length <= MAX_SET_ITEMS_SHOWN) return ` (${flips.join(", ")})`;
+  const hash = crypto.createHash("sha1").update(flips.join(",")).digest("hex").slice(0, 8);
+  return ` (${flips.slice(0, MAX_SET_ITEMS_SHOWN).join(", ")} +${flips.length - MAX_SET_ITEMS_SHOWN} more, #${hash})`;
 }
 
 /**
@@ -255,7 +278,8 @@ function diffResultsRegister(before, after) {
   const b = before == null ? null : before;
   const a = after == null ? null : after;
   if (JSON.stringify(b) === JSON.stringify(a)) return null;
-  return { before: formatResultsValue(before, after), after: formatResultsValue(after, before) };
+  const suffix = describeFlagFlipSuffix(before, after);
+  return { before: formatResultsValue(before, suffix), after: formatResultsValue(after, suffix) };
 }
 
 /**
@@ -449,9 +473,15 @@ function decodeEntities(text) {
  * @param {string} attrs - a tag's raw attribute string
  * @param {string} name
  * @returns {string|null} the attribute's value, or null if absent
+ *
+ * Anchored on a preceding whitespace (or start of string), not `\b` - a `\b`
+ * boundary also matches right after a hyphen, so `getAttr(attrs, "type")`
+ * would match inside `data-type="radio"` and misread it as `type="radio"`.
+ * `attrs` always starts with a leading space (it's everything between the
+ * tag name and `>`), so the whitespace anchor never misses the first attribute.
  */
 function getAttr(attrs, name) {
-  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`));
+  const match = attrs.match(new RegExp(`(?:^|\\s)${name}="([^"]*)"`));
   return match ? match[1] : null;
 }
 
@@ -485,7 +515,10 @@ function extractNamedFields(html) {
     // entity-encoded input value (e.g. `&amp;`) should render decoded here too.
     const decodedValue = rawValue === null ? null : decodeEntities(rawValue);
     if (getAttr(m[1], "type") === "radio") {
-      const isChecked = /\bchecked\b/.test(m[1]);
+      // Anchored on preceding whitespace, not `\b` - `aria-checked`/`data-checked`
+      // would otherwise also match, making every radio in a group look
+      // checked and silently reverting to last-wins.
+      const isChecked = /(?:^|\s)checked\b/.test(m[1]);
       if (isChecked) {
         fields.set(name, { tag: "input", value: decodedValue, placeholder: null });
       } else if (!fields.has(name)) {

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -188,6 +188,15 @@ function isFlagArray(arr) {
 }
 
 /**
+ * Normalize a flag-array element to "1" or "0" for index-by-index comparison.
+ * @param {string} v
+ * @returns {string}
+ */
+function normalizeFlag(v) {
+  return v === "1.0" || v === "1" ? "1" : "0";
+}
+
+/**
  * Format a `results` register value for display. Flag-shaped arrays (every
  * element 0/1) render as a triggered-count, since that's the reviewable
  * signal (e.g. "how many unreconciled indicators fired"); anything else
@@ -197,15 +206,34 @@ function isFlagArray(arr) {
  * be a legitimate value and shouldn't be indistinguishable from - and
  * miscounted alongside - a genuinely vanished register (see the "output
  * vanished" collapse heuristic in extractCompact).
+ *
+ * `other` is the paired before/after value, used only to catch the case
+ * where two same-length flag vectors have the same triggered count but
+ * different indices firing (e.g. ["1.0","0.0"] -> ["0.0","1.0"]) - without
+ * it, both sides render as the identical "N/M triggered" string, which both
+ * reads as a no-op to a reviewer and collapses distinct changes into one
+ * cross-entry dedup bucket (changeDedupKey hashes this rendered string).
  * @param {*} value
+ * @param {*} [other]
  * @returns {string}
  */
-function formatResultsValue(value) {
+function formatResultsValue(value, other) {
   if (value === undefined) return "undefined";
   if (value === null) return "null";
   if (isFlagArray(value)) {
     const triggered = value.filter((v) => v === "1.0" || v === "1").length;
-    return `${triggered}/${value.length} triggered`;
+    let suffix = "";
+    if (Array.isArray(other) && isFlagArray(other) && other.length === value.length) {
+      const otherTriggered = other.filter((v) => v === "1.0" || v === "1").length;
+      const flipped = [];
+      for (let i = 0; i < value.length; i += 1) {
+        if (normalizeFlag(value[i]) !== normalizeFlag(other[i])) flipped.push(i);
+      }
+      if (triggered === otherTriggered && flipped.length > 0) {
+        suffix = ` (indices ${flipped.join(",")} flipped)`;
+      }
+    }
+    return `${triggered}/${value.length} triggered${suffix}`;
   }
   return renderValue(value);
 }
@@ -227,7 +255,7 @@ function diffResultsRegister(before, after) {
   const b = before == null ? null : before;
   const a = after == null ? null : after;
   if (JSON.stringify(b) === JSON.stringify(a)) return null;
-  return { before: formatResultsValue(before), after: formatResultsValue(after) };
+  return { before: formatResultsValue(before, after), after: formatResultsValue(after, before) };
 }
 
 /**
@@ -433,7 +461,11 @@ function getAttr(attrs, name) {
  * Fields without a `data-name` (static markup, wrapper divs) aren't
  * individually addressable, so they fall outside this map entirely - a
  * change confined to those falls back to the generic note in
- * describeVisualChange.
+ * describeVisualChange. Radio groups share one `data-name` across several
+ * `<input>`s, so they're addressed by which option is `checked` (its
+ * `value`) rather than by attribute order like other inputs - otherwise a
+ * changed selection would be invisible (last radio in the group wins,
+ * `checked` never read).
  * @param {string} html
  * @returns {Map<string, {tag: string, value: string|null, placeholder: string|null}>}
  */
@@ -451,7 +483,17 @@ function extractNamedFields(html) {
     const rawValue = getAttr(m[1], "value");
     // Decoded for consistency with the textarea/select branches above - an
     // entity-encoded input value (e.g. `&amp;`) should render decoded here too.
-    fields.set(name, { tag: "input", value: rawValue === null ? null : decodeEntities(rawValue), placeholder: getAttr(m[1], "placeholder") });
+    const decodedValue = rawValue === null ? null : decodeEntities(rawValue);
+    if (getAttr(m[1], "type") === "radio") {
+      const isChecked = /\bchecked\b/.test(m[1]);
+      if (isChecked) {
+        fields.set(name, { tag: "input", value: decodedValue, placeholder: null });
+      } else if (!fields.has(name)) {
+        fields.set(name, { tag: "input", value: null, placeholder: null });
+      }
+      continue;
+    }
+    fields.set(name, { tag: "input", value: decodedValue, placeholder: getAttr(m[1], "placeholder") });
   }
   for (const m of html.matchAll(/<select\b([^>]*)>([\s\S]*?)<\/select>/g)) {
     const name = getAttr(m[1], "data-name");

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -596,7 +596,11 @@ function toTemplatesArray(byTemplate) {
  *   templates: Array,
  *   scopeTemplates: Array,
  *   collapsedTemplates: Array,
- *   visualOnlyEntries: Array<{kind: string, entryId: string, label: string, url: string|null, changes: Array<string>}>
+ *   visualOnlyEntries: Array<{kind: string, entryId: string, label: string, url: string|null, changes: Array<string>}>,
+ *   diffEntryKeys: Array<string> - every "kind/entryId" mentioned in any tier above (data,
+ *     scope, collapsed/vanished-output, visual-only), sorted. The set of entries a reviewer
+ *     would actually want before/after pairs for, as opposed to the (usually much larger)
+ *     set of entries sampled but rendered identically.
  * }}
  */
 function extractCompact(resultsDir) {
@@ -677,6 +681,20 @@ function extractCompact(resultsDir) {
   const entriesChanged = templates.reduce((sum, t) => sum + t.entriesChanged, 0);
   const collapsedCount = collapsedTemplates.reduce((sum, t) => sum + t.entriesChanged, 0);
 
+  const diffEntryKeys = new Set();
+  for (const bucket of byTemplate.values()) {
+    for (const entryKey of bucket.entryIds) diffEntryKeys.add(entryKey);
+  }
+  for (const bucket of scopeByTemplate.values()) {
+    for (const entryKey of bucket.entryIds) diffEntryKeys.add(entryKey);
+  }
+  for (const bucket of collapsedByTemplate.values()) {
+    for (const entryKey of bucket.entryIds) diffEntryKeys.add(entryKey);
+  }
+  for (const entry of visualOnlyEntries) {
+    diffEntryKeys.add(`${entry.kind}/${entry.entryId}`);
+  }
+
   return {
     summary: {
       templatesChanged: templates.length,
@@ -690,6 +708,7 @@ function extractCompact(resultsDir) {
     scopeTemplates,
     collapsedTemplates,
     visualOnlyEntries,
+    diffEntryKeys: [...diffEntryKeys].sort(),
   };
 }
 

--- a/lib/liquidSamplerCompact.js
+++ b/lib/liquidSamplerCompact.js
@@ -207,9 +207,11 @@ function normalizeFlag(v) {
  * miscounted alongside - a genuinely vanished register (see the "output
  * vanished" collapse heuristic in extractCompact).
  *
- * `suffix` (from describeFlagFlipSuffix) is appended verbatim so a
- * same-triggered-count reorder doesn't render as an identical no-op string
- * on both sides of the diff.
+ * `suffix` (from describeFlagFlipSuffix) is appended verbatim - callers pass
+ * it only on the `after` side, so a same-triggered-count reorder still
+ * renders "N/M triggered" -> "N/M triggered (...)" instead of the identical
+ * string on both sides (which would read as a no-op despite the direction
+ * being named in the text).
  * @param {*} value
  * @param {string} [suffix]
  * @returns {string}
@@ -279,7 +281,7 @@ function diffResultsRegister(before, after) {
   const a = after == null ? null : after;
   if (JSON.stringify(b) === JSON.stringify(a)) return null;
   const suffix = describeFlagFlipSuffix(before, after);
-  return { before: formatResultsValue(before, suffix), after: formatResultsValue(after, suffix) };
+  return { before: formatResultsValue(before), after: formatResultsValue(after, suffix) };
 }
 
 /**

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -327,22 +327,63 @@ class LiquidSamplerRunner {
   }
 
   /**
-   * Download the result zip, extract the named_results diff, and print a compact
-   * review-friendly summary to stdout (wrapped in markers for CI extraction).
-   * A failure here never fails the run - the run itself already succeeded and the
-   * report URL was logged; the compact diff is a best-effort convenience.
+   * Download the result zip and print the compact diff. A failure here never
+   * fails the run - the run itself already succeeded and the report URL was
+   * logged; the compact diff is a best-effort convenience.
    * @param {string} resultUrl - Presigned URL to the results.zip
    */
   async #printCompactDiff(resultUrl) {
+    try {
+      const response = await axios.get(resultUrl, {
+        responseType: "arraybuffer",
+        timeout: RESULTS_DOWNLOAD_TIMEOUT_MS,
+      });
+      await this.#printCompactFromBuffer(Buffer.from(response.data));
+    } catch (error) {
+      consola.warn(`Could not build compact diff (report is still available at the URL above): ${error.message}`);
+    }
+  }
+
+  /**
+   * Build the compact diff from an already-downloaded local results.zip - no
+   * network call, no partner/sampler API involved. Used by `--from-zip` to
+   * re-analyze a zip a reviewer already has on disk without re-triggering the
+   * backend run (which otherwise means another ~30-60 min wait per re-check).
+   * Unlike the live-run path, a failure here IS the whole point of the
+   * command, so it's a hard error rather than a warning.
+   * @param {string} zipPath - Path to a local results.zip
+   * @returns {Promise<void>}
+   */
+  async printCompactDiffFromZip(zipPath) {
+    let buffer;
+    try {
+      buffer = fs.readFileSync(zipPath);
+    } catch (error) {
+      consola.error(`Could not read zip at ${zipPath}: ${error.message}`);
+      process.exit(1);
+    }
+    try {
+      await this.#printCompactFromBuffer(buffer);
+    } catch (error) {
+      consola.error(`Could not build compact diff: ${error.message}`);
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Shared extract-diff-print-cleanup path for both the live download and
+   * the local-zip entry point. Lets errors propagate - callers decide whether
+   * a failure here is a soft warning or a hard exit.
+   * @param {Buffer} zipBuffer
+   */
+  async #printCompactFromBuffer(zipBuffer) {
     let resultsDir;
     try {
-      resultsDir = await this.#downloadAndExtractResults(resultUrl);
+      resultsDir = this.#extractResults(zipBuffer);
       const data = extractCompact(resultsDir);
       const body = escapeMarkers(formatCompact(data));
       // Plain stdout (not consola) so the markdown is captured verbatim in CI.
       console.log(`\n${COMPACT_START}\n${body}\n${COMPACT_END}`);
-    } catch (error) {
-      consola.warn(`Could not build compact diff (report is still available at the URL above): ${error.message}`);
     } finally {
       if (resultsDir) {
         fs.rmSync(resultsDir, { recursive: true, force: true });
@@ -351,25 +392,23 @@ class LiquidSamplerRunner {
   }
 
   /**
-   * Download the results.zip and selectively extract only the files needed for
-   * the named_results diff (sample_entry_ids.yml + every registers.json). The
-   * full archive is ~150 MB; extracting selectively keeps disk/IO minimal.
-   * @param {string} resultUrl - Presigned URL to the results.zip
-   * @returns {Promise<string>} Path to a temp directory holding the extracted files
+   * Selectively extract only the files the compact diff needs
+   * (sample_entry_ids.yml + every registers.json + every view.html) from a
+   * results.zip buffer. The full archive can run to ~150 MB (rendered_text.md
+   * + source_text.liquid dominate); extracting selectively keeps disk/IO minimal.
+   * @param {Buffer} zipBuffer
+   * @returns {string} Path to a temp directory holding the extracted files
    */
-  async #downloadAndExtractResults(resultUrl) {
-    const response = await axios.get(resultUrl, {
-      responseType: "arraybuffer",
-      timeout: RESULTS_DOWNLOAD_TIMEOUT_MS,
-    });
-    const zip = new AdmZip(Buffer.from(response.data));
+  #extractResults(zipBuffer) {
+    const zip = new AdmZip(zipBuffer);
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "silverfin-sampler-"));
     try {
       for (const entry of zip.getEntries()) {
         if (entry.isDirectory) continue;
         const name = entry.entryName;
-        if (name !== "sample_entry_ids.yml" && !name.endsWith("/registers.json")) continue;
+        const isNeeded = name === "sample_entry_ids.yml" || name.endsWith("/registers.json") || name.endsWith("/view.html");
+        if (!isNeeded) continue;
 
         const dest = path.resolve(tempDir, name);
         // Reject entries whose name (e.g. "../../etc/passwd") resolves outside

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -371,6 +371,64 @@ class LiquidSamplerRunner {
   }
 
   /**
+   * Add a `diffs/<kind>/<entryId>/{before,after}/view.html` folder to an
+   * existing results.zip, containing the before/after rendered view - as
+   * context, not for re-diffing - only for entries the compact diff actually
+   * flagged (data/scope/vanished-output/visual-only tiers). Lets a reviewer
+   * open just the changed pairs instead of digging through every sampled
+   * entry in the (often ~150 MB) full archive.
+   * Mutates the zip at `zipPath` in place. Like `--from-zip`, this is pure
+   * local re-analysis - no network call, no partner/sampler API involved.
+   * @param {string} zipPath - Path to a local results.zip
+   */
+  addDiffsFolderToZip(zipPath) {
+    let zipBuffer;
+    try {
+      zipBuffer = fs.readFileSync(zipPath);
+    } catch (error) {
+      consola.error(`Could not read zip at ${zipPath}: ${error.message}`);
+      process.exit(1);
+    }
+
+    let resultsDir;
+    try {
+      resultsDir = this.#extractResults(zipBuffer);
+      const data = extractCompact(resultsDir);
+
+      if (data.diffEntryKeys.length === 0) {
+        consola.info("No differing entries found - nothing to add to a diffs/ folder.");
+        return;
+      }
+
+      const zip = new AdmZip(zipBuffer);
+      let filesAdded = 0;
+      for (const entryKey of data.diffEntryKeys) {
+        const [kind, entryId] = entryKey.split("/");
+        for (const phase of ["before", "after"]) {
+          const viewHtmlPath = path.join(resultsDir, "output", kind, entryId, phase, "view.html");
+          if (!fs.existsSync(viewHtmlPath)) continue;
+          zip.addFile(`diffs/${kind}/${entryId}/${phase}/view.html`, fs.readFileSync(viewHtmlPath));
+          filesAdded += 1;
+        }
+      }
+
+      zip.writeZip(zipPath);
+      consola.success(
+        `Added diffs/ folder to ${zipPath}: ${filesAdded} view.html file(s) across ${data.diffEntryKeys.length} ${
+          data.diffEntryKeys.length === 1 ? "entry" : "entries"
+        }.`
+      );
+    } catch (error) {
+      consola.error(`Could not build diffs/ folder: ${error.message}`);
+      process.exit(1);
+    } finally {
+      if (resultsDir) {
+        fs.rmSync(resultsDir, { recursive: true, force: true });
+      }
+    }
+  }
+
+  /**
    * Shared extract-diff-print-cleanup path for both the live download and
    * the local-zip entry point. Lets errors propagate - callers decide whether
    * a failure here is a soft warning or a hard exit.

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -403,20 +403,47 @@ class LiquidSamplerRunner {
 
       const zip = new AdmZip(zipBuffer);
       let filesAdded = 0;
+      let identicalSkipped = 0;
       const entriesWithFiles = new Set();
       for (const entryKey of data.diffEntryKeys) {
         const [kind, entryId] = entryKey.split("/");
+        const phaseFiles = {};
         for (const phase of ["before", "after"]) {
           const viewHtmlPath = path.join(resultsDir, "output", kind, entryId, phase, "view.html");
-          if (!fs.existsSync(viewHtmlPath)) continue;
-          zip.addFile(`diffs/${kind}/${entryId}/${phase}/view.html`, fs.readFileSync(viewHtmlPath));
+          if (fs.existsSync(viewHtmlPath)) phaseFiles[phase] = fs.readFileSync(viewHtmlPath);
+        }
+
+        // An entry can be flagged for a change the RENDER doesn't show - a
+        // named_results/results value, a dependencies/scope change - in which
+        // case its two view.html files are byte-identical. Copying those in
+        // gives the reviewer a "diff" folder of pairs with nothing to compare
+        // (seen live: lu_market run 30920292551 produced 3 such pairs and
+        // nothing else). Only pairs that actually differ belong here.
+        if (phaseFiles.before && phaseFiles.after && phaseFiles.before.equals(phaseFiles.after)) {
+          identicalSkipped += 1;
+          continue;
+        }
+
+        for (const [phase, contents] of Object.entries(phaseFiles)) {
+          zip.addFile(`diffs/${kind}/${entryId}/${phase}/view.html`, contents);
           filesAdded += 1;
           entriesWithFiles.add(entryKey);
         }
       }
 
+      // Never silent about what was left out: a reviewer who sees no diffs/
+      // folder needs to know whether it's "nothing rendered differently" or
+      // "the render was never captured".
+      const skippedNote = identicalSkipped > 0 ? ` ${identicalSkipped} flagged ${identicalSkipped === 1 ? "entry" : "entries"} had identical before/after renders.` : "";
+
       if (filesAdded === 0) {
-        consola.info("No view.html files found for the differing entries - nothing to add to a diffs/ folder.");
+        if (identicalSkipped > 0) {
+          consola.info(
+            `No visual differences among the flagged entries - nothing to add to a diffs/ folder.${skippedNote} The change is in the data/scope tiers only; see the compact diff.`
+          );
+        } else {
+          consola.info("No view.html files found for the differing entries - nothing to add to a diffs/ folder.");
+        }
         return;
       }
 
@@ -427,7 +454,7 @@ class LiquidSamplerRunner {
       consola.success(
         `Added diffs/ folder to ${zipPath}: ${filesAdded} view.html file(s) across ${entriesWithFiles.size} ${
           entriesWithFiles.size === 1 ? "entry" : "entries"
-        }.`
+        }.${skippedNote}`
       );
     } catch (error) {
       consola.error(`Could not build diffs/ folder: ${error.message}`);

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -403,6 +403,7 @@ class LiquidSamplerRunner {
 
       const zip = new AdmZip(zipBuffer);
       let filesAdded = 0;
+      const entriesWithFiles = new Set();
       for (const entryKey of data.diffEntryKeys) {
         const [kind, entryId] = entryKey.split("/");
         for (const phase of ["before", "after"]) {
@@ -410,6 +411,7 @@ class LiquidSamplerRunner {
           if (!fs.existsSync(viewHtmlPath)) continue;
           zip.addFile(`diffs/${kind}/${entryId}/${phase}/view.html`, fs.readFileSync(viewHtmlPath));
           filesAdded += 1;
+          entriesWithFiles.add(entryKey);
         }
       }
 
@@ -423,8 +425,8 @@ class LiquidSamplerRunner {
       fs.renameSync(tmpZipPath, zipPath);
       tmpZipPath = undefined;
       consola.success(
-        `Added diffs/ folder to ${zipPath}: ${filesAdded} view.html file(s) across ${data.diffEntryKeys.length} ${
-          data.diffEntryKeys.length === 1 ? "entry" : "entries"
+        `Added diffs/ folder to ${zipPath}: ${filesAdded} view.html file(s) across ${entriesWithFiles.size} ${
+          entriesWithFiles.size === 1 ? "entry" : "entries"
         }.`
       );
     } catch (error) {

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -413,6 +413,11 @@ class LiquidSamplerRunner {
         }
       }
 
+      if (filesAdded === 0) {
+        consola.info("No view.html files found for the differing entries - nothing to add to a diffs/ folder.");
+        return;
+      }
+
       tmpZipPath = path.join(path.dirname(zipPath), `.${path.basename(zipPath)}.${process.pid}.tmp`);
       zip.writeZip(tmpZipPath);
       fs.renameSync(tmpZipPath, zipPath);

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -391,6 +391,7 @@ class LiquidSamplerRunner {
     }
 
     let resultsDir;
+    let tmpZipPath;
     try {
       resultsDir = this.#extractResults(zipBuffer);
       const data = extractCompact(resultsDir);
@@ -412,7 +413,10 @@ class LiquidSamplerRunner {
         }
       }
 
-      zip.writeZip(zipPath);
+      tmpZipPath = path.join(path.dirname(zipPath), `.${path.basename(zipPath)}.${process.pid}.tmp`);
+      zip.writeZip(tmpZipPath);
+      fs.renameSync(tmpZipPath, zipPath);
+      tmpZipPath = undefined;
       consola.success(
         `Added diffs/ folder to ${zipPath}: ${filesAdded} view.html file(s) across ${data.diffEntryKeys.length} ${
           data.diffEntryKeys.length === 1 ? "entry" : "entries"
@@ -424,6 +428,9 @@ class LiquidSamplerRunner {
     } finally {
       if (resultsDir) {
         fs.rmSync(resultsDir, { recursive: true, force: true });
+      }
+      if (tmpZipPath) {
+        fs.rmSync(tmpZipPath, { force: true });
       }
     }
   }

--- a/lib/liquidSamplerRunner.js
+++ b/lib/liquidSamplerRunner.js
@@ -229,7 +229,7 @@ class LiquidSamplerRunner {
   async #fetchAndWaitSamplerResult(samplerId) {
     let samplerRun = { status: "pending" };
     const pollingDelay = 15000; // 15 seconds
-    const waitingLimit = 3600000; // 1 hour
+    const waitingLimit = 7200000; // 2 hours
     const heartbeatInterval = 60000; // log a status line at most once a minute
 
     // The animated spinner relies on cursor/line control that only works on

--- a/tests/bin/cli.test.js
+++ b/tests/bin/cli.test.js
@@ -154,5 +154,10 @@ describe("bin/cli.js Commander wiring", () => {
       const output = runCli("run-sampler -h some_handle");
       expect(output).toMatch(/You need to specify a partner/);
     });
+
+    it("--add-diffs-folder without --from-zip is rejected before touching the partner API", () => {
+      const output = runCli("run-sampler --add-diffs-folder");
+      expect(output).toMatch(/--add-diffs-folder requires --from-zip/);
+    });
   });
 });

--- a/tests/bin/cli.test.js
+++ b/tests/bin/cli.test.js
@@ -140,4 +140,19 @@ describe("bin/cli.js Commander wiring", () => {
       expect(runCliExitCode("company-data-copier -f 13692")).toBe(1);
     });
   });
+
+  describe("silverfin run-sampler", () => {
+    it("--from-zip does not require -p/--partner (offline path, no partner API involved)", () => {
+      // No -p given; passing a non-existent zip path exercises the option
+      // parsing/validation only, before any partner-API-requiring code runs.
+      const output = runCli("run-sampler --from-zip /tmp/does-not-exist-cli-test.zip");
+      expect(output).not.toMatch(/You need to specify a partner/);
+      expect(output).toMatch(/Could not read zip/);
+    });
+
+    it("every other path still requires -p/--partner", () => {
+      const output = runCli("run-sampler -h some_handle");
+      expect(output).toMatch(/You need to specify a partner/);
+    });
+  });
 });

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -87,8 +87,19 @@ describe("liquidSamplerCompact - diffNamedResults", () => {
   it("truncates long values instead of printing them in full", () => {
     const longText = "x".repeat(500);
     const changes = diffNamedResults({ a: longText }, { a: "short" });
-    expect(changes[0].before).toMatch(/^"x+…\(502 chars\)$/);
-    expect(changes[0].before.length).toBeLessThan(120);
+    expect(changes[0].before).toMatch(/^"x+…\(502 chars, #[0-9a-f]{8}\)$/);
+    expect(changes[0].before.length).toBeLessThan(140);
+  });
+
+  it("gives distinct truncated values a distinct dedup fingerprint, even with the same prefix and length", () => {
+    // Same first 100 chars (JSON quote + 99 "x"s) and same total length (502),
+    // but genuinely different content - must not render identically, since
+    // the rendered string doubles as the cross-entry dedup key.
+    const longA = "x".repeat(499) + "A";
+    const longB = "x".repeat(499) + "B";
+    const changesA = diffNamedResults({ a: longA }, { a: "short" });
+    const changesB = diffNamedResults({ a: longB }, { a: "short" });
+    expect(changesA[0].before).not.toBe(changesB[0].before);
   });
 });
 
@@ -110,8 +121,14 @@ describe("liquidSamplerCompact - diffResultsRegister", () => {
     expect(diff.after).toBe('["996.08","27171.4"]');
   });
 
-  it("treats a vanished results register as undefined", () => {
-    expect(diffResultsRegister(["1.0"], null)).toEqual({ before: "1/1 triggered", after: "undefined" });
+  it("renders an explicit null distinctly from a genuinely absent (undefined) register", () => {
+    // Both are treated as equivalent to "no results" for the unchanged-check
+    // above, but once a change IS detected, the two must not display
+    // identically - `results: null` is a real distinction from the register
+    // being fully absent, and the "output vanished" collapse heuristic in
+    // extractCompact keys off this exact rendered string.
+    expect(diffResultsRegister(["1.0"], null)).toEqual({ before: "1/1 triggered", after: "null" });
+    expect(diffResultsRegister(["1.0"], undefined)).toEqual({ before: "1/1 triggered", after: "undefined" });
   });
 });
 
@@ -135,6 +152,19 @@ describe("liquidSamplerCompact - diffScope", () => {
     expect(change.subLines[1]).toContain("handle");
     expect(change.subLines[1]).toContain("b");
     expect(change.subLines[1]).toContain("c");
+  });
+
+  it("does not throw when `dependencies.ledgers` or `.account_ranges` is malformed (not an array)", () => {
+    // A single entry with a malformed register value shouldn't abort the
+    // whole run's diff (`.map` isn't a function on a string/number/object) -
+    // it should be treated the same as the value being absent.
+    const before = { dependencies: { ledgers: "not-an-array", account_ranges: 42 } };
+    const after = { dependencies: { ledgers: [1, 2], account_ranges: ["60"] } };
+    expect(() => diffScope(before, after)).not.toThrow();
+    const [change] = diffScope(before, after);
+    expect(change.key).toBe("dependencies");
+    expect(change.subLines.join(" ")).toContain("+2 ledgers (1, 2)");
+    expect(change.subLines.join(" ")).toContain('+1 account range (60)');
   });
 
   it("summarizes rollforward_params by name", () => {
@@ -210,6 +240,13 @@ describe("liquidSamplerCompact - describeVisualChange", () => {
     const after = field("unchanged", 'placeholder="p"', "v") + field("changed", "", "new");
     const notes = describeVisualChange(before, after);
     expect(notes).toEqual(['field `changed` value: "old" → "new"']);
+  });
+
+  it("decodes HTML entities in an <input> value, consistently with the <textarea>/<select> branches", () => {
+    const before = `<input data-name="company_name" value="Foo &amp; Bar" />`;
+    const after = `<input data-name="company_name" value="Foo &amp; Baz" />`;
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(['field `company_name` value: "Foo & Bar" → "Foo & Baz"']);
   });
 });
 
@@ -568,6 +605,24 @@ describe("liquidSamplerCompact - formatCompact", () => {
     expect(md).toContain("[example](https://example.staging.getsilverfin.com");
   });
 
+  it("falls back to an output-path reference instead of trusting an unsafe example URL", () => {
+    // `sample_entry_ids.yml` isn't guaranteed to come from Silverfin's own
+    // sampler backend with `--from-zip` - a crafted `url` value must not be
+    // interpolated straight into Markdown link syntax.
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        { id: "1", label: "unsafe_url_tpl", before: { a: "1" }, after: { a: "2" }, url: "javascript:alert(1)" },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).not.toContain("javascript:alert(1)");
+      expect(md).toContain("(`output/reconciliation_entries/1/`)");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a clear message when nothing changed at all, across every tier", () => {
     const md = formatCompact({ summary: { entriesSampled: 5 }, templates: [], scopeTemplates: [], collapsedTemplates: [], visualOnlyEntries: [] });
     expect(md).toContain("No changes detected across 5 sampled entries");
@@ -595,6 +650,20 @@ describe("liquidSamplerCompact - formatCompact", () => {
     const changeLines = md.split("\n").filter((l) => l.startsWith("- `key_"));
     expect(changeLines).toHaveLength(8);
     expect(md).toContain("+4 more changes");
+  });
+
+  it("doesn't print a contradictory '0 template(s) changed' headline when only the collapsed tier has findings", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [{ id: "1", label: "collapsed_only", before: { a: "1", b: "2", c: "3" }, after: {} }],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).not.toContain("**0** template(s) changed");
+      expect(md).toContain("No named_results/results changes");
+      expect(md).toContain("⚠️ Output vanished");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("renders the collapsed-output section with a file/url pointer, ahead of the normal template sections", () => {

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -623,6 +623,52 @@ describe("liquidSamplerCompact - formatCompact", () => {
     }
   });
 
+  it("rejects a URL that passes an http(s) scheme check but injects Markdown link syntax via parentheses", () => {
+    // `https://trusted.example/a) [injected](https://attacker)` starts with
+    // "https://" but the unescaped `)` closes the generated `(...)` link
+    // early, letting the rest inject arbitrary Markdown.
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "injection_tpl",
+          before: { a: "1" },
+          after: { a: "2" },
+          url: "https://trusted.example/a) [injected](https://attacker)",
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).not.toContain("[injected](https://attacker)");
+      expect(md).toContain("(`output/reconciliation_entries/1/`)");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("also sanitizes the visual-only section's 'open in app' link, not just exampleRef", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "visual_unsafe_url",
+          before: { a: "1" },
+          after: { a: "1" },
+          viewHtml: { before: "<div>old</div>", after: "<div>new</div>" },
+          url: "javascript:alert(1)",
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).not.toContain("javascript:alert(1)");
+      expect(md).not.toContain("[open in app]");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a clear message when nothing changed at all, across every tier", () => {
     const md = formatCompact({ summary: { entriesSampled: 5 }, templates: [], scopeTemplates: [], collapsedTemplates: [], visualOnlyEntries: [] });
     expect(md).toContain("No changes detected across 5 sampled entries");

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -1,14 +1,29 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { extractCompact, formatCompact, diffNamedResults, readEntryLabels } = require("../../lib/liquidSamplerCompact");
+const {
+  extractCompact,
+  formatCompact,
+  diffNamedResults,
+  diffResultsRegister,
+  diffScope,
+  describeVisualChange,
+  readEntryLabels,
+} = require("../../lib/liquidSamplerCompact");
 
 const FIXTURE_DIR = path.join(__dirname, "..", "fixtures", "sampler-results");
 
 /**
- * Build a minimal results directory (sample_entry_ids.yml + output/) under a
- * fresh temp dir, from a plain description of entries per kind.
- * @param {Object<string, Array<{id: string, label: string, before: Object, after: Object}>>} byKind
+ * Build a results directory (sample_entry_ids.yml + output/) under a fresh
+ * temp dir, from a plain description of entries per kind. Each entry accepts
+ * `before`/`after` (named_results), plus optional `registers` overrides
+ * (results/dependencies/rollforward_params/required_keys_missing, merged in
+ * per phase) and `viewHtml` (raw content per phase).
+ * @param {Object<string, Array<{
+ *   id: string, label: string, before: Object, after: Object,
+ *   registers?: {before?: Object, after?: Object},
+ *   viewHtml?: {before?: string, after?: string}
+ * }>>} byKind
  * @returns {string} path to the built results directory
  */
 function buildResultsDir(byKind) {
@@ -17,11 +32,15 @@ function buildResultsDir(byKind) {
   for (const [kind, entries] of Object.entries(byKind)) {
     yml[kind] = {};
     for (const entry of entries) {
-      yml[kind][entry.id] = { label: entry.label, url: null };
+      yml[kind][entry.id] = { label: entry.label, url: entry.url ?? null };
       for (const phase of ["before", "after"]) {
         const entryDir = path.join(dir, "output", kind, entry.id, phase);
         fs.mkdirSync(entryDir, { recursive: true });
-        fs.writeFileSync(path.join(entryDir, "registers.json"), JSON.stringify({ named_results: entry[phase] }));
+        const registers = { named_results: entry[phase], ...(entry.registers && entry.registers[phase]) };
+        fs.writeFileSync(path.join(entryDir, "registers.json"), JSON.stringify(registers));
+        if (entry.viewHtml && entry.viewHtml[phase] !== undefined) {
+          fs.writeFileSync(path.join(entryDir, "view.html"), entry.viewHtml[phase]);
+        }
       }
     }
   }
@@ -63,6 +82,134 @@ describe("liquidSamplerCompact - diffNamedResults", () => {
   it("still treats array element reordering as a real change", () => {
     const changes = diffNamedResults({ a: [1, 2] }, { a: [2, 1] });
     expect(changes.map((c) => c.key)).toEqual(["a"]);
+  });
+
+  it("truncates long values instead of printing them in full", () => {
+    const longText = "x".repeat(500);
+    const changes = diffNamedResults({ a: longText }, { a: "short" });
+    expect(changes[0].before).toMatch(/^"x+…\(502 chars\)$/);
+    expect(changes[0].before.length).toBeLessThan(120);
+  });
+});
+
+describe("liquidSamplerCompact - diffResultsRegister", () => {
+  it("returns null when unchanged", () => {
+    expect(diffResultsRegister(["1.0"], ["1.0"])).toBeNull();
+    expect(diffResultsRegister(null, null)).toBeNull();
+    expect(diffResultsRegister(undefined, null)).toBeNull();
+  });
+
+  it("formats an all-0/1 array as a triggered count", () => {
+    expect(diffResultsRegister(["1.0"], ["0.0"])).toEqual({ before: "1/1 triggered", after: "0/1 triggered" });
+    expect(diffResultsRegister(["0.0", "0.0"], ["1.0", "0.0"])).toEqual({ before: "0/2 triggered", after: "1/2 triggered" });
+  });
+
+  it("falls back to the raw value for non-flag (raw numeric) results arrays", () => {
+    const diff = diffResultsRegister(["996.08", "0.0"], ["996.08", "27171.4"]);
+    expect(diff.before).toBe('["996.08","0.0"]');
+    expect(diff.after).toBe('["996.08","27171.4"]');
+  });
+
+  it("treats a vanished results register as undefined", () => {
+    expect(diffResultsRegister(["1.0"], null)).toEqual({ before: "1/1 triggered", after: "undefined" });
+  });
+});
+
+describe("liquidSamplerCompact - diffScope", () => {
+  it("returns nothing when dependencies/rollforward_params/required_keys_missing are unchanged", () => {
+    const registers = {
+      dependencies: { ledgers: [1], reconciliations: { handles_per_ledger: { 1: ["general_settings"] } } },
+      rollforward_params: [{ name: "a" }],
+      required_keys_missing: ["x"],
+    };
+    expect(diffScope(registers, registers)).toEqual([]);
+  });
+
+  it("summarizes dependency changes as one sub-line per category (ledgers/handles/...), not a semicolon-packed dump", () => {
+    const before = { dependencies: { ledgers: [1, 2], reconciliations: { handles_per_ledger: { 1: ["a", "b"], 2: ["c"] } } } };
+    const after = { dependencies: { reconciliations: { handles_per_ledger: { 1: ["a"] } } } };
+    const [change] = diffScope(before, after);
+    expect(change.key).toBe("dependencies");
+    expect(change.subLines).toHaveLength(2);
+    expect(change.subLines[0]).toBe("−1 ledger (2)");
+    expect(change.subLines[1]).toContain("handle");
+    expect(change.subLines[1]).toContain("b");
+    expect(change.subLines[1]).toContain("c");
+  });
+
+  it("summarizes rollforward_params by name", () => {
+    const before = { rollforward_params: [{ name: "selected.size_company" }, { name: "deposit_layout.dropdown" }] };
+    const after = { rollforward_params: [{ name: "selected.size_company" }, { name: "show_prev_year_balance.presentation" }] };
+    const [change] = diffScope(before, after);
+    expect(change.key).toBe("rollforward_params");
+    expect(change.summary).toBe("−1 param (deposit_layout.dropdown), +1 param (show_prev_year_balance.presentation)");
+  });
+
+  it("summarizes required_keys_missing as added/removed keys", () => {
+    const before = { required_keys_missing: ["letter_of_representation.date"] };
+    const after = { required_keys_missing: ["letter_of_representation.date", "report.period", "statements.signed"] };
+    const [change] = diffScope(before, after);
+    expect(change.key).toBe("required_keys_missing");
+    expect(change.summary).toBe("+2 keys (report.period, statements.signed)");
+  });
+
+  it("caps preview lists and discloses the remainder", () => {
+    const before = { required_keys_missing: [] };
+    const after = { required_keys_missing: ["a", "b", "c", "d", "e"] };
+    const [change] = diffScope(before, after);
+    expect(change.summary).toBe("+5 keys (a, b, c +2 more)");
+  });
+});
+
+describe("liquidSamplerCompact - describeVisualChange", () => {
+  const field = (name, attrs, value) =>
+    `<td><textarea data-name="${name}" data-object-type="ReconciliationText" ${attrs}>${value}</textarea></td>`;
+
+  it("reports a removed field when a data-name'd tag disappears entirely", () => {
+    const before = field("salutation.address", 'placeholder="Begroeting"', "Aan het bestuur van:");
+    const after = `<td class="usr-width-76">&nbsp;</td><td></td>`;
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(["field `salutation.address` removed"]);
+  });
+
+  it("reports an added field the same way, symmetrically", () => {
+    const before = `<td></td>`;
+    const after = field("salutation.address", 'placeholder="Begroeting"', "Aan het bestuur van:");
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(["field `salutation.address` added"]);
+  });
+
+  it("reports a placeholder change on an otherwise-unchanged field (the real ac_policies_BS case)", () => {
+    const before = field("salutation.header", 'placeholder=""', "Geacht bestuur,");
+    const after = field("salutation.header", 'placeholder="Geacht bestuur,"', "Geacht bestuur,");
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(['field `salutation.header` placeholder: "" → "Geacht bestuur,"']);
+  });
+
+  it("reports a value change on a field whose placeholder didn't change", () => {
+    const before = field("company_city", 'placeholder=""', "Amsterdam");
+    const after = field("company_city", 'placeholder=""', "Rotterdam");
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(['field `company_city` value: "Amsterdam" → "Rotterdam"']);
+  });
+
+  it("reports both a value and a placeholder change as two separate notes", () => {
+    const before = field("x", 'placeholder="old hint"', "old value");
+    const after = field("x", 'placeholder="new hint"', "new value");
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(['field `x` value: "old value" → "new value"', 'field `x` placeholder: "old hint" → "new hint"']);
+  });
+
+  it("falls back to a generic note when no anchored field explains the diff", () => {
+    const notes = describeVisualChange("<div>old layout</div>", "<div class=\"new\">new layout</div>");
+    expect(notes).toEqual(["layout/markup changed with no anchored field explaining it - compare the two view.html files directly"]);
+  });
+
+  it("says nothing about fields that are identical in both", () => {
+    const before = field("unchanged", 'placeholder="p"', "v") + field("changed", "", "old");
+    const after = field("unchanged", 'placeholder="p"', "v") + field("changed", "", "new");
+    const notes = describeVisualChange(before, after);
+    expect(notes).toEqual(['field `changed` value: "old" → "new"']);
   });
 });
 
@@ -126,11 +273,18 @@ describe("liquidSamplerCompact - extractCompact", () => {
     expect(streetChange).toEqual({ key: "street_var", before: '""', after: "null", count: 2 });
   });
 
-  it("surfaces a broken template (value -> removed) as undefined", () => {
+  it("surfaces a broken template (value -> removed) as undefined when below the collapse threshold", () => {
     const liq = data.templates.find((t) => t.label === "liquidation_reserve");
     const change = liq.changes.find((c) => c.key === "distributable_at_5");
     expect(change.before).toBe('"20615.89"');
     expect(change.after).toBe("undefined");
+    // Only 1 key lost - not enough to call it a collapse.
+    expect(data.collapsedTemplates).toEqual([]);
+  });
+
+  it("attaches an example URL to each template for follow-up", () => {
+    const vkt = data.templates.find((t) => t.label === "vkt_1");
+    expect(vkt.exampleUrl).toMatch(/^https:\/\/example\.staging\.getsilverfin\.com/);
   });
 
   it("falls back to raw entry id when labels are missing", () => {
@@ -218,27 +372,352 @@ describe("liquidSamplerCompact - extractCompact", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("groups >= 3 keys vanishing at once into a single collapsed-template finding", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "7000",
+          label: "ac_policies_BS",
+          before: { a: "long policy text a", b: "long policy text b", c: "long policy text c" },
+          after: {},
+        },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.templates).toEqual([]); // not folded into the normal data-diff tier
+      expect(data.collapsedTemplates).toHaveLength(1);
+      expect(data.collapsedTemplates[0]).toMatchObject({ label: "ac_policies_BS", entriesChanged: 1 });
+      expect(data.collapsedTemplates[0].changes[0]).toMatchObject({ key: "output vanished", summary: "3 value(s) lost" });
+      expect(data.summary.collapsedCount).toBe(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("groups multiple collapsed entries of the same template into one finding", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        { id: "7010", label: "note_BEivAgi", before: { a: "1", b: "2", c: "3" }, after: {} },
+        { id: "7011", label: "note_BEivAgi", before: { a: "1", b: "2", c: "3" }, after: {} },
+        { id: "7012", label: "note_BEivAgi", before: { a: "1", b: "2", c: "3", d: "4" }, after: {} },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.collapsedTemplates).toHaveLength(1);
+      expect(data.collapsedTemplates[0].entriesChanged).toBe(3);
+      // Two entries lost 3 keys (deduped with a count), one lost 4 (separate line).
+      expect(data.collapsedTemplates[0].changes).toEqual(
+        expect.arrayContaining([
+          { key: "output vanished", summary: "3 value(s) lost", count: 2 },
+          { key: "output vanished", summary: "4 value(s) lost", count: 1 },
+        ]),
+      );
+      expect(data.summary.collapsedCount).toBe(3);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat 1-2 lost keys as a collapse (stays in the normal data-diff tier)", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [{ id: "7001", label: "small_break", before: { a: "1", b: "2" }, after: {} }],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.collapsedTemplates).toEqual([]);
+      expect(data.templates.map((t) => t.label)).toEqual(["small_break"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a template gaining named_results from nothing as a collapse", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [{ id: "7002", label: "newly_populated", before: {}, after: { a: "1", b: "2", c: "3" } }],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.collapsedTemplates).toEqual([]);
+      expect(data.templates.map((t) => t.label)).toEqual(["newly_populated"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a `results` register change alongside named_results changes", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "8000",
+          label: "general_settings",
+          before: {},
+          after: {},
+          registers: { before: { results: ["1.0"] }, after: { results: ["0.0"] } },
+        },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      const template = data.templates.find((t) => t.label === "general_settings");
+      const resultsChange = template.changes.find((c) => c.key === "results");
+      expect(resultsChange).toMatchObject({ before: "1/1 triggered", after: "0/1 triggered" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports scope (dependencies/rollforward_params/required_keys_missing) changes separately from data changes", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "9000",
+          label: "general_settings",
+          before: {},
+          after: {},
+          registers: {
+            before: { dependencies: { ledgers: [1, 2] } },
+            after: { dependencies: { ledgers: [1] } },
+          },
+        },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      // No data (named_results/results) change - must not appear in the main tier.
+      expect(data.templates).toEqual([]);
+      expect(data.scopeTemplates).toHaveLength(1);
+      expect(data.scopeTemplates[0].label).toBe("general_settings");
+      expect(data.scopeTemplates[0].changes[0]).toMatchObject({ key: "dependencies" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a visual-only change (view.html differs, named_results/results identical) and describes it field-by-field", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "10000",
+          label: "general_settings",
+          before: { a: "1" },
+          after: { a: "1" },
+          viewHtml: {
+            before: '<textarea data-name="salutation.header" placeholder="">Geacht bestuur,</textarea>',
+            after: '<textarea data-name="salutation.header" placeholder="Geacht bestuur,">Geacht bestuur,</textarea>',
+          },
+        },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.templates).toEqual([]);
+      expect(data.visualOnlyEntries).toHaveLength(1);
+      expect(data.visualOnlyEntries[0]).toMatchObject({ label: "general_settings", entryId: "10000" });
+      expect(data.visualOnlyEntries[0].changes).toEqual(['field `salutation.header` placeholder: "" → "Geacht bestuur,"']);
+      expect(data.summary.visualOnlyCount).toBe(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT flag a visual-only change when the data already changed (avoids redundant noise)", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "10001",
+          label: "general_settings",
+          before: { a: "1" },
+          after: { a: "2" },
+          viewHtml: { before: "<div>old</div>", after: "<div>new</div>" },
+        },
+      ],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.visualOnlyEntries).toEqual([]);
+      expect(data.templates).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not flag anything when view.html wasn't extracted at all", () => {
+    // No viewHtml given -> files simply don't exist, same as the old selective extraction.
+    const dir = buildResultsDir({
+      reconciliation_entries: [{ id: "10002", label: "general_settings", before: { a: "1" }, after: { a: "1" } }],
+    });
+    try {
+      const data = extractCompact(dir);
+      expect(data.visualOnlyEntries).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("liquidSamplerCompact - formatCompact", () => {
-  it("renders a markdown summary with per-template sections", () => {
+  it("renders a markdown summary with per-template sections and an example link", () => {
     const md = formatCompact(extractCompact(FIXTURE_DIR));
-    expect(md).toContain("Sampler compact diff (named_results)");
+    expect(md).toContain("## 🧪 Sampler compact diff");
     expect(md).toContain("### vkt_1");
     expect(md).toContain("[2×] `street_var`: `\"\"` → `null`");
     expect(md).toContain("### liquidation_reserve");
+    expect(md).toContain("[example](https://example.staging.getsilverfin.com");
   });
 
-  it("renders a clear message when nothing changed", () => {
-    const md = formatCompact({ summary: { templatesChanged: 0, entriesChanged: 0, entriesSampled: 5 }, templates: [] });
-    expect(md).toContain("No `named_results` changes across 5 sampled entries");
+  it("renders a clear message when nothing changed at all, across every tier", () => {
+    const md = formatCompact({ summary: { entriesSampled: 5 }, templates: [], scopeTemplates: [], collapsedTemplates: [], visualOnlyEntries: [] });
+    expect(md).toContain("No changes detected across 5 sampled entries");
   });
 
   it("discloses skipped entries when some registers.json were unreadable", () => {
     const md = formatCompact({
       summary: { templatesChanged: 0, entriesChanged: 0, entriesSampled: 5, entriesSkipped: 2 },
       templates: [],
+      scopeTemplates: [],
+      collapsedTemplates: [],
+      visualOnlyEntries: [],
     });
     expect(md).toContain("2 skipped (unreadable registers.json)");
+  });
+
+  it("caps the number of change lines per template and discloses the remainder", () => {
+    const before = {};
+    const after = {};
+    for (let i = 0; i < 12; i++) after[`key_${i}`] = `value_${i}`;
+    const data = extractCompact(
+      buildResultsDir({ reconciliation_entries: [{ id: "1", label: "many_changes", before, after }] }),
+    );
+    const md = formatCompact(data);
+    const changeLines = md.split("\n").filter((l) => l.startsWith("- `key_"));
+    expect(changeLines).toHaveLength(8);
+    expect(md).toContain("+4 more changes");
+  });
+
+  it("renders the collapsed-output section with a file/url pointer, ahead of the normal template sections", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        { id: "1", label: "collapsed_tpl", before: { a: "1", b: "2", c: "3" }, after: {}, url: "https://app.example.com/entry/1" },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).toContain("⚠️ Output vanished");
+      expect(md).toContain("collapsed_tpl");
+      expect(md).toContain("3 value(s) lost");
+      expect(md).toContain("[example](https://app.example.com/entry/1)");
+      expect(md.indexOf("⚠️ Output vanished")).toBeLessThan(md.indexOf("🔧 Scope") === -1 ? Infinity : md.indexOf("🔧 Scope"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders the scope section with a file/url pointer and without arrows (it's a delta, not a before/after pair)", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "scoped_tpl",
+          before: {},
+          after: {},
+          registers: { before: { required_keys_missing: [] }, after: { required_keys_missing: ["report.period"] } },
+          url: "https://app.example.com/entry/1",
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).toContain("🔧 Scope/dependency changes");
+      expect(md).toContain("required_keys_missing");
+      expect(md).toContain("report.period");
+      expect(md).toContain("[example](https://app.example.com/entry/1)");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders the visual-only section pointing at the view.html files, with the field-level change explained", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "visual_tpl",
+          before: { a: "1" },
+          after: { a: "1" },
+          viewHtml: {
+            before: '<textarea data-name="salutation.header" placeholder="">Geacht bestuur,</textarea>',
+            after: '<textarea data-name="salutation.header" placeholder="Geacht bestuur,">Geacht bestuur,</textarea>',
+          },
+          url: "https://app.example.com/entry/1",
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      expect(md).toContain("👁️ Visual-only changes");
+      expect(md).toContain("visual_tpl");
+      expect(md).toContain("[open in app](https://app.example.com/entry/1)");
+      expect(md).toContain("output/reconciliation_entries/1/{before,after}/view.html");
+      expect(md).toContain('- field `salutation.header` placeholder: "" → "Geacht bestuur,"');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("caps visual-only change notes per entry and discloses the remainder", () => {
+    const fields = Array.from({ length: 8 }, (_, i) => i);
+    const html = (val) => fields.map((i) => `<textarea data-name="f${i}">${val}${i}</textarea>`).join("");
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "many_visual_changes",
+          before: { a: "1" },
+          after: { a: "1" },
+          viewHtml: { before: html("old"), after: html("new") },
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      const noteLines = md.split("\n").filter((l) => l.startsWith("- field `f"));
+      expect(noteLines).toHaveLength(6);
+      expect(md).toContain("+2 more change");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders a dependencies change as an indented sub-list, one category per line", () => {
+    const dir = buildResultsDir({
+      reconciliation_entries: [
+        {
+          id: "1",
+          label: "deps_tpl",
+          before: {},
+          after: {},
+          registers: {
+            before: { dependencies: { ledgers: [1, 2], account_ranges: ["A%"] } },
+            after: { dependencies: { ledgers: [1] } },
+          },
+        },
+      ],
+    });
+    try {
+      const md = formatCompact(extractCompact(dir));
+      const lines = md.split("\n");
+      const keyLineIndex = lines.findIndex((l) => l.includes("`dependencies`:"));
+      expect(keyLineIndex).toBeGreaterThan(-1);
+      // No colon-separated summary crammed onto the key line itself.
+      expect(lines[keyLineIndex].trim()).toMatch(/`dependencies`:$/);
+      // Each category is its own indented sub-bullet underneath.
+      expect(lines[keyLineIndex + 1]).toMatch(/^ {2}- −1 ledger \(2\)$/);
+      expect(lines[keyLineIndex + 2]).toMatch(/^ {2}- −1 account range \(A%\)$/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -115,20 +115,41 @@ describe("liquidSamplerCompact - diffResultsRegister", () => {
     expect(diffResultsRegister(["0.0", "0.0"], ["1.0", "0.0"])).toEqual({ before: "0/2 triggered", after: "1/2 triggered" });
   });
 
-  it("names the flipped indices when a flag-array reorder keeps the same triggered count", () => {
-    // Same 1/2 triggered on both sides - without the flipped-index suffix
-    // this rendered identically on both sides and looked like a no-op, and
+  it("names which indices turned on/off when a flag-array reorder keeps the same triggered count", () => {
+    // Same 1/2 triggered on both sides - without naming direction this
+    // rendered identically on both sides and looked like a no-op, and
     // collapsed distinct reorders into one deduped change (see the
-    // dedup-key test below).
+    // dedup-key tests below).
     const diff = diffResultsRegister(["1.0", "0.0"], ["0.0", "1.0"]);
-    expect(diff.before).toBe("1/2 triggered (indices 0,1 flipped)");
-    expect(diff.after).toBe("1/2 triggered (indices 0,1 flipped)");
+    expect(diff.before).toBe("1/2 triggered (0 off, 1 on)");
+    expect(diff.after).toBe("1/2 triggered (0 off, 1 on)");
   });
 
   it("does not dedupe two entries whose flag-array reorders flip different indices into one change", () => {
     const a = diffResultsRegister(["1.0", "0.0", "0.0", "0.0"], ["0.0", "1.0", "0.0", "0.0"]);
     const b = diffResultsRegister(["0.0", "0.0", "1.0", "0.0"], ["0.0", "0.0", "0.0", "1.0"]);
     expect(a).not.toEqual(b);
+  });
+
+  it("does not dedupe two entries with opposite same-index reorders (naming direction, not just position)", () => {
+    // Both touch indices 0 and 1 - a position-only suffix (e.g. "indices
+    // 0,1 flipped") would render identically for both directions and still
+    // collapse them into one deduped change.
+    const a = diffResultsRegister(["1.0", "0.0"], ["0.0", "1.0"]);
+    const b = diffResultsRegister(["0.0", "1.0"], ["1.0", "0.0"]);
+    expect(a).not.toEqual(b);
+  });
+
+  it("caps the flip suffix and fingerprints the elided flips, so two long vectors don't collapse", () => {
+    const before = Array.from({ length: 20 }, (_, i) => (i % 2 === 0 ? "1.0" : "0.0"));
+    const afterA = before.map((v, i) => (i < 10 ? (v === "1.0" ? "0.0" : "1.0") : v));
+    const afterB = before.map((v, i) => (i >= 10 ? (v === "1.0" ? "0.0" : "1.0") : v));
+
+    const diffA = diffResultsRegister(before, afterA);
+    const diffB = diffResultsRegister(before, afterB);
+
+    expect(diffA.before.length).toBeLessThan(100);
+    expect(diffA).not.toEqual(diffB);
   });
 
   it("falls back to the raw value for non-flag (raw numeric) results arrays", () => {
@@ -269,6 +290,18 @@ describe("liquidSamplerCompact - describeVisualChange", () => {
     const radioGroup = (checkedValue) =>
       `<input type="radio" data-name="filing_type" value="vol" ${checkedValue === "vol" ? "checked" : ""} />` +
       `<input type="radio" data-name="filing_type" value="vkt" ${checkedValue === "vkt" ? "checked" : ""} />`;
+    const notes = describeVisualChange(radioGroup("vol"), radioGroup("vkt"));
+    expect(notes).toEqual(['field `filing_type` value: "vol" → "vkt"']);
+  });
+
+  it("does not mistake aria-checked for checked (which would make every radio look selected)", () => {
+    const radioGroup = (selectedValue) =>
+      `<input data-type="radio" type="radio" data-name="filing_type" value="vol" aria-checked="${selectedValue === "vol"}" ${
+        selectedValue === "vol" ? "checked" : ""
+      } />` +
+      `<input data-type="radio" type="radio" data-name="filing_type" value="vkt" aria-checked="${selectedValue === "vkt"}" ${
+        selectedValue === "vkt" ? "checked" : ""
+      } />`;
     const notes = describeVisualChange(radioGroup("vol"), radioGroup("vkt"));
     expect(notes).toEqual(['field `filing_type` value: "vol" → "vkt"']);
   });

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -324,6 +324,16 @@ describe("liquidSamplerCompact - extractCompact", () => {
     expect(vkt.exampleUrl).toMatch(/^https:\/\/example\.staging\.getsilverfin\.com/);
   });
 
+  it("collects every flagged entry's kind/entryId into diffEntryKeys, excluding unchanged entries", () => {
+    expect(data.diffEntryKeys).toEqual([
+      "reconciliation_entries/1_100_1000_5000",
+      "reconciliation_entries/1_101_1001_5000",
+      "reconciliation_entries/1_102_1002_6000",
+    ]);
+    // the unchanged account entry must not appear
+    expect(data.diffEntryKeys).not.toContain("account_entries/1_103_1003_490000.000");
+  });
+
   it("falls back to raw entry id when labels are missing", () => {
     // point at a dir with entries but no sample_entry_ids.yml -> label = entry id.
     // Reuse the fixture output dir but from a path without the yml alongside.

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -115,6 +115,22 @@ describe("liquidSamplerCompact - diffResultsRegister", () => {
     expect(diffResultsRegister(["0.0", "0.0"], ["1.0", "0.0"])).toEqual({ before: "0/2 triggered", after: "1/2 triggered" });
   });
 
+  it("names the flipped indices when a flag-array reorder keeps the same triggered count", () => {
+    // Same 1/2 triggered on both sides - without the flipped-index suffix
+    // this rendered identically on both sides and looked like a no-op, and
+    // collapsed distinct reorders into one deduped change (see the
+    // dedup-key test below).
+    const diff = diffResultsRegister(["1.0", "0.0"], ["0.0", "1.0"]);
+    expect(diff.before).toBe("1/2 triggered (indices 0,1 flipped)");
+    expect(diff.after).toBe("1/2 triggered (indices 0,1 flipped)");
+  });
+
+  it("does not dedupe two entries whose flag-array reorders flip different indices into one change", () => {
+    const a = diffResultsRegister(["1.0", "0.0", "0.0", "0.0"], ["0.0", "1.0", "0.0", "0.0"]);
+    const b = diffResultsRegister(["0.0", "0.0", "1.0", "0.0"], ["0.0", "0.0", "0.0", "1.0"]);
+    expect(a).not.toEqual(b);
+  });
+
   it("falls back to the raw value for non-flag (raw numeric) results arrays", () => {
     const diff = diffResultsRegister(["996.08", "0.0"], ["996.08", "27171.4"]);
     expect(diff.before).toBe('["996.08","0.0"]');
@@ -247,6 +263,14 @@ describe("liquidSamplerCompact - describeVisualChange", () => {
     const after = `<input data-name="company_name" value="Foo &amp; Baz" />`;
     const notes = describeVisualChange(before, after);
     expect(notes).toEqual(['field `company_name` value: "Foo & Bar" → "Foo & Baz"']);
+  });
+
+  it("reports a changed radio-group selection by which option is checked, not the last input in the group", () => {
+    const radioGroup = (checkedValue) =>
+      `<input type="radio" data-name="filing_type" value="vol" ${checkedValue === "vol" ? "checked" : ""} />` +
+      `<input type="radio" data-name="filing_type" value="vkt" ${checkedValue === "vkt" ? "checked" : ""} />`;
+    const notes = describeVisualChange(radioGroup("vol"), radioGroup("vkt"));
+    expect(notes).toEqual(['field `filing_type` value: "vol" → "vkt"']);
   });
 });
 

--- a/tests/lib/liquidSamplerCompact.test.js
+++ b/tests/lib/liquidSamplerCompact.test.js
@@ -116,12 +116,11 @@ describe("liquidSamplerCompact - diffResultsRegister", () => {
   });
 
   it("names which indices turned on/off when a flag-array reorder keeps the same triggered count", () => {
-    // Same 1/2 triggered on both sides - without naming direction this
-    // rendered identically on both sides and looked like a no-op, and
-    // collapsed distinct reorders into one deduped change (see the
-    // dedup-key tests below).
+    // Same 1/2 triggered on both sides - the suffix goes on `after` only, so
+    // the line reads "1/2 triggered -> 1/2 triggered (0 off, 1 on)" instead
+    // of an identical-looking string on both sides.
     const diff = diffResultsRegister(["1.0", "0.0"], ["0.0", "1.0"]);
-    expect(diff.before).toBe("1/2 triggered (0 off, 1 on)");
+    expect(diff.before).toBe("1/2 triggered");
     expect(diff.after).toBe("1/2 triggered (0 off, 1 on)");
   });
 
@@ -148,7 +147,7 @@ describe("liquidSamplerCompact - diffResultsRegister", () => {
     const diffA = diffResultsRegister(before, afterA);
     const diffB = diffResultsRegister(before, afterB);
 
-    expect(diffA.before.length).toBeLessThan(100);
+    expect(diffA.after.length).toBeLessThan(100);
     expect(diffA).not.toEqual(diffB);
   });
 

--- a/tests/lib/liquidSamplerRunner.test.js
+++ b/tests/lib/liquidSamplerRunner.test.js
@@ -159,6 +159,22 @@ describe("LiquidSamplerRunner - compact diff", () => {
     expect(output).toContain("injected");
   });
 
+  it("extracts view.html too, so a visual-only (data-unchanged) change surfaces", async () => {
+    const zip = new AdmZip();
+    zip.addFile("sample_entry_ids.yml", Buffer.from(JSON.stringify({ reconciliation_entries: { 1: { label: "vkt_1", url: null } } })));
+    zip.addFile("output/reconciliation_entries/1/before/registers.json", Buffer.from(JSON.stringify({ named_results: { a: "1" } })));
+    zip.addFile("output/reconciliation_entries/1/after/registers.json", Buffer.from(JSON.stringify({ named_results: { a: "1" } })));
+    zip.addFile("output/reconciliation_entries/1/before/view.html", Buffer.from("<div>old</div>"));
+    zip.addFile("output/reconciliation_entries/1/after/view.html", Buffer.from("<div>new</div>"));
+    axios.get.mockResolvedValue({ data: zip.toBuffer() });
+
+    await new LiquidSamplerRunner("1", { compact: true }).checkStatus("run-1");
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("👁️ Visual-only changes");
+    expect(output).toContain("output/reconciliation_entries/1/{before,after}/view.html");
+  });
+
   it("does NOT download or print a compact diff by default", async () => {
     await new LiquidSamplerRunner("1", { openReport: false }).checkStatus("run-1");
 
@@ -222,6 +238,53 @@ describe("LiquidSamplerRunner - compact diff", () => {
       writeSpy.mockRestore();
       mkdtempSpy.mockRestore();
     }
+  });
+});
+
+describe("LiquidSamplerRunner - compact diff from a local zip (--from-zip)", () => {
+  let logSpy;
+  let originalExit;
+  let zipPath;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalExit = process.exit;
+    process.exit = jest.fn();
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    zipPath = path.join(os.tmpdir(), `sampler-from-zip-test-${process.pid}.zip`);
+    fs.writeFileSync(zipPath, fixtureZipBuffer());
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.exit = originalExit;
+    fs.rmSync(zipPath, { force: true });
+  });
+
+  it("prints the compact diff without any network call", async () => {
+    await new LiquidSamplerRunner("1").printCompactDiffFromZip(zipPath);
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(SF.readSamplerRun).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("<!-- SAMPLER_COMPACT_START -->");
+    expect(output).toContain("### vkt_1");
+  });
+
+  it("exits non-zero with a clear error when the path doesn't exist", async () => {
+    await new LiquidSamplerRunner("1").printCompactDiffFromZip("/no/such/results.zip");
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Could not read zip"));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits non-zero (rather than silently warning) when the zip is unreadable", async () => {
+    fs.writeFileSync(zipPath, "not a zip file");
+
+    await new LiquidSamplerRunner("1").printCompactDiffFromZip(zipPath);
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Could not build compact diff"));
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 });
 

--- a/tests/lib/liquidSamplerRunner.test.js
+++ b/tests/lib/liquidSamplerRunner.test.js
@@ -350,6 +350,22 @@ describe("LiquidSamplerRunner - add diffs folder to a local zip (--add-diffs-fol
     expect(consola.success).toHaveBeenCalledWith(expect.stringContaining("2 view.html file(s) across 1 entry"));
   });
 
+  it("counts only entries that actually got a view.html, not every flagged entry", () => {
+    writeZip([
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+      ["output/reconciliation_entries/1/before/view.html", "<div>1 old</div>"],
+      ["output/reconciliation_entries/1/after/view.html", "<div>1 new</div>"],
+      // Entry 2 also differs, but has no view.html - it must not inflate the entry count.
+      ["output/reconciliation_entries/2/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/2/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining("2 view.html file(s) across 1 entry"));
+  });
+
   it("reports and leaves the zip untouched when no entries differ", () => {
     writeZip([
       ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "same" } })],

--- a/tests/lib/liquidSamplerRunner.test.js
+++ b/tests/lib/liquidSamplerRunner.test.js
@@ -379,6 +379,55 @@ describe("LiquidSamplerRunner - add diffs folder to a local zip (--add-diffs-fol
     expect(zip.getEntries().some((e) => e.entryName.startsWith("diffs/"))).toBe(false);
   });
 
+  it("skips flagged entries whose before/after renders are byte-identical", () => {
+    writeZip([
+      // Flagged on a named_results change the render doesn't show (e.g. a
+      // timestamp-derived result): identical view.html, so a diffs/ pair for it
+      // would give the reviewer two files with nothing to compare.
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+      ["output/reconciliation_entries/1/before/view.html", "<div>same render</div>"],
+      ["output/reconciliation_entries/1/after/view.html", "<div>same render</div>"],
+      // Flagged AND visibly different - this one belongs in diffs/.
+      ["output/reconciliation_entries/2/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/2/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+      ["output/reconciliation_entries/2/before/view.html", "<div>2 old</div>"],
+      ["output/reconciliation_entries/2/after/view.html", "<div>2 new</div>"],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    const names = new AdmZip(fs.readFileSync(zipPath)).getEntries().map((e) => e.entryName);
+    expect(names).not.toContain("diffs/reconciliation_entries/1/before/view.html");
+    expect(names).not.toContain("diffs/reconciliation_entries/1/after/view.html");
+    expect(names).toContain("diffs/reconciliation_entries/2/before/view.html");
+    expect(names).toContain("diffs/reconciliation_entries/2/after/view.html");
+    // The skip is reported, not silent.
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining("2 view.html file(s) across 1 entry"));
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining("1 flagged entry had identical before/after renders"));
+  });
+
+  it("reports and leaves the zip untouched when every flagged entry renders identically", () => {
+    writeZip([
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+      ["output/reconciliation_entries/1/before/view.html", "<div>same</div>"],
+      ["output/reconciliation_entries/1/after/view.html", "<div>same</div>"],
+      ["output/reconciliation_entries/2/before/registers.json", JSON.stringify({ named_results: { b: "before" } })],
+      ["output/reconciliation_entries/2/after/registers.json", JSON.stringify({ named_results: { b: "after" } })],
+      ["output/reconciliation_entries/2/before/view.html", "<div>same too</div>"],
+      ["output/reconciliation_entries/2/after/view.html", "<div>same too</div>"],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining("No visual differences among the flagged entries"));
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining("2 flagged entries had identical before/after renders"));
+    expect(consola.success).not.toHaveBeenCalled();
+    const zip = new AdmZip(fs.readFileSync(zipPath));
+    expect(zip.getEntries().some((e) => e.entryName.startsWith("diffs/"))).toBe(false);
+  });
+
   it("reports and leaves the zip untouched when entries differ but none have a view.html", () => {
     writeZip([
       ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],

--- a/tests/lib/liquidSamplerRunner.test.js
+++ b/tests/lib/liquidSamplerRunner.test.js
@@ -288,6 +288,98 @@ describe("LiquidSamplerRunner - compact diff from a local zip (--from-zip)", () 
   });
 });
 
+describe("LiquidSamplerRunner - add diffs folder to a local zip (--add-diffs-folder)", () => {
+  let zipPath;
+  let originalExit;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalExit = process.exit;
+    process.exit = jest.fn();
+    zipPath = path.join(os.tmpdir(), `sampler-diffs-test-${process.pid}.zip`);
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    fs.rmSync(zipPath, { force: true });
+  });
+
+  function writeZip(entries) {
+    const zip = new AdmZip();
+    zip.addFile(
+      "sample_entry_ids.yml",
+      Buffer.from(
+        JSON.stringify({
+          reconciliation_entries: {
+            1: { label: "vkt_1", url: null },
+            2: { label: "vkt_1", url: null },
+          },
+        }),
+      ),
+    );
+    for (const [name, content] of entries) {
+      zip.addFile(name, Buffer.from(content));
+    }
+    fs.writeFileSync(zipPath, zip.toBuffer());
+  }
+
+  it("adds view.html before/after only for entries the compact diff flagged, leaving the rest of the zip intact", () => {
+    writeZip([
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+      ["output/reconciliation_entries/1/before/view.html", "<div>1 old</div>"],
+      ["output/reconciliation_entries/1/after/view.html", "<div>1 new</div>"],
+      ["output/reconciliation_entries/2/before/registers.json", JSON.stringify({ named_results: { a: "same" } })],
+      ["output/reconciliation_entries/2/after/registers.json", JSON.stringify({ named_results: { a: "same" } })],
+      ["output/reconciliation_entries/2/before/view.html", "<div>2 unchanged</div>"],
+      ["output/reconciliation_entries/2/after/view.html", "<div>2 unchanged</div>"],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    const zip = new AdmZip(fs.readFileSync(zipPath));
+    const names = zip.getEntries().map((e) => e.entryName);
+    expect(names).toContain("diffs/reconciliation_entries/1/before/view.html");
+    expect(names).toContain("diffs/reconciliation_entries/1/after/view.html");
+    expect(names).not.toContain("diffs/reconciliation_entries/2/before/view.html");
+    expect(names).not.toContain("diffs/reconciliation_entries/2/after/view.html");
+    expect(zip.getEntry("diffs/reconciliation_entries/1/after/view.html").getData().toString()).toBe("<div>1 new</div>");
+    // The original entries stay intact - the zip is augmented, not replaced.
+    expect(names).toContain("output/reconciliation_entries/1/after/registers.json");
+
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining("2 view.html file(s) across 1 entry"));
+  });
+
+  it("reports and leaves the zip untouched when no entries differ", () => {
+    writeZip([
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "same" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "same" } })],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining("No differing entries"));
+    const zip = new AdmZip(fs.readFileSync(zipPath));
+    expect(zip.getEntries().some((e) => e.entryName.startsWith("diffs/"))).toBe(false);
+  });
+
+  it("exits non-zero with a clear error when the path doesn't exist", () => {
+    new LiquidSamplerRunner("1").addDiffsFolderToZip("/no/such/results.zip");
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Could not read zip"));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits non-zero (rather than throwing) when the zip is unreadable", () => {
+    fs.writeFileSync(zipPath, "not a zip file");
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Could not build diffs/ folder"));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});
+
 describe("LiquidSamplerRunner - polling status output", () => {
   const originalIsTTY = process.stdout.isTTY;
   const originalCI = process.env.CI;

--- a/tests/lib/liquidSamplerRunner.test.js
+++ b/tests/lib/liquidSamplerRunner.test.js
@@ -363,6 +363,20 @@ describe("LiquidSamplerRunner - add diffs folder to a local zip (--add-diffs-fol
     expect(zip.getEntries().some((e) => e.entryName.startsWith("diffs/"))).toBe(false);
   });
 
+  it("reports and leaves the zip untouched when entries differ but none have a view.html", () => {
+    writeZip([
+      ["output/reconciliation_entries/1/before/registers.json", JSON.stringify({ named_results: { a: "before" } })],
+      ["output/reconciliation_entries/1/after/registers.json", JSON.stringify({ named_results: { a: "after" } })],
+    ]);
+
+    new LiquidSamplerRunner("1").addDiffsFolderToZip(zipPath);
+
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining("No view.html files found"));
+    expect(consola.success).not.toHaveBeenCalled();
+    const zip = new AdmZip(fs.readFileSync(zipPath));
+    expect(zip.getEntries().some((e) => e.entryName.startsWith("diffs/"))).toBe(false);
+  });
+
   it("exits non-zero with a clear error when the path doesn't exist", () => {
     new LiquidSamplerRunner("1").addDiffsFolderToZip("/no/such/results.zip");
 


### PR DESCRIPTION
## Summary

**DO NOT MERGE UNTIL NL AND LU PILOT PHASE HAS FINISHED**


Follow-up to #236/#261's `--compact` mode, driven by real feedback while reviewing PR #894's sampler run against nl_market: the `named_results`-only diff missed real signal and got unreadable fast (78KB/~19.7K tokens on a 202-entry NL run). This PR:

- Diffs the `results` register alongside `named_results` - 0/1 flag arrays render as a triggered-indicator count (e.g. `1/1 triggered`), other shapes (raw numeric values) fall back to a plain value diff.
- Groups entries whose `named_results`/`results` collapsed entirely (≥3 keys lost at once, all to `undefined`) into a single **"output vanished"** finding per template - previously this showed as dozens of individual "value → undefined" lines and could dominate the whole summary.
- Adds a **scope/dependency tier** (`dependencies`/`rollforward_params`/`required_keys_missing`), kept separate from the data diff so a dependency change is never mistaken for a data regression. `dependencies` renders as one sub-line per category (ledgers/handles/account ranges/company.attributes) instead of a semicolon-packed single line.
- Adds a **visual-only tier**: entries where `view.html` changed but the data diff found nothing to explain it - a rendering-only regression the old diff couldn't see at all. Described field-by-field via Silverfin's `data-name` attribute where one anchors the change, with an honest "compare the files directly" fallback where it doesn't.
- Truncates long values (accounting-policy paragraphs, notes) and caps per-template/per-entry change lists, always disclosing what was elided rather than silently dropping it.
- Every finding now links to a concrete follow-up: the entry's live app URL when known, else its path inside the results directory.
- Adds `run-sampler --from-zip <path>`: build the compact diff from an already-downloaded `results.zip`, with no sampler run or network call - lets a reviewer re-analyze a real result (or iterate on the compact-diff format itself) without a 30-60 min re-run against the shared staging backend.

Net effect measured on the real PR #894 zip (202 entries, 6 templates changed + 21 collapsed + 9 visual-only): output went from 78KB/~19.7K tokens (old format) to ~31.7KB while covering strictly more signal.

## Why keeping this open for now

This is currently pointed at from nl_market's and lu_market's `run_sampler.yml` (temporarily, on this branch) so we can gather real feedback across their approved PRs before merging - see the follow-up in each of those repos.

## Test plan
- [x] `npm test` - 640/640 passing
- [x] `npm run lint` - clean
- [x] Validated against a real downloaded `results.zip` from nl_market PR #894 via `--from-zip`, output reviewed in full
- [ ] Real end-to-end validation via a live download URL (only the local-zip path has been exercised against real data so far; the live-download path is covered by mocked tests)
- [ ] Feedback gathered from nl_market/lu_market usage before merge

- [ ] Skip bumping the CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)