### PR TITLE
Isolate a failed token refresh to one run-test --status handle instead of killing the batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.58.0] (23/07/2026)
+Fix `run-test --status` killing every other in-flight handle in the same batch when one handle hits a 401 whose token refresh also fails (e.g. a deliberately-blanked `refreshToken`, as CI does to avoid poisoning a shared token secret). Previously `AxiosFactory`'s failed-refresh handling always called `process.exit(1)`, which terminates the whole Node process regardless of `Promise.all` - so a single stale/expired token could report a false `FAILED` for every other, otherwise-passing template in the same `--status` call. `run-test --status` now isolates the failure to just the affected handle(s), reporting a distinct "Authentication error" reason instead. `AxiosFactory.setSuppressExitOnAuthFailure` is opt-in and only used by this batched code path, so every other command keeps its existing "print and exit" behavior on an auth failure.
+
 ## [1.57.1] (15/07/2026)
 Improve `silverfin run-sampler` by adding a compact output mode.
 

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -9,6 +9,25 @@ class AxiosFactory {
   // Cache of "does this staging host sit behind an HTTP Basic Auth gateway", keyed by host.
   static #basicGateByHost = {};
 
+  // When true, a failed token/API-key refresh (see #handleFailedRefresh) rejects the request
+  // with a normal (marked) Error instead of calling process.exit(1). Off by default so every
+  // existing single-shot CLI command keeps its current "print + hard exit" behaviour unchanged.
+  // Batch callers that run many independent requests in the same process (e.g. `run-test
+  // --status`'s Promise.all over handles) opt in via #setSuppressExitOnAuthFailure so that one
+  // stale/expired token fails only the request(s) that hit it, instead of killing every other
+  // in-flight request in the same batch.
+  static suppressExitOnAuthFailure = false;
+
+  /**
+   * Toggle whether a failed refresh throws (rejecting only the affected request) instead of
+   * calling process.exit(1) (killing the whole process). Intended for batch callers that need to
+   * isolate a stale-token failure to a single item instead of aborting everything in flight.
+   * @param {Boolean} value
+   */
+  static setSuppressExitOnAuthFailure(value) {
+    this.suppressExitOnAuthFailure = Boolean(value);
+  }
+
   /**
    * Create an axios instance for a given type and environment id.
    * It will add the necessary headers and interceptors to handle the authorization, and refresh the tokens if needed.
@@ -349,6 +368,17 @@ class AxiosFactory {
       consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
     }
     consola.error(`Error refreshing credentials. Try running the authentication process again`);
+
+    if (this.suppressExitOnAuthFailure) {
+      // Let this specific request fail instead of taking down the whole process, so a caller
+      // running many requests in parallel (e.g. a Promise.all batch) can isolate the failure to
+      // just the item(s) that hit a stale/expired token.
+      const authError = new Error("Authentication error: failed to refresh credentials");
+      authError.isAuthFailure = true;
+      authError.cause = error;
+      throw authError;
+    }
+
     process.exit(1);
   }
 }

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -4,6 +4,7 @@ const chalk = require("chalk");
 const errorUtils = require("./utils/errorUtils");
 const { spinner } = require("./cli/spinner");
 const SF = require("./api/sfApi");
+const { AxiosFactory } = require("./api/axiosFactory");
 const fsUtils = require("./utils/fsUtils");
 const runTestUtils = require("./utils/runTestUtils");
 const { consola } = require("consola");
@@ -562,6 +563,12 @@ async function runTests(firmId, templateType, handle, testName = "", previewOnly
 
     return { testRun, previewRun, metadata };
   } catch (error) {
+    // Only ever set when a caller opted in via AxiosFactory.setSuppressExitOnAuthFailure (see
+    // runTestsStatusOnly below); every other caller keeps the previous behaviour of exiting the
+    // whole process on any error.
+    if (error.isAuthFailure) {
+      throw error;
+    }
     errorUtils.errorHandler(error);
   }
 }
@@ -603,10 +610,25 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
     // printing a bare FAILED that is indistinguishable from a real assertion failure.
     let failureReason = "";
     const failedTestNames = [];
-    const testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none", pattern);
+    let testResult;
+    try {
+      testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none", pattern);
+    } catch (error) {
+      // Only reachable because AxiosFactory.setSuppressExitOnAuthFailure(true) is set below:
+      // a 401 whose refresh attempt also failed (e.g. a deliberately-blanked refreshToken, as
+      // CI does to avoid poisoning a shared token) rejects this one handle instead of calling
+      // process.exit(1) and killing every other handle's in-flight request in this batch.
+      if (!error.isAuthFailure) throw error;
+      testResult = null;
+      // Deliberately doesn't match the caller's transient-error detection (e.g. "internal
+      // error"/"no response from the platform"): retrying within this same process can't help,
+      // since nothing here refreshes the token. Phrased so it reads as an auth/ops issue, not a
+      // genuine test failure or a platform hiccup worth retrying.
+      failureReason = "Authentication error refreshing credentials for this firm (likely a stale/expired CI token) - not a template failure";
+    }
 
     if (!testResult) {
-      failureReason = "Error running tests (no response from the platform)";
+      failureReason = failureReason || "Error running tests (no response from the platform)";
     } else {
       const testRun = testResult?.testRun;
 
@@ -650,7 +672,16 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
     return { handle: singleHandle, status, failedTestNames, failureReason };
   };
 
-  const results = await Promise.all(handles.map(runSingleHandle));
+  // Isolate a failed-refresh 401 to the handle(s) that hit it (see the catch above) instead of
+  // exiting the whole process, since this call runs many handles concurrently via Promise.all.
+  // Always restored in `finally` so this doesn't leak into any later command run in this process.
+  AxiosFactory.setSuppressExitOnAuthFailure(true);
+  let results;
+  try {
+    results = await Promise.all(handles.map(runSingleHandle));
+  } finally {
+    AxiosFactory.setSuppressExitOnAuthFailure(false);
+  }
 
   const overallStatus = results.every((result) => result.status === "PASSED") ? "PASSED" : "FAILED";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.57.1",
+  "version": "1.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.57.1",
+      "version": "1.58.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.57.1",
+  "version": "1.58.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -347,6 +347,7 @@ Source: `lib/api/axiosFactory.js`
 | `AxiosFactory.createInstance` (firm) | should attempt to refresh tokens only once on 401 and terminate the process | Verifies that when the token refresh itself returns 401 the process exits with code 1 after exactly one refresh attempt. |
 | `AxiosFactory.createInstance` (firm) | should throw any other response errors | Verifies that non-401 HTTP errors (e.g. 404) are rethrown without triggering a refresh or exiting the process. |
 | `AxiosFactory.createInstance` (firm) | should throw the error again if there is no response | Verifies that network-level errors (no HTTP response) are rethrown without triggering a refresh or process exit. |
+| `AxiosFactory.createInstance` (firm) | should reject with a marked error instead of exiting when suppressExitOnAuthFailure is set | Verifies that with `AxiosFactory.setSuppressExitOnAuthFailure(true)`, a failed refresh rejects the request with an `isAuthFailure`-marked error instead of calling `process.exit(1)`. |
 | `AxiosFactory.createInstance` (partner) | should create a valid instance | Verifies that a partner instance has the correct `baseURL` and no `Authorization` header. |
 | `AxiosFactory.createInstance` (partner) | should add partner_id and api_key to requests params | Verifies that every outgoing request automatically includes `api_key` and `partner_id` query parameters. |
 | `AxiosFactory.createInstance` (partner) | should throw an error for missing API key and terminate process | Verifies that when no partner credentials are stored an error is logged and the process exits. |
@@ -871,6 +872,8 @@ Source: `lib/liquidTestRunner.js`
 | `runTestsStatusOnly` | should collapse newlines in the error message onto a single indented line | Verifies that a multi-line `error_message` is collapsed to spaces so it stays on one indented line and can't be misparsed as a new top-level result. |
 | `runTestsStatusOnly` | should surface a specific error message for internal_error when present | Verifies that an `internal_error` run prefers the platform's `error_message` over the generic fallback text. |
 | `runTestsStatusOnly` | should handle multiple handles and return FAILED if any fail | Verifies that `"FAILED"` is returned when at least one handle in a multi-handle run fails. |
+| `runTestsStatusOnly` | should isolate an auth-failure (401 with failed refresh) to the affected handle instead of throwing | Verifies that an `isAuthFailure`-marked error from `runTests` is caught and reported as a `FAILED` result with a distinct reason, instead of propagating out of `runTestsStatusOnly`. |
+| `runTestsStatusOnly` | should isolate an auth failure to just the affected handle when running several handles together | Verifies that one handle's auth failure does not affect the outcome of the other handles running concurrently in the same `Promise.all` batch. |
 
 ---
 

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -37,6 +37,8 @@ describe("AxiosFactory", () => {
 
   afterEach(() => {
     exitSpy.mockRestore();
+    // Safety net: never let one test's opt-in leak into the next.
+    AxiosFactory.setSuppressExitOnAuthFailure(false);
 
     axiosMockAdapter.restore();
   });
@@ -179,6 +181,26 @@ describe("AxiosFactory", () => {
       // Error is raised and not handled by AxiosFactory
       expect(exitSpy).toHaveBeenCalledTimes(0);
       expect(consola.error).toHaveBeenCalledTimes(0);
+    });
+
+    it("should reject with a marked error instead of exiting when suppressExitOnAuthFailure is set", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      AxiosFactory.setSuppressExitOnAuthFailure(true);
+      try {
+        const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+        axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+        axiosMockAdapter.onPost(`${mockHost}/f/${firmId}/oauth/token`).reply(401, "Unauthorized");
+
+        await expect(axiosInstance.get("/test-endpoint")).rejects.toMatchObject({ isAuthFailure: true });
+
+        expect(exitSpy).not.toHaveBeenCalled();
+        expect(consola.error).toHaveBeenCalledWith("Error refreshing credentials. Try running the authentication process again");
+      } finally {
+        AxiosFactory.setSuppressExitOnAuthFailure(false);
+      }
     });
 
     it("should throw the error again if there is no response", async () => {

--- a/tests/lib/liquidTestRunner.test.js
+++ b/tests/lib/liquidTestRunner.test.js
@@ -19,6 +19,7 @@ jest.mock("../../lib/templates/accountTemplate");
 
 const SF = require("../../lib/api/sfApi");
 const { consola } = require("consola");
+const errorUtils = require("../../lib/utils/errorUtils");
 const fsUtils = require("../../lib/utils/fsUtils");
 const { ReconciliationText } = require("../../lib/templates/reconciliationText");
 const { AccountTemplate } = require("../../lib/templates/accountTemplate");
@@ -508,6 +509,68 @@ describe("runTestsStatusOnly", () => {
 
     expect(overallStatus).toBe("FAILED");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Backend timeout"));
+  });
+
+  it("should isolate an auth-failure (401 with failed refresh) to the affected handle instead of throwing", async () => {
+    const handle = "reconciliation_text_1";
+    setupFsUtilsMocks(handle);
+
+    const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+
+    ReconciliationText.read.mockReturnValue({ handle, text: "x", text_parts: [] });
+
+    const authError = new Error("Authentication error: failed to refresh credentials");
+    authError.isAuthFailure = true;
+    SF.createTestRun = jest.fn().mockRejectedValue(authError);
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handle]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(`${handle}: FAILED`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Authentication error"));
+    // Isolated to this handle: runTests's own catch never falls through to the generic handler.
+    expect(errorUtils.errorHandler).not.toHaveBeenCalled();
+  });
+
+  it("should isolate an auth failure to just the affected handle when running several handles together", async () => {
+    const handleOk = "reconciliation_text_1";
+    const handleAuthFail = "reconciliation_text_2";
+
+    fsUtils.configExists.mockReturnValue(true);
+    fsUtils.readConfig.mockImplementation((type, handle) => ({
+      test: `tests/${handle}_liquid_test.yml`,
+      reconciliation_type: "can_be_reconciled_without_data",
+      id: { 1001: handle === handleOk ? 8801 : 9901 },
+    }));
+    fsUtils.listSharedPartsUsedInTemplate.mockReturnValue([]);
+
+    for (const handle of [handleOk, handleAuthFail]) {
+      const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+      fs.mkdirSync(testDir, { recursive: true });
+      fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+    }
+
+    ReconciliationText.read.mockImplementation((handle) => ({ handle, text: "x", text_parts: [] }));
+
+    const authError = new Error("Authentication error: failed to refresh credentials");
+    authError.isAuthFailure = true;
+    SF.createTestRun = jest.fn().mockImplementation((firmId, testParams) => {
+      return testParams.template.handle === handleAuthFail ? Promise.reject(authError) : Promise.resolve({ data: 20 });
+    });
+    SF.readTestRun = jest.fn().mockResolvedValue({ data: makeTestRun("completed", makePassedTests()) });
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handleOk, handleAuthFail]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    // The stale-token handle fails, but the other handle's own request is never touched by it.
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(`${handleOk}: PASSED`);
+    expect(consola.log).toHaveBeenCalledWith(`${handleAuthFail}: FAILED`);
   });
 
   it("should handle multiple handles and return FAILED if any fail", async () => {


### PR DESCRIPTION
## Summary
Found while reviewing `be_market#3047` (decoupling CI auth from `run_tests.yml`): that PR's design blanks every firm's `refreshToken` before running liquid tests, so a stale/expired access token is meant to "fail cleanly on a 401 instead of silently rotating (and poisoning) the shared token".

It doesn't fail cleanly for `run-test --status` specifically: `AxiosFactory`'s failed-refresh handling (`#handleFailedRefresh`) always calls `process.exit(1)`, which kills the **entire Node process immediately** - regardless of `Promise.all`. `runTestsStatusOnly` runs many handles concurrently in one process, so one handle's 401-with-failed-refresh took down every other in-flight handle's request too, not just the affected one - reporting a false `FAILED` for otherwise-passing templates whenever a shared CI token happened to be near/at expiry.

## Fix
- `AxiosFactory.setSuppressExitOnAuthFailure(true)` (opt-in, default off): a failed refresh rejects the request with an `isAuthFailure`-marked error instead of exiting.
- `runTestsStatusOnly` enables it only around its own `Promise.all` batch (restored in a `finally`), and reports the isolated failure as `FAILED` with a distinct "Authentication error" reason - deliberately phrased so it does **not** match the existing transient-error retry regex used by `be_market`'s CI workflow, since retrying within the same process can't fix a stale shared token (only the scheduled refresh cron can).
- Every other command is unaffected: the flag defaults to off, so `#handleFailedRefresh` still calls `process.exit(1)` exactly as before everywhere else.

## Test plan
- [x] `npx jest` - 606/606 passing
- [x] `npx eslint` - clean
- [x] New unit tests: `AxiosFactory` rejects instead of exiting when the flag is set; `runTestsStatusOnly` isolates an auth failure to the affected handle (single- and multi-handle cases).

Made with [Cursor](https://cursor.com)