### PR TITLE
Isolate CI auth failures to the affected handle in run-test --status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.58.0] (23/07/2026)
+Isolate an authentication failure to the affected handle in `run-test --status`: previously, if a token/API-key refresh failed for one handle in a batch (e.g. a CI run with a deliberately stale token), `AxiosFactory` called `process.exit(1)` and killed the whole Node process, taking down every other handle's in-flight request with it. Now this specific `--status` batch path catches the failure and reports it as `FAILED` (with an "Authentication error refreshing credentials" reason) for just that handle, while every other handle in the same run completes normally. Every other CLI command keeps the previous exit-on-failure behaviour unchanged.
+
 ## [1.57.1] (15/07/2026)
 Improve `silverfin run-sampler` by adding a compact output mode.
 

--- a/lib/api/axiosFactory.js
+++ b/lib/api/axiosFactory.js
@@ -9,6 +9,25 @@ class AxiosFactory {
   // Cache of "does this staging host sit behind an HTTP Basic Auth gateway", keyed by host.
   static #basicGateByHost = {};
 
+  // When true, a failed token/API-key refresh (see #handleFailedRefresh) rejects the request
+  // with a normal (marked) Error instead of calling process.exit(1). Off by default so every
+  // existing single-shot CLI command keeps its current "print + hard exit" behaviour unchanged.
+  // Batch callers that run many independent requests in the same process (e.g. `run-test
+  // --status`'s Promise.all over handles) opt in via #setSuppressExitOnAuthFailure so that one
+  // stale/expired token fails only the request(s) that hit it, instead of killing every other
+  // in-flight request in the same batch.
+  static suppressExitOnAuthFailure = false;
+
+  /**
+   * Toggle whether a failed refresh throws (rejecting only the affected request) instead of
+   * calling process.exit(1) (killing the whole process). Intended for batch callers that need to
+   * isolate a stale-token failure to a single item instead of aborting everything in flight.
+   * @param {Boolean} value
+   */
+  static setSuppressExitOnAuthFailure(value) {
+    this.suppressExitOnAuthFailure = Boolean(value);
+  }
+
   /**
    * Create an axios instance for a given type and environment id.
    * It will add the necessary headers and interceptors to handle the authorization, and refresh the tokens if needed.
@@ -349,6 +368,17 @@ class AxiosFactory {
       consola.error(`Response Status: ${error.response.status} (${error.response.statusText})`);
     }
     consola.error(`Error refreshing credentials. Try running the authentication process again`);
+
+    if (this.suppressExitOnAuthFailure) {
+      // Let this specific request fail instead of taking down the whole process, so a caller
+      // running many requests in parallel (e.g. a Promise.all batch) can isolate the failure to
+      // just the item(s) that hit a stale/expired token.
+      const authError = new Error("Authentication error: failed to refresh credentials");
+      authError.isAuthFailure = true;
+      authError.cause = error;
+      throw authError;
+    }
+
     process.exit(1);
   }
 }

--- a/lib/liquidTestRunner.js
+++ b/lib/liquidTestRunner.js
@@ -4,6 +4,7 @@ const chalk = require("chalk");
 const errorUtils = require("./utils/errorUtils");
 const { spinner } = require("./cli/spinner");
 const SF = require("./api/sfApi");
+const { AxiosFactory } = require("./api/axiosFactory");
 const fsUtils = require("./utils/fsUtils");
 const runTestUtils = require("./utils/runTestUtils");
 const { consola } = require("consola");
@@ -562,6 +563,12 @@ async function runTests(firmId, templateType, handle, testName = "", previewOnly
 
     return { testRun, previewRun, metadata };
   } catch (error) {
+    // Only ever set when a caller opted in via AxiosFactory.setSuppressExitOnAuthFailure (see
+    // runTestsStatusOnly below); every other caller keeps the previous behaviour of exiting the
+    // whole process on any error.
+    if (error.isAuthFailure) {
+      throw error;
+    }
     errorUtils.errorHandler(error);
   }
 }
@@ -603,10 +610,25 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
     // printing a bare FAILED that is indistinguishable from a real assertion failure.
     let failureReason = "";
     const failedTestNames = [];
-    const testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none", pattern);
+    let testResult;
+    try {
+      testResult = await runTests(firmId, templateType, singleHandle, testName, false, "none", pattern);
+    } catch (error) {
+      // Only reachable because AxiosFactory.setSuppressExitOnAuthFailure(true) is set below:
+      // a 401 whose refresh attempt also failed (e.g. a deliberately-blanked refreshToken, as
+      // CI does to avoid poisoning a shared token) rejects this one handle instead of calling
+      // process.exit(1) and killing every other handle's in-flight request in this batch.
+      if (!error.isAuthFailure) throw error;
+      testResult = null;
+      // Deliberately doesn't match the caller's transient-error detection (e.g. "internal
+      // error"/"no response from the platform"): retrying within this same process can't help,
+      // since nothing here refreshes the token. Phrased so it reads as an auth/ops issue, not a
+      // genuine test failure or a platform hiccup worth retrying.
+      failureReason = "Authentication error refreshing credentials for this firm (likely a stale/expired CI token) - not a template failure";
+    }
 
     if (!testResult) {
-      failureReason = "Error running tests (no response from the platform)";
+      failureReason = failureReason || "Error running tests (no response from the platform)";
     } else {
       const testRun = testResult?.testRun;
 
@@ -650,7 +672,16 @@ async function runTestsStatusOnly(firmId, templateType, handles, testName = "", 
     return { handle: singleHandle, status, failedTestNames, failureReason };
   };
 
-  const results = await Promise.all(handles.map(runSingleHandle));
+  // Isolate a failed-refresh 401 to the handle(s) that hit it (see the catch above) instead of
+  // exiting the whole process, since this call runs many handles concurrently via Promise.all.
+  // Always restored in `finally` so this doesn't leak into any later command run in this process.
+  AxiosFactory.setSuppressExitOnAuthFailure(true);
+  let results;
+  try {
+    results = await Promise.all(handles.map(runSingleHandle));
+  } finally {
+    AxiosFactory.setSuppressExitOnAuthFailure(false);
+  }
 
   const overallStatus = results.every((result) => result.status === "PASSED") ? "PASSED" : "FAILED";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silverfin-cli",
-  "version": "1.57.1",
+  "version": "1.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silverfin-cli",
-      "version": "1.57.1",
+      "version": "1.58.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverfin-cli",
-  "version": "1.57.1",
+  "version": "1.58.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -345,6 +345,7 @@ Source: `lib/api/axiosFactory.js`
 | `AxiosFactory.createInstance` (firm) | should throw an error for missing tokens and terminate process | Verifies that when no token pair is stored for the firm an error is logged and the process exits with code 1. |
 | `AxiosFactory.createInstance` (firm) | should refresh tokens on 401 Unauthorized error | Verifies that a 401 response triggers a token refresh POST, new tokens are stored, and the original request is retried successfully. |
 | `AxiosFactory.createInstance` (firm) | should attempt to refresh tokens only once on 401 and terminate the process | Verifies that when the token refresh itself returns 401 the process exits with code 1 after exactly one refresh attempt. |
+| `AxiosFactory.createInstance` (firm) | should reject with a marked error instead of exiting when suppressExitOnAuthFailure is set | Verifies that with `AxiosFactory.setSuppressExitOnAuthFailure(true)`, a failed refresh rejects the request with an `isAuthFailure`-marked error instead of calling `process.exit(1)`. |
 | `AxiosFactory.createInstance` (firm) | should throw any other response errors | Verifies that non-401 HTTP errors (e.g. 404) are rethrown without triggering a refresh or exiting the process. |
 | `AxiosFactory.createInstance` (firm) | should throw the error again if there is no response | Verifies that network-level errors (no HTTP response) are rethrown without triggering a refresh or process exit. |
 | `AxiosFactory.createInstance` (partner) | should create a valid instance | Verifies that a partner instance has the correct `baseURL` and no `Authorization` header. |
@@ -871,6 +872,8 @@ Source: `lib/liquidTestRunner.js`
 | `runTestsStatusOnly` | should collapse newlines in the error message onto a single indented line | Verifies that a multi-line `error_message` is collapsed to spaces so it stays on one indented line and can't be misparsed as a new top-level result. |
 | `runTestsStatusOnly` | should surface a specific error message for internal_error when present | Verifies that an `internal_error` run prefers the platform's `error_message` over the generic fallback text. |
 | `runTestsStatusOnly` | should handle multiple handles and return FAILED if any fail | Verifies that `"FAILED"` is returned when at least one handle in a multi-handle run fails. |
+| `runTestsStatusOnly` | should isolate an auth-failure (401 with failed refresh) to the affected handle instead of throwing | Verifies that an `isAuthFailure`-marked error from `runTests` is reported as `"FAILED"` with an authentication-error reason, without going through the generic `errorUtils.errorHandler`. |
+| `runTestsStatusOnly` | should isolate an auth failure to just the affected handle when running several handles together | Verifies that in a multi-handle batch, an auth failure for one handle does not prevent the other handles from completing and reporting their own (e.g. passing) result. |
 
 ---
 

--- a/tests/lib/api/axiosFactory.test.js
+++ b/tests/lib/api/axiosFactory.test.js
@@ -37,6 +37,8 @@ describe("AxiosFactory", () => {
 
   afterEach(() => {
     exitSpy.mockRestore();
+    // Safety net: never let one test's opt-in leak into the next.
+    AxiosFactory.setSuppressExitOnAuthFailure(false);
 
     axiosMockAdapter.restore();
   });
@@ -179,6 +181,26 @@ describe("AxiosFactory", () => {
       // Error is raised and not handled by AxiosFactory
       expect(exitSpy).toHaveBeenCalledTimes(0);
       expect(consola.error).toHaveBeenCalledTimes(0);
+    });
+
+    it("should reject with a marked error instead of exiting when suppressExitOnAuthFailure is set", async () => {
+      firmCredentials.getHost.mockReturnValue(mockHost);
+      firmCredentials.getTokenPair.mockReturnValue(mockTokenPair);
+
+      AxiosFactory.setSuppressExitOnAuthFailure(true);
+      try {
+        const axiosInstance = AxiosFactory.createInstance("firm", firmId);
+
+        axiosMockAdapter.onGet("/test-endpoint").reply(401, "Unauthorized");
+        axiosMockAdapter.onPost(`${mockHost}/f/${firmId}/oauth/token`).reply(401, "Unauthorized");
+
+        await expect(axiosInstance.get("/test-endpoint")).rejects.toMatchObject({ isAuthFailure: true });
+
+        expect(exitSpy).not.toHaveBeenCalled();
+        expect(consola.error).toHaveBeenCalledWith("Error refreshing credentials. Try running the authentication process again");
+      } finally {
+        AxiosFactory.setSuppressExitOnAuthFailure(false);
+      }
     });
 
     it("should throw the error again if there is no response", async () => {

--- a/tests/lib/liquidTestRunner.test.js
+++ b/tests/lib/liquidTestRunner.test.js
@@ -19,6 +19,7 @@ jest.mock("../../lib/templates/accountTemplate");
 
 const SF = require("../../lib/api/sfApi");
 const { consola } = require("consola");
+const errorUtils = require("../../lib/utils/errorUtils");
 const fsUtils = require("../../lib/utils/fsUtils");
 const { ReconciliationText } = require("../../lib/templates/reconciliationText");
 const { AccountTemplate } = require("../../lib/templates/accountTemplate");
@@ -508,6 +509,68 @@ describe("runTestsStatusOnly", () => {
 
     expect(overallStatus).toBe("FAILED");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Backend timeout"));
+  });
+
+  it("should isolate an auth-failure (401 with failed refresh) to the affected handle instead of throwing", async () => {
+    const handle = "reconciliation_text_1";
+    setupFsUtilsMocks(handle);
+
+    const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+
+    ReconciliationText.read.mockReturnValue({ handle, text: "x", text_parts: [] });
+
+    const authError = new Error("Authentication error: failed to refresh credentials");
+    authError.isAuthFailure = true;
+    SF.createTestRun = jest.fn().mockRejectedValue(authError);
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handle]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(`${handle}: FAILED`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Authentication error"));
+    // Isolated to this handle: runTests's own catch never falls through to the generic handler.
+    expect(errorUtils.errorHandler).not.toHaveBeenCalled();
+  });
+
+  it("should isolate an auth failure to just the affected handle when running several handles together", async () => {
+    const handleOk = "reconciliation_text_1";
+    const handleAuthFail = "reconciliation_text_2";
+
+    fsUtils.configExists.mockReturnValue(true);
+    fsUtils.readConfig.mockImplementation((type, handle) => ({
+      test: `tests/${handle}_liquid_test.yml`,
+      reconciliation_type: "can_be_reconciled_without_data",
+      id: { 1001: handle === handleOk ? 8801 : 9901 },
+    }));
+    fsUtils.listSharedPartsUsedInTemplate.mockReturnValue([]);
+
+    for (const handle of [handleOk, handleAuthFail]) {
+      const testDir = path.join(tempDir, "reconciliation_texts", handle, "tests");
+      fs.mkdirSync(testDir, { recursive: true });
+      fs.writeFileSync(path.join(testDir, `${handle}_liquid_test.yml`), SIMPLE_YAML);
+    }
+
+    ReconciliationText.read.mockImplementation((handle) => ({ handle, text: "x", text_parts: [] }));
+
+    const authError = new Error("Authentication error: failed to refresh credentials");
+    authError.isAuthFailure = true;
+    SF.createTestRun = jest.fn().mockImplementation((firmId, testParams) => {
+      return testParams.template.handle === handleAuthFail ? Promise.reject(authError) : Promise.resolve({ data: 20 });
+    });
+    SF.readTestRun = jest.fn().mockResolvedValue({ data: makeTestRun("completed", makePassedTests()) });
+
+    const promise = runTestsStatusOnly(1001, "reconciliationText", [handleOk, handleAuthFail]);
+    await jest.runAllTimersAsync();
+    const overallStatus = await promise;
+
+    // The stale-token handle fails, but the other handle's own request is never touched by it.
+    expect(overallStatus).toBe("FAILED");
+    expect(consola.log).toHaveBeenCalledWith(`${handleOk}: PASSED`);
+    expect(consola.log).toHaveBeenCalledWith(`${handleAuthFail}: FAILED`);
   });
 
   it("should handle multiple handles and return FAILED if any fail", async () => {


### PR DESCRIPTION
## Why

`be_market`'s `run_tests.yml` (see [be_market#3047](https://github.com/silverfin/be_market/pull/3047)) deliberately blanks every firm's `refreshToken` before running `run-test --status`, so this job never writes back to the shared `CONFIG_JSON` secret (a separate cron owns rotation). The design assumes an expired access token then "fails a 401 cleanly" for just the affected template.

It didn't: `AxiosFactory`'s response interceptor still catches the 401, still attempts a refresh with the (now-blanked) token, that refresh POST fails, and `#handleFailedRefresh` unconditionally called `process.exit(1)`. Since `runTestsStatusOnly` runs many handles concurrently via `Promise.all` in the same process, one stale-token 401 killed every other in-flight handle's request too - not just the one that hit it.

## What changed

- `AxiosFactory.setSuppressExitOnAuthFailure(true/false)`: an opt-in static toggle. When enabled, `#handleFailedRefresh` rejects the request with an `isAuthFailure`-marked `Error` instead of calling `process.exit(1)`. Off by default, so every existing single-shot CLI command keeps its current behaviour unchanged.
- `runTestsStatusOnly` opts in around its `Promise.all` batch (reset in a `finally`), catches the marked error per-handle, and reports that handle as `FAILED` with a clear "Authentication error refreshing credentials for this firm..." reason - distinct from the transient-error retry path, since retrying can't help (nothing here refreshes the token).
- Added targeted tests in `axiosFactory.test.js` and `liquidTestRunner.test.js`, and `tests/TESTS.md` entries.
- Version bump to 1.58.0 + CHANGELOG entry.

## Testing

- `npx jest` - 606/606 passing.
- `npm run lint` - clean.
- Manually verified (via the mocked 401-then-401-refresh scenario in `axiosFactory.test.js`) that `process.exit` is no longer called when the toggle is set, and that a batch of handles with one auth failure still returns per-handle verdicts for the others.

Made with [Cursor](https://cursor.com)